### PR TITLE
Release 1.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # next release  
 
+# 1.8.2  
+
+Fixes:  
+- Broken types for arrays of union types ([issue](https://github.com/acacode/swagger-typescript-api/issues/49))  
+
 # 1.8.1  
 
 Fixes:  

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-typescript-api",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-typescript-api",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Create typescript api module from swagger schema",
   "scripts": {
     "cli": "node index.js -r -d -p http://localhost:8080/api/v1/swagger.json -n swagger-test-cli.ts",

--- a/src/schema.js
+++ b/src/schema.js
@@ -20,7 +20,7 @@ const types = {
   },
   array: ({ items, ...schemaPart }) => {
     const { content } = parseSchema(items, null, inlineExtraFormatters);
-    return checkAndAddNull(schemaPart, `${content}[]`);
+    return checkAndAddNull(schemaPart, `(${content})[]`);
   },
 
   // TODO: probably it can be needed

--- a/tests/generated/v2.0/another-example.ts
+++ b/tests/generated/v2.0/another-example.ts
@@ -241,7 +241,7 @@ export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
      * @secure
      * @description Multiple status values can be provided with comma separated strings
      */
-    findPetsByStatus: (query: { status: "available" | "pending" | "sold"[] }, params?: RequestParams) =>
+    findPetsByStatus: (query: { status: ("available" | "pending" | "sold")[] }, params?: RequestParams) =>
       this.request<Pet[], any>(
         `/pet/findByStatus${this.addQueryParams(query)}`,
         "GET",

--- a/tests/generated/v2.0/github-swagger.ts
+++ b/tests/generated/v2.0/github-swagger.ts
@@ -492,7 +492,7 @@ export type hook = {
   active?: boolean;
   config?: { content_type?: string; url?: string };
   created_at?: string;
-  events?:
+  events?: (
     | "push"
     | "issues"
     | "issue_comment"
@@ -507,7 +507,8 @@ export type hook = {
     | "member"
     | "public"
     | "team_add"
-    | "status"[];
+    | "status"
+  )[];
   id?: number;
   name?: string;
   updated_at?: string;

--- a/tests/generated/v2.0/petstore-swagger-io.ts
+++ b/tests/generated/v2.0/petstore-swagger-io.ts
@@ -247,7 +247,7 @@ export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
      * @secure
      * @description Multiple status values can be provided with comma separated strings
      */
-    findPetsByStatus: (query: { status: "available" | "pending" | "sold"[] }, params?: RequestParams) =>
+    findPetsByStatus: (query: { status: ("available" | "pending" | "sold")[] }, params?: RequestParams) =>
       this.request<Pet[], any>(
         `/pet/findByStatus${this.addQueryParams(query)}`,
         "GET",

--- a/tests/spec/noClient/schema.ts
+++ b/tests/spec/noClient/schema.ts
@@ -492,7 +492,7 @@ export type hook = {
   active?: boolean;
   config?: { content_type?: string; url?: string };
   created_at?: string;
-  events?:
+  events?: (
     | "push"
     | "issues"
     | "issue_comment"
@@ -507,7 +507,8 @@ export type hook = {
     | "member"
     | "public"
     | "team_add"
-    | "status"[];
+    | "status"
+  )[];
   id?: number;
   name?: string;
   updated_at?: string;

--- a/tests/spec/routeTypes/schema.ts
+++ b/tests/spec/routeTypes/schema.ts
@@ -492,7 +492,7 @@ export type hook = {
   active?: boolean;
   config?: { content_type?: string; url?: string };
   created_at?: string;
-  events?:
+  events?: (
     | "push"
     | "issues"
     | "issue_comment"
@@ -507,7 +507,8 @@ export type hook = {
     | "member"
     | "public"
     | "team_add"
-    | "status"[];
+    | "status"
+  )[];
   id?: number;
   name?: string;
   updated_at?: string;


### PR DESCRIPTION

Fixes:  
- Broken types for arrays of union types ([issue](https://github.com/acacode/swagger-typescript-api/issues/49))  
