### PR TITLE
Generate types for API methods

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -202,9 +202,11 @@ const groupRoutes = routes => {
         )
         route.comments.push(`@originalName ${route.name}`)
         route.comments.push(`@duplicate`)
-        route.name += ++duplicates[route.moduleName][route.name];
+        const duplicateNumber = ++duplicates[route.moduleName][route.name]
+        route.name += duplicateNumber;
+        route.pascalName += duplicateNumber;
       }
-      
+
       modules[route.moduleName].push(route)
     } else {
       modules.$outOfModule.push(route)

--- a/src/templates/api.mustache
+++ b/src/templates/api.mustache
@@ -30,7 +30,41 @@ type ApiConfig{{apiConfig.generic}} = {
 {{/apiConfig.props}}
 }
 
+{{#routes}}
+{{#outOfModule}}
+{{#routes}}
 
+/**
+{{#comments}}
+* {{.}}
+{{/comments}}
+*/
+export namespace {{pascalName}} {
+  export type RequestQuery = {{#queryType}}{{.}}{{/queryType}};
+  export type RequestBody = {{#bodyType}}{{.}}{{/bodyType}};
+  export type ResponseBody = {{returnType}};
+}
+{{/routes}}
+{{/outOfModule}}
+
+{{#combined}}
+export namespace {{moduleName}} {
+  {{#routes}}
+
+  /**
+  {{#comments}}
+  * {{.}}
+  {{/comments}}
+  */
+  export namespace {{pascalName}} {
+    export type RequestQuery = {{#queryType}}{{.}}{{/queryType}};
+    export type RequestBody = {{#bodyType}}{{.}}{{/bodyType}};
+    export type ResponseBody = {{returnType}};
+  }
+  {{/routes}}
+}
+{{/combined}}
+{{/routes}}
 
 export class Api{{apiConfig.generic}} {
   

--- a/tests/generated/v2.0/another-example.ts
+++ b/tests/generated/v2.0/another-example.ts
@@ -109,6 +109,270 @@ type ApiConfig<SecurityDataType> = {
 }
 
 
+export namespace pet {
+
+  /**
+  * @tags pet
+  * @name addPet
+  * @summary Add a new pet to the store
+  * @request POST:/pet
+  * @secure
+  */
+  export namespace AddPet {
+    export type RequestQuery = {};
+    export type RequestBody = any;
+    export type ResponseBody = any;
+  }
+
+  /**
+  * @tags pet
+  * @name updatePet
+  * @summary Update an existing pet
+  * @request PUT:/pet
+  * @secure
+  */
+  export namespace UpdatePet {
+    export type RequestQuery = {};
+    export type RequestBody = any;
+    export type ResponseBody = any;
+  }
+
+  /**
+  * @tags pet
+  * @name findPetsByStatus
+  * @summary Finds Pets by status
+  * @request GET:/pet/findByStatus
+  * @secure
+  * @description Multiple status values can be provided with comma separated strings
+  */
+  export namespace FindPetsByStatus {
+    export type RequestQuery = { status: Array<"available" | "pending" | "sold"> };
+    export type RequestBody = never;
+    export type ResponseBody = Pet[];
+  }
+
+  /**
+  * @tags pet
+  * @name findPetsByTags
+  * @summary Finds Pets by tags
+  * @request GET:/pet/findByTags
+  * @secure
+  * @description Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+  */
+  export namespace FindPetsByTags {
+    export type RequestQuery = { tags: string[] };
+    export type RequestBody = never;
+    export type ResponseBody = Pet[];
+  }
+
+  /**
+  * @tags pet
+  * @name getPetById
+  * @summary Find pet by ID
+  * @request GET:/pet/{petId}
+  * @secure
+  * @description Returns a single pet
+  */
+  export namespace GetPetById {
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type ResponseBody = Pet;
+  }
+
+  /**
+  * @tags pet
+  * @name updatePetWithForm
+  * @summary Updates a pet in the store with form data
+  * @request POST:/pet/{petId}
+  * @secure
+  */
+  export namespace UpdatePetWithForm {
+    export type RequestQuery = {};
+    export type RequestBody = any;
+    export type ResponseBody = any;
+  }
+
+  /**
+  * @tags pet
+  * @name deletePet
+  * @summary Deletes a pet
+  * @request DELETE:/pet/{petId}
+  * @secure
+  */
+  export namespace DeletePet {
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type ResponseBody = any;
+  }
+
+  /**
+  * @tags pet
+  * @name uploadFile
+  * @summary uploads an image
+  * @request POST:/pet/{petId}/uploadImage
+  * @secure
+  */
+  export namespace UploadFile {
+    export type RequestQuery = {};
+    export type RequestBody = any;
+    export type ResponseBody = ApiResponse;
+  }
+}
+export namespace store {
+
+  /**
+  * @tags store
+  * @name getInventory
+  * @summary Returns pet inventories by status
+  * @request GET:/store/inventory
+  * @secure
+  * @description Returns a map of status codes to quantities
+  */
+  export namespace GetInventory {
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type ResponseBody = number;
+  }
+
+  /**
+  * @tags store
+  * @name placeOrder
+  * @summary Place an order for a pet
+  * @request POST:/store/order
+  */
+  export namespace PlaceOrder {
+    export type RequestQuery = {};
+    export type RequestBody = Order;
+    export type ResponseBody = Order;
+  }
+
+  /**
+  * @tags store
+  * @name getOrderById
+  * @summary Find purchase order by ID
+  * @request GET:/store/order/{orderId}
+  * @description For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
+  */
+  export namespace GetOrderById {
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type ResponseBody = Order;
+  }
+
+  /**
+  * @tags store
+  * @name deleteOrder
+  * @summary Delete purchase order by ID
+  * @request DELETE:/store/order/{orderId}
+  * @description For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
+  */
+  export namespace DeleteOrder {
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type ResponseBody = any;
+  }
+}
+export namespace user {
+
+  /**
+  * @tags user
+  * @name createUser
+  * @summary Create user
+  * @request POST:/user
+  * @description This can only be done by the logged in user.
+  */
+  export namespace CreateUser {
+    export type RequestQuery = {};
+    export type RequestBody = User;
+    export type ResponseBody = any;
+  }
+
+  /**
+  * @tags user
+  * @name createUsersWithArrayInput
+  * @summary Creates list of users with given input array
+  * @request POST:/user/createWithArray
+  */
+  export namespace CreateUsersWithArrayInput {
+    export type RequestQuery = {};
+    export type RequestBody = any;
+    export type ResponseBody = any;
+  }
+
+  /**
+  * @tags user
+  * @name createUsersWithListInput
+  * @summary Creates list of users with given input array
+  * @request POST:/user/createWithList
+  */
+  export namespace CreateUsersWithListInput {
+    export type RequestQuery = {};
+    export type RequestBody = any;
+    export type ResponseBody = any;
+  }
+
+  /**
+  * @tags user
+  * @name loginUser
+  * @summary Logs user into the system
+  * @request GET:/user/login
+  */
+  export namespace LoginUser {
+    export type RequestQuery = { username: string, password: string };
+    export type RequestBody = never;
+    export type ResponseBody = Currency;
+  }
+
+  /**
+  * @tags user
+  * @name logoutUser
+  * @summary Logs out current logged in user session
+  * @request GET:/user/logout
+  */
+  export namespace LogoutUser {
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type ResponseBody = any;
+  }
+
+  /**
+  * @tags user
+  * @name getUserByName
+  * @summary Get user by user name
+  * @request GET:/user/{username}
+  */
+  export namespace GetUserByName {
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type ResponseBody = User;
+  }
+
+  /**
+  * @tags user
+  * @name updateUser
+  * @summary Updated user
+  * @request PUT:/user/{username}
+  * @description This can only be done by the logged in user.
+  */
+  export namespace UpdateUser {
+    export type RequestQuery = {};
+    export type RequestBody = User;
+    export type ResponseBody = any;
+  }
+
+  /**
+  * @tags user
+  * @name deleteUser
+  * @summary Delete user
+  * @request DELETE:/user/{username}
+  * @description This can only be done by the logged in user.
+  */
+  export namespace DeleteUser {
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type ResponseBody = any;
+  }
+}
 
 export class Api<SecurityDataType> {
   

--- a/tests/generated/v2.0/api-with-examples.ts
+++ b/tests/generated/v2.0/api-with-examples.ts
@@ -22,6 +22,31 @@ type ApiConfig<SecurityDataType> = {
 }
 
 
+/**
+* @name listVersionsv2
+* @summary List API versions
+* @request GET:/
+* @description multiple line 1. multiple line 2. multiple line 3. 
+*/
+export namespace ListVersionsv2 {
+  export type RequestQuery = {};
+  export type RequestBody = never;
+  export type ResponseBody = any;
+}
+
+export namespace v2 {
+
+  /**
+  * @name getVersionDetailsv2
+  * @summary Show API version details
+  * @request GET:/v2
+  */
+  export namespace GetVersionDetailsv2 {
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type ResponseBody = any;
+  }
+}
 
 export class Api<SecurityDataType> {
   

--- a/tests/generated/v2.0/petstore-expanded.ts
+++ b/tests/generated/v2.0/petstore-expanded.ts
@@ -34,6 +34,52 @@ type ApiConfig<SecurityDataType> = {
 }
 
 
+export namespace pets {
+
+  /**
+  * @name findPets
+  * @request GET:/pets
+  * @description Returns all pets from the system that the user has access to. Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.. . Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.. 
+  */
+  export namespace FindPets {
+    export type RequestQuery = { tags?: string[], limit?: number };
+    export type RequestBody = never;
+    export type ResponseBody = Pet[];
+  }
+
+  /**
+  * @name addPet
+  * @request POST:/pets
+  * @description Creates a new pet in the store.  Duplicates are allowed
+  */
+  export namespace AddPet {
+    export type RequestQuery = {};
+    export type RequestBody = NewPet;
+    export type ResponseBody = Pet;
+  }
+
+  /**
+  * @name find pet by id
+  * @request GET:/pets/{id}
+  * @description Returns a user based on a single ID, if the user does not have access to the pet
+  */
+  export namespace FindPetById {
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type ResponseBody = Pet;
+  }
+
+  /**
+  * @name deletePet
+  * @request DELETE:/pets/{id}
+  * @description deletes a single pet based on the ID supplied
+  */
+  export namespace DeletePet {
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type ResponseBody = any;
+  }
+}
 
 export class Api<SecurityDataType> {
   

--- a/tests/generated/v2.0/petstore-minimal.ts
+++ b/tests/generated/v2.0/petstore-minimal.ts
@@ -28,6 +28,19 @@ type ApiConfig<SecurityDataType> = {
 }
 
 
+export namespace pets {
+
+  /**
+  * @name petsList
+  * @request GET:/pets
+  * @description Returns all pets from the system that the user has access to
+  */
+  export namespace PetsList {
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type ResponseBody = Pet[];
+  }
+}
 
 export class Api<SecurityDataType> {
   

--- a/tests/generated/v2.0/petstore-simple.ts
+++ b/tests/generated/v2.0/petstore-simple.ts
@@ -34,6 +34,52 @@ type ApiConfig<SecurityDataType> = {
 }
 
 
+export namespace pets {
+
+  /**
+  * @name findPets
+  * @request GET:/pets
+  * @description Returns all pets from the system that the user has access to
+  */
+  export namespace FindPets {
+    export type RequestQuery = { tags?: string[], limit?: number };
+    export type RequestBody = never;
+    export type ResponseBody = Pet[];
+  }
+
+  /**
+  * @name addPet
+  * @request POST:/pets
+  * @description Creates a new pet in the store.  Duplicates are allowed
+  */
+  export namespace AddPet {
+    export type RequestQuery = {};
+    export type RequestBody = NewPet;
+    export type ResponseBody = Pet;
+  }
+
+  /**
+  * @name findPetById
+  * @request GET:/pets/{id}
+  * @description Returns a user based on a single ID, if the user does not have access to the pet
+  */
+  export namespace FindPetById {
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type ResponseBody = Pet;
+  }
+
+  /**
+  * @name deletePet
+  * @request DELETE:/pets/{id}
+  * @description deletes a single pet based on the ID supplied
+  */
+  export namespace DeletePet {
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type ResponseBody = any;
+  }
+}
 
 export class Api<SecurityDataType> {
   

--- a/tests/generated/v2.0/petstore-with-external-docs.ts
+++ b/tests/generated/v2.0/petstore-with-external-docs.ts
@@ -34,6 +34,52 @@ type ApiConfig<SecurityDataType> = {
 }
 
 
+export namespace pets {
+
+  /**
+  * @name findPets
+  * @request GET:/pets
+  * @description Returns all pets from the system that the user has access to
+  */
+  export namespace FindPets {
+    export type RequestQuery = { tags?: string[], limit?: number };
+    export type RequestBody = never;
+    export type ResponseBody = Pet[];
+  }
+
+  /**
+  * @name addPet
+  * @request POST:/pets
+  * @description Creates a new pet in the store.  Duplicates are allowed
+  */
+  export namespace AddPet {
+    export type RequestQuery = {};
+    export type RequestBody = NewPet;
+    export type ResponseBody = Pet;
+  }
+
+  /**
+  * @name findPetById
+  * @request GET:/pets/{id}
+  * @description Returns a user based on a single ID, if the user does not have access to the pet
+  */
+  export namespace FindPetById {
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type ResponseBody = Pet;
+  }
+
+  /**
+  * @name deletePet
+  * @request DELETE:/pets/{id}
+  * @description deletes a single pet based on the ID supplied
+  */
+  export namespace DeletePet {
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type ResponseBody = any;
+  }
+}
 
 export class Api<SecurityDataType> {
   

--- a/tests/generated/v2.0/petstore.ts
+++ b/tests/generated/v2.0/petstore.ts
@@ -35,6 +35,44 @@ type ApiConfig<SecurityDataType> = {
 }
 
 
+export namespace pets {
+
+  /**
+  * @tags pets
+  * @name listPets
+  * @summary List all pets
+  * @request GET:/pets
+  */
+  export namespace ListPets {
+    export type RequestQuery = { limit?: number };
+    export type RequestBody = never;
+    export type ResponseBody = Pets;
+  }
+
+  /**
+  * @tags pets
+  * @name createPets
+  * @summary Create a pet
+  * @request POST:/pets
+  */
+  export namespace CreatePets {
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type ResponseBody = any;
+  }
+
+  /**
+  * @tags pets
+  * @name showPetById
+  * @summary Info for a specific pet
+  * @request GET:/pets/{petId}
+  */
+  export namespace ShowPetById {
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type ResponseBody = Pets;
+  }
+}
 
 export class Api<SecurityDataType> {
   

--- a/tests/generated/v2.0/uber.ts
+++ b/tests/generated/v2.0/uber.ts
@@ -113,6 +113,80 @@ type ApiConfig<SecurityDataType> = {
 }
 
 
+export namespace products {
+
+  /**
+  * @tags Products
+  * @name productsList
+  * @summary Product Types
+  * @request GET:/products
+  * @secure
+  * @description The Products endpoint returns information about the Uber products offered at a given location. The response includes the display name and other details about each product, and lists the products in the proper display order.
+  */
+  export namespace ProductsList {
+    export type RequestQuery = { latitude: number, longitude: number };
+    export type RequestBody = never;
+    export type ResponseBody = Product[];
+  }
+}
+export namespace estimates {
+
+  /**
+  * @tags Estimates
+  * @name priceList
+  * @summary Price Estimates
+  * @request GET:/estimates/price
+  * @description The Price Estimates endpoint returns an estimated price range for each product offered at a given location. The price estimate is provided as a formatted string with the full price range and the localized currency symbol.<br><br>The response also includes low and high estimates, and the [ISO 4217](http://en.wikipedia.org/wiki/ISO_4217) currency code for situations requiring currency conversion. When surge is active for a particular product, its surge_multiplier will be greater than 1, but the price estimate already factors in this multiplier.
+  */
+  export namespace PriceList {
+    export type RequestQuery = { start_latitude: number, start_longitude: number, end_latitude?: number, end_longitude: number };
+    export type RequestBody = never;
+    export type ResponseBody = PriceEstimate[];
+  }
+
+  /**
+  * @tags Estimates
+  * @name timeList
+  * @summary Time Estimates
+  * @request GET:/estimates/time
+  * @description The Time Estimates endpoint returns ETAs for all products offered at a given location, with the responses expressed as integers in seconds. We recommend that this endpoint be called every minute to provide the most accurate, up-to-date ETAs.
+  */
+  export namespace TimeList {
+    export type RequestQuery = { start_latitude: number, start_longitude: number, customer_uuid?: string, product_id?: string };
+    export type RequestBody = never;
+    export type ResponseBody = Product[];
+  }
+}
+export namespace me {
+
+  /**
+  * @tags User
+  * @name getMe
+  * @summary User Profile
+  * @request GET:/me
+  * @description The User Profile endpoint returns information about the Uber user that has authorized with the application.
+  */
+  export namespace GetMe {
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type ResponseBody = Profile;
+  }
+}
+export namespace history {
+
+  /**
+  * @tags User
+  * @name historyList
+  * @summary User Activity
+  * @request GET:/history
+  * @description The User Activity endpoint returns data about a user's lifetime activity with Uber. The response will include pickup locations and times, dropoff locations and times, the distance of past requests, and information about which products were requested.<br><br>The history array in the response will have a maximum length based on the limit parameter. The response value count may exceed limit, therefore subsequent API requests may be necessary.
+  */
+  export namespace HistoryList {
+    export type RequestQuery = { offset?: number, limit?: number };
+    export type RequestBody = never;
+    export type ResponseBody = Activities;
+  }
+}
 
 export class Api<SecurityDataType> {
   

--- a/tests/generated/v3.0/allof-example.ts
+++ b/tests/generated/v3.0/allof-example.ts
@@ -30,6 +30,18 @@ type ApiConfig<SecurityDataType> = {
 }
 
 
+export namespace pets {
+
+  /**
+  * @name petsPartialUpdate
+  * @request PATCH:/pets
+  */
+  export namespace PetsPartialUpdate {
+    export type RequestQuery = {};
+    export type RequestBody = Cat | Dog;
+    export type ResponseBody = any;
+  }
+}
 
 export class Api<SecurityDataType> {
   

--- a/tests/generated/v3.0/anyof-example.ts
+++ b/tests/generated/v3.0/anyof-example.ts
@@ -32,6 +32,18 @@ type ApiConfig<SecurityDataType> = {
 }
 
 
+export namespace pets {
+
+  /**
+  * @name petsPartialUpdate
+  * @request PATCH:/pets
+  */
+  export namespace PetsPartialUpdate {
+    export type RequestQuery = {};
+    export type RequestBody = PetByAge | PetByType | (PetByAge & PetByType);
+    export type ResponseBody = any;
+  }
+}
 
 export class Api<SecurityDataType> {
   

--- a/tests/generated/v3.0/api-with-examples.ts
+++ b/tests/generated/v3.0/api-with-examples.ts
@@ -22,6 +22,30 @@ type ApiConfig<SecurityDataType> = {
 }
 
 
+/**
+* @name listVersionsv2
+* @summary List API versions
+* @request GET:/
+*/
+export namespace ListVersionsv2 {
+  export type RequestQuery = {};
+  export type RequestBody = never;
+  export type ResponseBody = any;
+}
+
+export namespace v2 {
+
+  /**
+  * @name getVersionDetailsv2
+  * @summary Show API version details
+  * @request GET:/v2
+  */
+  export namespace GetVersionDetailsv2 {
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type ResponseBody = any;
+  }
+}
 
 export class Api<SecurityDataType> {
   

--- a/tests/generated/v3.0/callback-example.ts
+++ b/tests/generated/v3.0/callback-example.ts
@@ -22,6 +22,19 @@ type ApiConfig<SecurityDataType> = {
 }
 
 
+export namespace streams {
+
+  /**
+  * @name streamsCreate
+  * @request POST:/streams
+  * @description subscribes a client to receive out-of-band data
+  */
+  export namespace StreamsCreate {
+    export type RequestQuery = { callbackUrl: string };
+    export type RequestBody = never;
+    export type ResponseBody = { subscriptionId: string };
+  }
+}
 
 export class Api<SecurityDataType> {
   

--- a/tests/generated/v3.0/link-example.ts
+++ b/tests/generated/v3.0/link-example.ts
@@ -39,6 +39,68 @@ type ApiConfig<SecurityDataType> = {
 }
 
 
+export namespace v20 {
+
+  /**
+  * @name getUserByName
+  * @request GET:/2.0/users/{username}
+  */
+  export namespace GetUserByName {
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type ResponseBody = user;
+  }
+
+  /**
+  * @name getRepositoriesByOwner
+  * @request GET:/2.0/repositories/{username}
+  */
+  export namespace GetRepositoriesByOwner {
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type ResponseBody = repository[];
+  }
+
+  /**
+  * @name getRepository
+  * @request GET:/2.0/repositories/{username}/{slug}
+  */
+  export namespace GetRepository {
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type ResponseBody = repository;
+  }
+
+  /**
+  * @name getPullRequestsByRepository
+  * @request GET:/2.0/repositories/{username}/{slug}/pullrequests
+  */
+  export namespace GetPullRequestsByRepository {
+    export type RequestQuery = { state?: "open" | "merged" | "declined" };
+    export type RequestBody = never;
+    export type ResponseBody = pullrequest[];
+  }
+
+  /**
+  * @name getPullRequestsById
+  * @request GET:/2.0/repositories/{username}/{slug}/pullrequests/{pid}
+  */
+  export namespace GetPullRequestsById {
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type ResponseBody = pullrequest;
+  }
+
+  /**
+  * @name mergePullRequest
+  * @request POST:/2.0/repositories/{username}/{slug}/pullrequests/{pid}/merge
+  */
+  export namespace MergePullRequest {
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type ResponseBody = any;
+  }
+}
 
 export class Api<SecurityDataType> {
   
@@ -117,7 +179,7 @@ export class Api<SecurityDataType> {
 
 
 
-  20 = {
+  v20 = {
 
 
     /**

--- a/tests/generated/v3.0/oneof-example.ts
+++ b/tests/generated/v3.0/oneof-example.ts
@@ -32,6 +32,18 @@ type ApiConfig<SecurityDataType> = {
 }
 
 
+export namespace pets {
+
+  /**
+  * @name petsPartialUpdate
+  * @request PATCH:/pets
+  */
+  export namespace PetsPartialUpdate {
+    export type RequestQuery = {};
+    export type RequestBody = Cat | Dog;
+    export type ResponseBody = any;
+  }
+}
 
 export class Api<SecurityDataType> {
   

--- a/tests/generated/v3.0/personal-api-example.ts
+++ b/tests/generated/v3.0/personal-api-example.ts
@@ -111,6 +111,168 @@ type ApiConfig<SecurityDataType> = {
 }
 
 
+export namespace auth {
+
+  /**
+  * @tags Auth
+  * @name Login
+  * @request POST:/auth
+  */
+  export namespace Login {
+    export type RequestQuery = {};
+    export type RequestBody = AuthUser;
+    export type ResponseBody = string;
+  }
+
+  /**
+  * @tags Auth
+  * @name Refresh
+  * @request POST:/auth/refresh
+  * @secure
+  */
+  export namespace Refresh {
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type ResponseBody = string;
+  }
+}
+export namespace jobs {
+
+  /**
+  * @tags Jobs
+  * @name GetJobs
+  * @request GET:/jobs
+  * @secure
+  */
+  export namespace GetJobs {
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type ResponseBody = Job[];
+  }
+
+  /**
+  * @tags Jobs
+  * @name AddJob
+  * @request POST:/jobs
+  * @secure
+  */
+  export namespace AddJob {
+    export type RequestQuery = {};
+    export type RequestBody = JobUpdate;
+    export type ResponseBody = string;
+  }
+
+  /**
+  * @tags Jobs
+  * @name GetJob
+  * @request GET:/jobs/{id}
+  * @secure
+  */
+  export namespace GetJob {
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type ResponseBody = Job;
+  }
+
+  /**
+  * @tags Jobs
+  * @name UpdateJob
+  * @request PATCH:/jobs/{id}
+  * @secure
+  */
+  export namespace UpdateJob {
+    export type RequestQuery = {};
+    export type RequestBody = JobUpdate;
+    export type ResponseBody = UpdatedJob;
+  }
+}
+export namespace projects {
+
+  /**
+  * @tags Projects
+  * @name GetProjects
+  * @request GET:/projects
+  */
+  export namespace GetProjects {
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type ResponseBody = Project[];
+  }
+
+  /**
+  * @tags Projects
+  * @name AddProjects
+  * @request POST:/projects
+  * @secure
+  */
+  export namespace AddProjects {
+    export type RequestQuery = {};
+    export type RequestBody = ProjectUpdate;
+    export type ResponseBody = string;
+  }
+
+  /**
+  * @tags Projects
+  * @name UpdateProject
+  * @request PATCH:/projects/{id}
+  * @secure
+  */
+  export namespace UpdateProject {
+    export type RequestQuery = {};
+    export type RequestBody = ProjectUpdate;
+    export type ResponseBody = UpdatedProject;
+  }
+}
+export namespace users {
+
+  /**
+  * @tags Users
+  * @name GetUsers
+  * @request GET:/users
+  * @secure
+  */
+  export namespace GetUsers {
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type ResponseBody = User[];
+  }
+
+  /**
+  * @tags Users
+  * @name AddUser
+  * @request POST:/users
+  * @secure
+  */
+  export namespace AddUser {
+    export type RequestQuery = {};
+    export type RequestBody = AuthUser;
+    export type ResponseBody = User;
+  }
+
+  /**
+  * @tags Users
+  * @name DeleteUser
+  * @request DELETE:/users/{id}
+  * @secure
+  */
+  export namespace DeleteUser {
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type ResponseBody = any;
+  }
+
+  /**
+  * @tags Users
+  * @name UpdateUser
+  * @request PATCH:/users/{id}
+  * @secure
+  */
+  export namespace UpdateUser {
+    export type RequestQuery = {};
+    export type RequestBody = UserUpdate;
+    export type ResponseBody = User;
+  }
+}
 
 export class Api<SecurityDataType> {
   

--- a/tests/generated/v3.0/petstore-expanded.ts
+++ b/tests/generated/v3.0/petstore-expanded.ts
@@ -34,6 +34,52 @@ type ApiConfig<SecurityDataType> = {
 }
 
 
+export namespace pets {
+
+  /**
+  * @name findPets
+  * @request GET:/pets
+  * @description Returns all pets from the system that the user has access to. Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.. . Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.. 
+  */
+  export namespace FindPets {
+    export type RequestQuery = { tags?: string[], limit?: number };
+    export type RequestBody = never;
+    export type ResponseBody = Pet[];
+  }
+
+  /**
+  * @name addPet
+  * @request POST:/pets
+  * @description Creates a new pet in the store. Duplicates are allowed
+  */
+  export namespace AddPet {
+    export type RequestQuery = {};
+    export type RequestBody = NewPet;
+    export type ResponseBody = Pet;
+  }
+
+  /**
+  * @name find pet by id
+  * @request GET:/pets/{id}
+  * @description Returns a user based on a single ID, if the user does not have access to the pet
+  */
+  export namespace FindPetById {
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type ResponseBody = Pet;
+  }
+
+  /**
+  * @name deletePet
+  * @request DELETE:/pets/{id}
+  * @description deletes a single pet based on the ID supplied
+  */
+  export namespace DeletePet {
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type ResponseBody = any;
+  }
+}
 
 export class Api<SecurityDataType> {
   

--- a/tests/generated/v3.0/petstore.ts
+++ b/tests/generated/v3.0/petstore.ts
@@ -35,6 +35,44 @@ type ApiConfig<SecurityDataType> = {
 }
 
 
+export namespace pets {
+
+  /**
+  * @tags pets
+  * @name listPets
+  * @summary List all pets
+  * @request GET:/pets
+  */
+  export namespace ListPets {
+    export type RequestQuery = { limit?: number };
+    export type RequestBody = never;
+    export type ResponseBody = Pets;
+  }
+
+  /**
+  * @tags pets
+  * @name createPets
+  * @summary Create a pet
+  * @request POST:/pets
+  */
+  export namespace CreatePets {
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type ResponseBody = any;
+  }
+
+  /**
+  * @tags pets
+  * @name showPetById
+  * @summary Info for a specific pet
+  * @request GET:/pets/{petId}
+  */
+  export namespace ShowPetById {
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type ResponseBody = Pet;
+  }
+}
 
 export class Api<SecurityDataType> {
   

--- a/tests/generated/v3.0/tsoa-odd-types-3.0.2.ts
+++ b/tests/generated/v3.0/tsoa-odd-types-3.0.2.ts
@@ -129,6 +129,180 @@ type ApiConfig<SecurityDataType> = {
 }
 
 
+export namespace auth {
+
+  /**
+  * @tags Auth
+  * @name Login
+  * @request POST:/auth
+  */
+  export namespace Login {
+    export type RequestQuery = {};
+    export type RequestBody = AuthUser;
+    export type ResponseBody = string;
+  }
+
+  /**
+  * @tags Auth
+  * @name Refresh
+  * @request POST:/auth/refresh
+  * @secure
+  */
+  export namespace Refresh {
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type ResponseBody = string;
+  }
+}
+export namespace jobs {
+
+  /**
+  * @tags Jobs
+  * @name GetJobs
+  * @request GET:/jobs
+  * @secure
+  */
+  export namespace GetJobs {
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type ResponseBody = Job[];
+  }
+
+  /**
+  * @tags Jobs
+  * @name AddJob
+  * @request POST:/jobs
+  * @secure
+  */
+  export namespace AddJob {
+    export type RequestQuery = {};
+    export type RequestBody = Pick_Job_github;
+    export type ResponseBody = string;
+  }
+
+  /**
+  * @tags Jobs
+  * @name GetJob
+  * @request GET:/jobs/{id}
+  * @secure
+  */
+  export namespace GetJob {
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type ResponseBody = UpdatedJob;
+  }
+
+  /**
+  * @tags Jobs
+  * @name UpdateJob
+  * @request PATCH:/jobs/{id}
+  * @secure
+  */
+  export namespace UpdateJob {
+    export type RequestQuery = {};
+    export type RequestBody = JobUpdate;
+    export type ResponseBody = UpdatedJob;
+  }
+
+  /**
+  * @tags Jobs
+  * @name DeleteJob
+  * @request DELETE:/jobs/{id}
+  * @secure
+  */
+  export namespace DeleteJob {
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type ResponseBody = any;
+  }
+}
+export namespace projects {
+
+  /**
+  * @tags Projects
+  * @name GetProjects
+  * @request GET:/projects
+  */
+  export namespace GetProjects {
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type ResponseBody = Project[];
+  }
+
+  /**
+  * @tags Projects
+  * @name AddProjects
+  * @request POST:/projects
+  * @secure
+  */
+  export namespace AddProjects {
+    export type RequestQuery = {};
+    export type RequestBody = ProjectUpdate;
+    export type ResponseBody = string;
+  }
+
+  /**
+  * @tags Projects
+  * @name UpdateProject
+  * @request PATCH:/projects/{id}
+  * @secure
+  */
+  export namespace UpdateProject {
+    export type RequestQuery = {};
+    export type RequestBody = ProjectUpdate;
+    export type ResponseBody = UpdatedProject;
+  }
+}
+export namespace users {
+
+  /**
+  * @tags Users
+  * @name GetUsers
+  * @request GET:/users
+  * @secure
+  */
+  export namespace GetUsers {
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type ResponseBody = User[];
+  }
+
+  /**
+  * @tags Users
+  * @name AddUser
+  * @request POST:/users
+  * @secure
+  */
+  export namespace AddUser {
+    export type RequestQuery = {};
+    export type RequestBody = AuthUser;
+    export type ResponseBody = User;
+  }
+
+  /**
+  * @tags Users
+  * @name DeleteUser
+  * @request DELETE:/users/{id}
+  * @secure
+  */
+  export namespace DeleteUser {
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type ResponseBody = any;
+  }
+
+  /**
+  * @tags Users
+  * @name UpdateUser
+  * @request PATCH:/users/{id}
+  * @secure
+  */
+  export namespace UpdateUser {
+    export type RequestQuery = {};
+    export type RequestBody = UserUpdate;
+    export type ResponseBody = User;
+  }
+}
 
 export class Api<SecurityDataType> {
   

--- a/tests/generated/v3.0/uspto.ts
+++ b/tests/generated/v3.0/uspto.ts
@@ -27,6 +27,46 @@ type ApiConfig<SecurityDataType> = {
 }
 
 
+/**
+* @tags metadata
+* @name list-data-sets
+* @summary List available data sets
+* @request GET:/
+*/
+export namespace ListDataSets {
+  export type RequestQuery = {};
+  export type RequestBody = never;
+  export type ResponseBody = dataSetList;
+}
+
+export namespace dataset {
+
+  /**
+  * @tags metadata
+  * @name list-searchable-fields
+  * @summary Provides the general information about the API and the list of fields that can be used to query the dataset.
+  * @request GET:/{dataset}/{version}/fields
+  * @description This GET API returns the list of all the searchable field names that are in the oa_citations. Please see the 'fields' attribute which returns an array of field names. Each field or a combination of fields can be searched using the syntax options shown below.
+  */
+  export namespace ListSearchableFields {
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type ResponseBody = string;
+  }
+
+  /**
+  * @tags search
+  * @name perform-search
+  * @summary Provides search capability for the data set with the given search criteria.
+  * @request POST:/{dataset}/{version}/records
+  * @description This API is based on Solr/Lucense Search. The data is indexed using SOLR. This GET API returns the list of all the searchable field names that are in the Solr Index. Please see the 'fields' attribute which returns an array of field names. Each field or a combination of fields can be searched using the Solr/Lucene Syntax. Please refer https://lucene.apache.org/core/3_6_2/queryparsersyntax.html#Overview for the query syntax. List of field names that are searchable can be determined using above GET api.
+  */
+  export namespace PerformSearch {
+    export type RequestQuery = {};
+    export type RequestBody = any;
+    export type ResponseBody = object[];
+  }
+}
 
 export class Api<SecurityDataType> {
   


### PR DESCRIPTION
👋 Hi @acacode, I have been searching the internets for a tool to convert an OpenAPI spec into TS declarations and I was surprised with the lack of quality in this area. None of the tools seemed to offer what I was after, which is simply Type Definitions (not even the generated client) for a REST API.

I then stumbled across your repo and found it super approachable to hack on and I got the result I was after in no time.

This PR adds exports for interfaces describing the `RequestQuery`, `RequestBody` and `ResponseBody` types for each route. These are very useful things to have as type annotations for function declarations dealing with API requests/responses.

Is this something you would like to see in the project?