### PR TITLE
Release 1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # next release  
 
+Features:  
+- `--union-enums` CLI option. Allows to generate all enums as union types.  
+  For example, schema part:  
+  ```
+  "StringEnum": {
+    "enum": ["String1", "String2", "String3", "String4"],
+    "type": "string"
+  }
+  ```  
+  will be converted into:
+      ```
+export type StringEnum = "String1" | "String2" | "String3" | "String4";
+      ```  
+  
+
 # 1.8.4  
 
 Fixes:  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 # 1.10.0  
 
 Features:  
-- `--templates` CLI option.  
+- `--templates` CLI option. ([feature request])(https://github.com/acacode/swagger-typescript-api/issues/54)  
   Provide custom `mustache` templates folder which allows to generate custom code (models, Api class, routes)  
-- `--union-enums` CLI option.  
+- `--union-enums` CLI option. ([feature request])(https://github.com/acacode/swagger-typescript-api/issues/58)  
   Allows to generate all enums as union types.  
   For example, schema part:  
   ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 # next release  
 
+
+# 1.10.0  
+
 Features:  
-- `--union-enums` CLI option. Allows to generate all enums as union types.  
+- `--templates` CLI option.  
+  Provide custom `mustache` templates folder which allows to generate custom code (models, Api class, routes)  
+- `--union-enums` CLI option.  
+  Allows to generate all enums as union types.  
   For example, schema part:  
   ```
   "StringEnum": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 # 1.10.0  
 
 Features:  
-- `--templates` CLI option. ([feature request])(https://github.com/acacode/swagger-typescript-api/issues/54)  
+- `--templates` CLI option. [[feature request]](https://github.com/acacode/swagger-typescript-api/issues/54)  
   Provide custom `mustache` templates folder which allows to generate custom code (models, Api class, routes)  
-- `--union-enums` CLI option. ([feature request])(https://github.com/acacode/swagger-typescript-api/issues/58)  
+- `--union-enums` CLI option. [[feature request]](https://github.com/acacode/swagger-typescript-api/issues/58)  
   Allows to generate all enums as union types.  
   For example, schema part:  
   ```

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Options:
                             as success response type by default. (default: false)
   -r, --responses           generate additional information about request responses  
                             also add typings for bad responses  
+  --union-enums             generate all "enum" types as union types (T1 | T2 | TN) (default: false)
   --route-types             generate type definitions for API routes (default: false)
   --no-client               do not generate an API class
   -h, --help                output usage information

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Options:
   -p, --path <path>         path/url to swagger scheme
   -o, --output <output>     output path of typescript api file (default: "./")
   -n, --name <name>         name of output typescript api file (default: "Api.ts")
+  -t, --templates <path>    path to folder containing templates (default: "./src/templates")
   -d, --default-as-success  use "default" response status code as success response too.
                             some swagger schemas use "default" response status code
                             as success response type by default. (default: false)

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,4 @@
-
 interface GenerateApiParams {
-
   /**
    * path to swagger schema
    */
@@ -20,7 +18,12 @@ interface GenerateApiParams {
    * path to folder where will been located the created api module
    */
   output?: string;
-  
+
+  /**
+   * path to folder containing templates (default: ./scr/templates)
+   */
+  templates?: string;
+
   /**
    * generate type definitions for API routes (default: false)
    */
@@ -32,7 +35,7 @@ interface GenerateApiParams {
   generateClient?: boolean;
 
   /**
-   * use "default" response status code as success response too.  
+   * use "default" response status code as success response too.
    * some swagger schemas use "default" response status code as success response type by default.
    */
   defaultResponseAsSuccess?: boolean;
@@ -44,5 +47,5 @@ interface GenerateApiParams {
   generateResponses?: boolean;
 }
 
-export declare function generateApi(params: Omit<GenerateApiParams, "url">): Promise<string>
-export declare function generateApi(params: Omit<GenerateApiParams, "input">): Promise<string>
+export declare function generateApi(params: Omit<GenerateApiParams, "url">): Promise<string>;
+export declare function generateApi(params: Omit<GenerateApiParams, "input">): Promise<string>;

--- a/index.js
+++ b/index.js
@@ -30,12 +30,13 @@ program
       "also add typings for bad responses",
     false,
   )
+  .option("--union-enums", 'generate all "enum" types as union types (T1 | T2 | TN)', false)
   .option("--route-types", "generate type definitions for API routes", false)
   .option("--no-client", "do not generate an API class", false);
 
 program.parse(process.argv);
 
-const { path, output, name, templates, routeTypes, client, defaultAsSuccess, responses } = program;
+const { path, output, name, templates, unionEnums, routeTypes, client, defaultAsSuccess, responses } = program;
 
 generateApi({
   name,
@@ -43,6 +44,7 @@ generateApi({
   generateRouteTypes: routeTypes,
   generateClient: client,
   defaultResponseAsSuccess: defaultAsSuccess,
+  generateUnionEnums: unionEnums,
   generateResponses: responses,
   input: resolve(process.cwd(), path),
   output: resolve(process.cwd(), output || "."),

--- a/index.js
+++ b/index.js
@@ -6,43 +6,36 @@
 // License text available at https://opensource.org/licenses/MIT
 // Repository https://github.com/acacode/swagger-typescript-api
 
-const program = require('commander');
-const { resolve } = require('path');
-const { generateApi } = require('./src');
-const { version } = require('./package.json');
+const program = require("commander");
+const { resolve } = require("path");
+const { generateApi } = require("./src");
+const { version } = require("./package.json");
 
 program
-  .version(version, '-v, --version', 'output the current version')
+  .version(version, "-v, --version", "output the current version")
   .description("Generate api via swagger scheme.\nSupports OA 3.0, 2.0, JSON, yaml.")
-  .requiredOption('-p, --path <path>', 'path/url to swagger scheme')
-  .option('-o, --output <output>', 'output path of typescript api file', './')
-  .option('-n, --name <name>', 'name of output typescript api file', 'Api.ts')
+  .requiredOption("-p, --path <path>", "path/url to swagger scheme")
+  .option("-o, --output <output>", "output path of typescript api file", "./")
+  .option("-n, --name <name>", "name of output typescript api file", "Api.ts")
+  .option("-t, --templates <path>", "path to folder containing templates")
   .option(
-    '-d, --default-as-success',
+    "-d, --default-as-success",
     'use "default" response status code as success response too.\n' +
-    'some swagger schemas use "default" response status code as success response type by default.',
-    false
-  )
-  .option(
-    '-r, --responses',
-    'generate additional information about request responses\n' +
-    'also add typings for bad responses',
+      'some swagger schemas use "default" response status code as success response type by default.',
     false,
   )
-  .option('--route-types', 'generate type definitions for API routes', false)
-  .option('--no-client', 'do not generate an API class', false);
- 
+  .option(
+    "-r, --responses",
+    "generate additional information about request responses\n" +
+      "also add typings for bad responses",
+    false,
+  )
+  .option("--route-types", "generate type definitions for API routes", false)
+  .option("--no-client", "do not generate an API class", false);
+
 program.parse(process.argv);
 
-const {
-  path,
-  output,
-  name,
-  routeTypes,
-  client,
-  defaultAsSuccess,
-  responses,
-} = program;
+const { path, output, name, templates, routeTypes, client, defaultAsSuccess, responses } = program;
 
 generateApi({
   name,
@@ -52,5 +45,6 @@ generateApi({
   defaultResponseAsSuccess: defaultAsSuccess,
   generateResponses: responses,
   input: resolve(process.cwd(), path),
-  output: resolve(process.cwd(), output || '.')
-})
+  output: resolve(process.cwd(), output || "."),
+  templates: resolve(templates ? process.cwd() : __dirname, templates || "./src/templates"),
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-typescript-api",
-  "version": "1.8.4",
+  "version": "1.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "scripts": {
     "cli:json": "node index.js -r -d -p ./swagger-test-cli.json -n swagger-test-cli.ts",
     "cli:yaml": "node index.js -r -d -p ./swagger-test-cli.yaml -n swagger-test-cli.ts",
-    "cli:debug:json": "node  --nolazy --inspect-brk=9229 index.js -p ./swagger-test-cli.json -n swagger-test-cli.ts",
+    "cli:debug:json": "node  --nolazy --inspect-brk=9229 index.js -p ./swagger-test-cli.json -n swagger-test-cli.ts --union-enums",
     "cli:debug:yaml": "node  --nolazy --inspect-brk=9229 index.js -p ./swagger-test-cli.yaml -n swagger-test-cli.ts",
     "cli:help": "node index.js -h",
-    "test:all": "npm-run-all generate validate test:routeTypes test:noClient test:defaultAsSuccess test:responses test:templates --continue-on-error",
+    "test:all": "npm-run-all generate validate test:routeTypes test:noClient test:defaultAsSuccess test:responses test:templates test:unionEnums --continue-on-error",
     "generate": "node tests/generate.js",
     "generate:debug": "node --nolazy --inspect-brk=9229 tests/generate.js",
     "validate": "node tests/validate.js",
@@ -17,6 +17,7 @@
     "test:noClient": "node tests/spec/noClient/test.js",
     "test:defaultAsSuccess": "node tests/spec/defaultAsSuccess/test.js",
     "test:templates": "node tests/spec/templates/test.js",
+    "test:unionEnums": "node tests/spec/unionEnums/test.js",
     "test:responses": "node tests/spec/responses/test.js"
   },
   "author": "acacode",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "cli:debug:json": "node  --nolazy --inspect-brk=9229 index.js -p ./swagger-test-cli.json -n swagger-test-cli.ts",
     "cli:debug:yaml": "node  --nolazy --inspect-brk=9229 index.js -p ./swagger-test-cli.yaml -n swagger-test-cli.ts",
     "cli:help": "node index.js -h",
-    "test:all": "npm-run-all generate validate test:routeTypes test:noClient test:defaultAsSuccess test:responses --continue-on-error",
+    "test:all": "npm-run-all generate validate test:routeTypes test:noClient test:defaultAsSuccess test:responses test:templates --continue-on-error",
     "generate": "node tests/generate.js",
     "generate:debug": "node --nolazy --inspect-brk=9229 tests/generate.js",
     "validate": "node tests/validate.js",
@@ -16,6 +16,7 @@
     "test:routeTypes": "node tests/spec/routeTypes/test.js",
     "test:noClient": "node tests/spec/noClient/test.js",
     "test:defaultAsSuccess": "node tests/spec/defaultAsSuccess/test.js",
+    "test:templates": "node tests/spec/templates/test.js",
     "test:responses": "node tests/spec/responses/test.js"
   },
   "author": "acacode",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-typescript-api",
-  "version": "1.8.4",
+  "version": "1.10.0",
   "description": "Create typescript api module from swagger schema",
   "scripts": {
     "cli:json": "node index.js -r -d -p ./swagger-test-cli.json -n swagger-test-cli.ts",

--- a/src/config.js
+++ b/src/config.js
@@ -1,5 +1,7 @@
 const config = {
   /** CLI flag */
+  templates: "./templates",
+  /** CLI flag */
   generateResponses: false,
   /** CLI flag */
   defaultResponseAsSuccess: false,

--- a/src/config.js
+++ b/src/config.js
@@ -9,6 +9,8 @@ const config = {
   generateRouteTypes: false,
   /** CLI flag */
   generateClient: true,
+  /** CLI flag */
+  generateUnionEnums: false,
   /** parsed swagger schema from getSwaggerObject() */
 
   /** parsed swagger schema ref */

--- a/src/files.js
+++ b/src/files.js
@@ -2,21 +2,15 @@ const _ = require("lodash");
 const fs = require("fs");
 const { resolve } = require("path");
 
-const getFileContent = path =>
-  fs.readFileSync(path, { encoding: 'UTF-8' })
+const getFileContent = (path) => fs.readFileSync(path, { encoding: "UTF-8" });
 
-const pathIsExist = path =>
-  path && fs.existsSync(path)
+const pathIsExist = (path) => path && fs.existsSync(path);
 
 const createFile = (pathTo, fileName, content) =>
-  fs.writeFileSync(resolve(__dirname, pathTo, `./${fileName}`), content, _.noop)
-
-const getTemplate = templateName =>
-  getFileContent(resolve(__dirname, `./templates/${templateName}.mustache`))                       
+  fs.writeFileSync(resolve(__dirname, pathTo, `./${fileName}`), content, _.noop);
 
 module.exports = {
-  getTemplate,
   createFile,
   pathIsExist,
   getFileContent,
-}
+};

--- a/src/index.js
+++ b/src/index.js
@@ -9,14 +9,16 @@
 const mustache = require("mustache");
 const prettier = require("prettier");
 const _ = require("lodash");
+const { resolve } = require("path");
 const { parseSchemas } = require("./schema");
 const { parseRoutes, groupRoutes } = require("./routes");
 const { createApiConfig } = require("./apiConfig");
 const { getModelType } = require("./modelTypes");
 const { getSwaggerObject, fixSwaggerScheme } = require("./swagger");
 const { createComponentsMap, filterComponentsMap } = require("./components");
-const { getTemplate, createFile, pathIsExist } = require("./files");
+const { createFile, pathIsExist } = require("./files");
 const { addToConfig, config } = require("./config");
+const { getTemplates } = require("./templates");
 
 mustache.escape = (value) => value;
 
@@ -33,6 +35,7 @@ module.exports = {
     output,
     url,
     name,
+    templates = resolve(__dirname, config.templates),
     generateResponses = config.generateResponses,
     defaultResponseAsSuccess = config.defaultResponseAsSuccess,
     generateRouteTypes = config.generateRouteTypes,
@@ -44,9 +47,12 @@ module.exports = {
         generateRouteTypes,
         generateClient,
         generateResponses,
+        templates,
       });
       getSwaggerObject(input, url)
         .then(({ usageSchema, originalSchema }) => {
+          const { apiTemplate, clientTemplate, routeTypesTemplate } = getTemplates();
+
           console.log("☄️  start generating your typescript api");
 
           fixSwaggerScheme(usageSchema, originalSchema);
@@ -57,10 +63,6 @@ module.exports = {
           });
 
           const { info, paths, servers, components } = usageSchema;
-
-          const apiTemplate = getTemplate("api");
-          const clientTemplate = getTemplate("client");
-          const routeTypesTemplate = getTemplate("route-types");
 
           const componentsMap = createComponentsMap(components);
           const schemasMap = filterComponentsMap(componentsMap, "schemas");

--- a/src/index.js
+++ b/src/index.js
@@ -40,6 +40,7 @@ module.exports = {
     defaultResponseAsSuccess = config.defaultResponseAsSuccess,
     generateRouteTypes = config.generateRouteTypes,
     generateClient = config.generateClient,
+    generateUnionEnums = config.generateUnionEnums,
   }) =>
     new Promise((resolve, reject) => {
       addToConfig({
@@ -48,6 +49,7 @@ module.exports = {
         generateClient,
         generateResponses,
         templates,
+        generateUnionEnums,
       });
       getSwaggerObject(input, url)
         .then(({ usageSchema, originalSchema }) => {

--- a/src/modelTypes.js
+++ b/src/modelTypes.js
@@ -1,22 +1,27 @@
-const _ = require('lodash');
+const _ = require("lodash");
 const { formatters } = require("./typeFormatters");
 const { checkAndRenameModelName } = require("./modelNames");
-const { formatDescription } = require("./common")
-const { getTypeData } = require('./components');
+const { formatDescription } = require("./common");
+const { config } = require("./config");
+const { getTypeData } = require("./components");
 
-const CONTENT_KEYWORD = '__CONTENT__';
+const CONTENT_KEYWORD = "__CONTENT__";
 
 const contentWrapersByTypeIdentifier = {
-  'enum': `{\r\n${CONTENT_KEYWORD} \r\n }`,
-  'interface': `{\r\n${CONTENT_KEYWORD}}`,
-  'type': `= ${CONTENT_KEYWORD}`,
-}
+  enum: `{\r\n${CONTENT_KEYWORD} \r\n }`,
+  interface: `{\r\n${CONTENT_KEYWORD}}`,
+  type: `= ${CONTENT_KEYWORD}`,
+};
 
-const getModelType = typeInfo => {
-  const { typeIdentifier, name: originalName, content, type, description } = getTypeData(typeInfo);
+const getModelType = (typeInfo) => {
+  let { typeIdentifier, name: originalName, content, type, description } = getTypeData(typeInfo);
+
+  if (config.generateUnionEnums && typeIdentifier === "enum") {
+    typeIdentifier = "type";
+  }
 
   if (!contentWrapersByTypeIdentifier[typeIdentifier]) {
-    throw new Error(`${typeIdentifier} - type identifier is unknown for this utility`)
+    throw new Error(`${typeIdentifier} - type identifier is unknown for this utility`);
   }
 
   const resultContent = formatters[type] ? formatters[type](content) : content;
@@ -27,11 +32,15 @@ const getModelType = typeInfo => {
     name,
     rawContent: resultContent,
     description: formatDescription(description),
-    content: _.replace(contentWrapersByTypeIdentifier[typeIdentifier], CONTENT_KEYWORD, resultContent)
-  }
-}
+    content: _.replace(
+      contentWrapersByTypeIdentifier[typeIdentifier],
+      CONTENT_KEYWORD,
+      resultContent,
+    ),
+  };
+};
 
 module.exports = {
   getModelType,
   checkAndRenameModelName,
-}
+};

--- a/src/templates.js
+++ b/src/templates.js
@@ -1,0 +1,20 @@
+const { getFileContent } = require("./files");
+const { config } = require("./config");
+const { resolve } = require("path");
+
+const getTemplates = () => {
+  console.log(`✨ try to read templates from directory "${config.templates}"`);
+
+  return {
+    apiTemplate: getTemplate("api"),
+    clientTemplate: config.generateClient ? getTemplate("client") : null,
+    routeTypesTemplate: config.generateRouteTypes ? getTemplate("route-types") : null,
+  };
+};
+
+const getTemplate = (templateName) =>
+  getFileContent(resolve(config.templates, `./${templateName}.mustache`));
+
+module.exports = {
+  getTemplates,
+};

--- a/src/typeFormatters.js
+++ b/src/typeFormatters.js
@@ -1,8 +1,12 @@
 const _ = require("lodash");
+const { config } = require("./config");
 const { checkAndRenameModelName } = require("./modelNames");
 
 const formatters = {
-  enum: (content) => _.map(content, ({ key, value }) => `  ${key} = ${value}`).join(",\n"),
+  enum: (content) =>
+    _.map(content, ({ key, value }) =>
+      config.generateUnionEnums ? value : `  ${key} = ${value}`,
+    ).join(config.generateUnionEnums ? " | " : ",\n"),
   intEnum: (content) => _.map(content, ({ value }) => value).join(" | "),
   object: (content) =>
     _.map(content, (part) => {

--- a/tests/spec/templates/schema.json
+++ b/tests/spec/templates/schema.json
@@ -1,0 +1,60 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "description": "A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "name": "Swagger API Team"
+    },
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/api",
+  "schemes": ["http"],
+  "consumes": ["application/json"],
+  "produces": ["application/json"],
+  "paths": {
+    "/pets": {
+      "get": {
+        "description": "Returns all pets from the system that the user has access to",
+        "produces": ["application/json"],
+        "responses": {
+          "200": {
+            "description": "A list of pets.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Pet"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Pet": {
+      "type": "object",
+      "required": ["id", "name"],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        },
+        "multiple": {
+          "type": ["string", "number"]
+        }
+      }
+    }
+  }
+}

--- a/tests/spec/templates/schema.ts
+++ b/tests/spec/templates/schema.ts
@@ -1,0 +1,96 @@
+/* tslint:disable */
+/* eslint-disable */
+
+export interface Pet {
+  id: number;
+  name: string;
+  tag?: string;
+  multiple?: string | number;
+}
+
+export type RequestParams = Omit<RequestInit, "body" | "method"> & {
+  secure?: boolean;
+};
+
+type ApiConfig<SecurityDataType> = {
+  baseUrl?: string;
+  baseApiParams?: RequestParams;
+  securityWorker?: (securityData: SecurityDataType) => RequestParams;
+};
+
+const enum BodyType {
+  Json,
+}
+
+class HttpClient<SecurityDataType> {
+  public baseUrl: string = "http://petstore.swagger.io/api";
+  private securityData: SecurityDataType = null as any;
+  private securityWorker: ApiConfig<SecurityDataType>["securityWorker"] = (() => {}) as any;
+
+  private baseApiParams: RequestParams = {
+    credentials: "same-origin",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    redirect: "follow",
+    referrerPolicy: "no-referrer",
+  };
+
+  constructor({ baseUrl, baseApiParams, securityWorker }: ApiConfig<SecurityDataType> = {}) {
+    this.baseUrl = baseUrl || this.baseUrl;
+    this.baseApiParams = baseApiParams || this.baseApiParams;
+    this.securityWorker = securityWorker || this.securityWorker;
+  }
+
+  public setSecurityData = (data: SecurityDataType) => {
+    this.securityData = data;
+  };
+
+  private bodyFormatters: Record<BodyType, (input: any) => any> = {
+    [BodyType.Json]: JSON.stringify,
+  };
+
+  private mergeRequestOptions(params: RequestParams, securityParams?: RequestParams): RequestParams {
+    return {
+      ...this.baseApiParams,
+      ...params,
+      ...(securityParams || {}),
+      headers: {
+        ...(this.baseApiParams.headers || {}),
+        ...(params.headers || {}),
+        ...((securityParams && securityParams.headers) || {}),
+      },
+    };
+  }
+
+  private safeParseResponse = <T = any, E = any>(response: Response): Promise<T> =>
+    response
+      .json()
+      .then((data) => data)
+      .catch((e) => response.text);
+
+  public request = <T = any, E = any>(
+    path: string,
+    method: string,
+    { secure, ...params }: RequestParams = {},
+    body?: any,
+    bodyType?: BodyType,
+    secureByDefault?: boolean,
+  ): Promise<T> =>
+    fetch(`${this.baseUrl}${path}`, {
+      // @ts-ignore
+      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+      method,
+      body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
+    }).then(async (response) => {
+      const data = await this.safeParseResponse<T, E>(response);
+      if (!response.ok) throw data;
+      return data;
+    });
+}
+
+export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
+  pets = {
+    petsList: (params?: RequestParams) => this.request<Pet[], any>(`/pets`, "GET", params),
+  };
+}

--- a/tests/spec/templates/spec_templates/api.mustache
+++ b/tests/spec/templates/spec_templates/api.mustache
@@ -1,0 +1,6 @@
+/* tslint:disable */
+/* eslint-disable */
+
+{{#modelTypes}}
+export {{typeIdentifier}} {{name}} {{content}}
+{{/modelTypes}}

--- a/tests/spec/templates/spec_templates/client.mustache
+++ b/tests/spec/templates/spec_templates/client.mustache
@@ -1,0 +1,132 @@
+
+export type RequestParams = Omit<RequestInit, "body" | "method"> & {
+  secure?: boolean;
+}
+
+{{#hasQueryRoutes}}
+export type RequestQueryParamsType = Record<string | number, any>;
+{{/hasQueryRoutes}}
+
+type ApiConfig<{{#apiConfig.generic}}{{name}},{{/apiConfig.generic}}> = {
+{{#apiConfig.props}}
+  {{name}}{{#optional}}?{{/optional}}: {{type}},
+{{/apiConfig.props}}
+}
+
+const enum BodyType {
+  Json,
+  {{#hasFormDataRoutes}}
+  FormData,
+  {{/hasFormDataRoutes}}
+}
+
+class HttpClient<{{#apiConfig.generic}}{{name}},{{/apiConfig.generic}}> {
+  public baseUrl: string = "{{apiConfig.baseUrl}}";
+  private securityData: SecurityDataType = (null as any);
+  private securityWorker: ApiConfig<{{#apiConfig.generic}}{{name}},{{/apiConfig.generic}}>["securityWorker"] = (() => {}) as any
+  
+  private baseApiParams: RequestParams = {
+    credentials: 'same-origin',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    redirect: 'follow',
+    referrerPolicy: 'no-referrer',
+  }
+
+  constructor({ {{#apiConfig.props}}{{name}},{{/apiConfig.props}} }: ApiConfig<{{#apiConfig.generic}}{{name}},{{/apiConfig.generic}}> = {}) {
+  {{#apiConfig.props}}
+    this.{{name}} = {{name}} || this.{{name}};
+  {{/apiConfig.props}}
+  }
+
+  public setSecurityData = (data: SecurityDataType) => {
+    this.securityData = data
+  }
+
+  {{#hasQueryRoutes}}
+  private addQueryParam(query: RequestQueryParamsType, key: string) {
+    return encodeURIComponent(key) + "=" + encodeURIComponent(Array.isArray(query[key]) ? query[key].join(",") : query[key])
+  }
+
+  protected addQueryParams(rawQuery?: RequestQueryParamsType): string {
+    const query = rawQuery || {};
+    const keys = Object.keys(query).filter((key) => "undefined" !== typeof query[key]);
+    return keys.length ? `?${keys.map(key =>
+      typeof query[key] === "object" && !Array.isArray(query[key]) ?
+        this.addQueryParams(query[key] as object).substring(1) :
+        this.addQueryParam(query, key)).join("&")
+      }` : "";
+  }
+  {{/hasQueryRoutes}}
+
+  private bodyFormatters: Record<BodyType, (input: any) => any> = {
+    [BodyType.Json]: JSON.stringify,
+    {{#hasFormDataRoutes}}
+    [BodyType.FormData]: (input: any) =>
+      Object.keys(input).reduce((data, key) => {
+        data.append(key, input[key]);
+        return data;
+      }, new FormData()),
+    {{/hasFormDataRoutes}}
+  }
+
+  private mergeRequestOptions(params: RequestParams, securityParams?: RequestParams): RequestParams {
+    return {
+      ...this.baseApiParams,
+      ...params,
+      ...(securityParams || {}),
+      headers: {
+        ...(this.baseApiParams.headers || {}),
+        ...(params.headers || {}),
+        ...((securityParams && securityParams.headers) || {})
+      }
+    }
+  }
+  
+  private safeParseResponse = <T = any, E = any>(response: Response): {{#generateResponses}}TPromise<T, E>{{/generateResponses}}{{^generateResponses}}Promise<T>{{/generateResponses}} =>
+    response.json()
+      .then(data => data)
+      .catch(e => response.text);
+  
+  public request = <T = any, E = any>(
+    path: string,
+    method: string,
+    { secure, ...params }: RequestParams = {},
+    body?: any,
+    bodyType?: BodyType,
+    secureByDefault?: boolean,
+  ): {{#generateResponses}}TPromise<T, E>{{/generateResponses}}{{^generateResponses}}Promise<T>{{/generateResponses}} =>
+    fetch(`${this.baseUrl}${path}`, {
+      // @ts-ignore
+      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+      method,
+      body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
+    }).then(async response => {
+      const data = await this.safeParseResponse<T, E>(response);
+      if (!response.ok) throw data
+      return data
+    })
+}
+
+export class Api<{{#apiConfig.generic}}{{name}}{{#defaultValue}} = {{.}}{{/defaultValue}},{{/apiConfig.generic}}> extends HttpClient<{{#apiConfig.generic}}{{name}},{{/apiConfig.generic}}>{
+{{#routes}}
+
+  {{#outOfModule}}
+
+  {{name}} = ({{#routeArgs}}{{name}}{{#optional}}?{{/optional}}: {{type}}, {{/routeArgs}}) =>
+    this.request<{{returnType}}, {{errorReturnType}}>({{requestMethodContent}})
+  {{/outOfModule}}
+
+  {{#combined}}
+  {{moduleName}} = {
+    {{#routes}}
+
+    {{name}}: ({{#routeArgs}}{{name}}{{#optional}}?{{/optional}}: {{type}}, {{/routeArgs}}) =>
+      this.request<{{returnType}}, {{errorReturnType}}>({{requestMethodContent}}),
+    {{/routes}}
+  }
+  {{/combined}}
+{{/routes}}
+
+}

--- a/tests/spec/templates/spec_templates/route-types.mustache
+++ b/tests/spec/templates/spec_templates/route-types.mustache
@@ -1,0 +1,35 @@
+{{#routes}}
+{{#outOfModule}}
+{{#routes}}
+
+/**
+{{#comments}}
+ * {{.}}
+{{/comments}}
+ */
+export namespace {{pascalName}} {
+  export type RequestQuery = {{queryType}};
+  export type RequestBody = {{bodyType}};
+  export type ResponseBody = {{returnType}};
+}
+{{/routes}}
+{{/outOfModule}}
+
+{{#combined}}
+export namespace {{moduleName}} {
+  {{#routes}}
+
+  /**
+  {{#comments}}
+   * {{.}}
+  {{/comments}}
+   */
+  export namespace {{pascalName}} {
+    export type RequestQuery = {{queryType}};
+    export type RequestBody = {{bodyType}};
+    export type ResponseBody = {{returnType}};
+  }
+  {{/routes}}
+}
+{{/combined}}
+{{/routes}}

--- a/tests/spec/templates/test.js
+++ b/tests/spec/templates/test.js
@@ -1,0 +1,26 @@
+const { generateApi } = require("../../../src");
+const { resolve } = require("path");
+const validateGeneratedModule = require("../../helpers/validateGeneratedModule");
+const createSchemasInfos = require("../../helpers/createSchemaInfos");
+
+const schemas = createSchemasInfos({ absolutePathToSchemas: resolve(__dirname, "./") });
+
+schemas.forEach(({ absolutePath, apiFileName }) => {
+  generateApi({
+    name: apiFileName,
+    input: absolutePath,
+    output: resolve(__dirname, "./"),
+    // because this script was called from package.json folder
+    templates: "./tests/spec/templates/spec_templates",
+  })
+    .then(() => {
+      const diagnostics = validateGeneratedModule({
+        pathToFile: resolve(__dirname, `./${apiFileName}`),
+      });
+      if (diagnostics.length) throw "Failed";
+    })
+    .catch((e) => {
+      console.error("templates option test failed.");
+      throw e;
+    });
+});

--- a/tests/spec/unionEnums/schema.json
+++ b/tests/spec/unionEnums/schema.json
@@ -1,0 +1,30 @@
+{
+  "components": {
+    "examples": {},
+    "headers": {},
+    "parameters": {},
+    "requestBodies": {},
+    "responses": {},
+    "schemas": {
+      "StringEnum": {
+        "enum": ["String1", "String2", "String3", "String4"],
+        "type": "string"
+      },
+      "NumberEnum": {
+        "enum": [1, 2, 3, 4],
+        "type": "number"
+      }
+    },
+    "securitySchemes": {}
+  },
+  "info": {
+    "title": ""
+  },
+  "openapi": "3.0.0",
+  "paths": {},
+  "servers": [
+    {
+      "url": "http://localhost:8080/api/v1"
+    }
+  ]
+}

--- a/tests/spec/unionEnums/schema.ts
+++ b/tests/spec/unionEnums/schema.ts
@@ -1,0 +1,102 @@
+/* tslint:disable */
+/* eslint-disable */
+
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+export type StringEnum = "String1" | "String2" | "String3" | "String4";
+
+export type NumberEnum = 1 | 2 | 3 | 4;
+
+export type RequestParams = Omit<RequestInit, "body" | "method"> & {
+  secure?: boolean;
+};
+
+type ApiConfig<SecurityDataType> = {
+  baseUrl?: string;
+  baseApiParams?: RequestParams;
+  securityWorker?: (securityData: SecurityDataType) => RequestParams;
+};
+
+const enum BodyType {
+  Json,
+}
+
+class HttpClient<SecurityDataType> {
+  public baseUrl: string = "http://localhost:8080/api/v1";
+  private securityData: SecurityDataType = null as any;
+  private securityWorker: ApiConfig<SecurityDataType>["securityWorker"] = (() => {}) as any;
+
+  private baseApiParams: RequestParams = {
+    credentials: "same-origin",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    redirect: "follow",
+    referrerPolicy: "no-referrer",
+  };
+
+  constructor({ baseUrl, baseApiParams, securityWorker }: ApiConfig<SecurityDataType> = {}) {
+    this.baseUrl = baseUrl || this.baseUrl;
+    this.baseApiParams = baseApiParams || this.baseApiParams;
+    this.securityWorker = securityWorker || this.securityWorker;
+  }
+
+  public setSecurityData = (data: SecurityDataType) => {
+    this.securityData = data;
+  };
+
+  private bodyFormatters: Record<BodyType, (input: any) => any> = {
+    [BodyType.Json]: JSON.stringify,
+  };
+
+  private mergeRequestOptions(params: RequestParams, securityParams?: RequestParams): RequestParams {
+    return {
+      ...this.baseApiParams,
+      ...params,
+      ...(securityParams || {}),
+      headers: {
+        ...(this.baseApiParams.headers || {}),
+        ...(params.headers || {}),
+        ...((securityParams && securityParams.headers) || {}),
+      },
+    };
+  }
+
+  private safeParseResponse = <T = any, E = any>(response: Response): Promise<T> =>
+    response
+      .json()
+      .then((data) => data)
+      .catch((e) => response.text);
+
+  public request = <T = any, E = any>(
+    path: string,
+    method: string,
+    { secure, ...params }: RequestParams = {},
+    body?: any,
+    bodyType?: BodyType,
+    secureByDefault?: boolean,
+  ): Promise<T> =>
+    fetch(`${this.baseUrl}${path}`, {
+      // @ts-ignore
+      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+      method,
+      body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
+    }).then(async (response) => {
+      const data = await this.safeParseResponse<T, E>(response);
+      if (!response.ok) throw data;
+      return data;
+    });
+}
+
+/**
+ * @title Api
+ * @baseUrl http://localhost:8080/api/v1
+ */
+export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {}

--- a/tests/spec/unionEnums/test.js
+++ b/tests/spec/unionEnums/test.js
@@ -1,0 +1,25 @@
+const { generateApi } = require("../../../src");
+const { resolve } = require("path");
+const validateGeneratedModule = require("../../helpers/validateGeneratedModule");
+const createSchemasInfos = require("../../helpers/createSchemaInfos");
+
+const schemas = createSchemasInfos({ absolutePathToSchemas: resolve(__dirname, "./") });
+
+schemas.forEach(({ absolutePath, apiFileName }) => {
+  generateApi({
+    name: apiFileName,
+    input: absolutePath,
+    output: resolve(__dirname, "./"),
+    generateUnionEnums: true,
+  })
+    .then(() => {
+      const diagnostics = validateGeneratedModule({
+        pathToFile: resolve(__dirname, `./${apiFileName}`),
+      });
+      if (diagnostics.length) throw "Failed";
+    })
+    .catch((e) => {
+      console.error("unionEnums option test failed.");
+      throw e;
+    });
+});


### PR DESCRIPTION
## Features:  

- `--templates` CLI option. [[feature request]](https://github.com/acacode/swagger-typescript-api/issues/54)  
  Provide custom `mustache` templates folder which allows to generate custom code (models, Api class, routes)  
- `--union-enums` CLI option. [[feature request]](https://github.com/acacode/swagger-typescript-api/issues/58)  
  Allows to generate all enums as union types.  
  For example, schema part:  
  ```
  "StringEnum": {
    "enum": ["String1", "String2", "String3", "String4"],
    "type": "string"
  }
  ```  
  will be converted into:
      ```
export type StringEnum = "String1" | "String2" | "String3" | "String4";
      ```  
  

Closes https://github.com/acacode/swagger-typescript-api/issues/54  
Closes https://github.com/acacode/swagger-typescript-api/issues/58
