### PR TITLE
[Bugfix] TypeScript 3.7.5 error in the strict mode inside addQueryParams method

### DIFF
--- a/src/templates/client.mustache
+++ b/src/templates/client.mustache
@@ -49,15 +49,12 @@ export class Api{{apiConfig.generic}} {
   }
 
   {{#hasQueryRoutes}}
-  private addQueryParams(query: object): string {
-    const keys = Object.keys(query);
-    return keys.length ? (
-      '?' +
-      keys.reduce((paramsArray, param) => [
-        ...paramsArray,
-        param + '=' + encodeURIComponent(query[param])
-      ], []).join('&')
-    ) : ''
+  private addQueryParams(query: Record<string, string|string[]|number|number[]|boolean|undefined>): string {
+    const keys = Object.keys(query).filter(key => "undefined" !== typeof query[key])
+    return keys.length === 0 ? ''
+      : '?' + keys.map(key => encodeURIComponent(key) + '=' + encodeURIComponent(
+                Array.isArray(query[key]) ? (query[key] as any).join(',') : query[key])
+              ).join('&')
   }
   {{/hasQueryRoutes}}
 


### PR DESCRIPTION
[issue 22](https://github.com/acacode/swagger-typescript-api/issues/22)