### PR TITLE
Complete #69 add spec option to convert schema object

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,29 @@ generateApi({
   .then(sourceFile => fs.writeFile(path, sourceFile))
   .catch(e => console.error(e))
 
+// example with parsed schema  
+generateApi({
+  name: "ApiModule.ts", // name of output typescript file
+  spec: {
+    swagger: "2.0",
+    info: {
+      version: "1.0.0",
+      title: "Swagger Petstore",
+    },
+    host: "petstore.swagger.io",
+    basePath: "/api",
+    schemes: ["http"],
+    consumes: ["application/json"],
+    produces: ["application/json"],
+    paths: {
+      // ...
+    }
+    // ...
+  }
+})
+  .then(sourceFile => fs.writeFile(path, sourceFile))
+  .catch(e => console.error(e))
+
 ```
 
 ## 📄 Mass media  

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
+import { Spec } from "swagger-schema-official";
+
 interface GenerateApiParams {
   /**
    * path to swagger schema
@@ -8,6 +10,11 @@ interface GenerateApiParams {
    * url to swagger schema
    */
   url: string;
+
+  /**
+   * swagger schema JSON
+   */
+  spec: Spec;
 
   /**
    * default 'api.ts'
@@ -47,5 +54,12 @@ interface GenerateApiParams {
   generateResponses?: boolean;
 }
 
-export declare function generateApi(params: Omit<GenerateApiParams, "url">): Promise<string>;
-export declare function generateApi(params: Omit<GenerateApiParams, "input">): Promise<string>;
+export declare function generateApi(
+  params: Omit<GenerateApiParams, "url" | "spec">,
+): Promise<string>;
+export declare function generateApi(
+  params: Omit<GenerateApiParams, "input" | "spec">,
+): Promise<string>;
+export declare function generateApi(
+  params: Omit<GenerateApiParams, "input" | "url">,
+): Promise<string>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1450,6 +1450,12 @@
         "has-flag": "^3.0.0"
       }
     },
+    "swagger-schema-official": {
+      "version": "2.0.0-bab6bed",
+      "resolved": "https://registry.npmjs.org/swagger-schema-official/-/swagger-schema-official-2.0.0-bab6bed.tgz",
+      "integrity": "sha1-cAcEaNbSl3ylI3suUZyn0Gouo/0=",
+      "dev": true
+    },
     "swagger2openapi": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/swagger2openapi/-/swagger2openapi-6.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "cli:debug:json": "node  --nolazy --inspect-brk=9229 index.js -p ./swagger-test-cli.json -n swagger-test-cli.ts --union-enums",
     "cli:debug:yaml": "node  --nolazy --inspect-brk=9229 index.js -p ./swagger-test-cli.yaml -n swagger-test-cli.ts",
     "cli:help": "node index.js -h",
-    "test:all": "npm-run-all generate validate test:routeTypes test:noClient test:defaultAsSuccess test:responses test:templates test:unionEnums --continue-on-error",
+    "test:all": "npm-run-all generate validate test:routeTypes test:noClient test:defaultAsSuccess test:responses test:templates test:unionEnums test:specProperty --continue-on-error",
     "generate": "node tests/generate.js",
     "generate:debug": "node --nolazy --inspect-brk=9229 tests/generate.js",
     "validate": "node tests/validate.js",
@@ -18,7 +18,8 @@
     "test:defaultAsSuccess": "node tests/spec/defaultAsSuccess/test.js",
     "test:templates": "node tests/spec/templates/test.js",
     "test:unionEnums": "node tests/spec/unionEnums/test.js",
-    "test:responses": "node tests/spec/responses/test.js"
+    "test:responses": "node tests/spec/responses/test.js",
+    "test:specProperty": "node tests/spec/specProperty/test.js"
   },
   "author": "acacode",
   "license": "MIT",
@@ -31,6 +32,7 @@
     "husky": "^4.2.3",
     "npm-run-all": "^4.1.5",
     "pretty-quick": "^2.0.1",
+    "swagger-schema-official": "^2.0.0-bab6bed",
     "typescript": "^3.9.3"
   },
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ const { parseSchemas } = require("./schema");
 const { parseRoutes, groupRoutes } = require("./routes");
 const { createApiConfig } = require("./apiConfig");
 const { getModelType } = require("./modelTypes");
-const { getSwaggerObject, fixSwaggerScheme } = require("./swagger");
+const { getSwaggerObject, fixSwaggerScheme, convertSwaggerObject } = require("./swagger");
 const { createComponentsMap, filterComponentsMap } = require("./components");
 const { createFile, pathIsExist } = require("./files");
 const { addToConfig, config } = require("./config");
@@ -34,6 +34,7 @@ module.exports = {
     input,
     output,
     url,
+    spec,
     name,
     templates = resolve(__dirname, config.templates),
     generateResponses = config.generateResponses,
@@ -51,7 +52,7 @@ module.exports = {
         templates,
         generateUnionEnums,
       });
-      getSwaggerObject(input, url)
+      (spec ? convertSwaggerObject(spec) : getSwaggerObject(input, url))
         .then(({ usageSchema, originalSchema }) => {
           const { apiTemplate, clientTemplate, routeTypesTemplate } = getTemplates();
 

--- a/tests/spec/specProperty/schema.json
+++ b/tests/spec/specProperty/schema.json
@@ -1,0 +1,244 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "description": "A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "name": "Swagger API Team",
+      "email": "apiteam@swagger.io",
+      "url": "http://swagger.io"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/api",
+  "schemes": ["http"],
+  "consumes": ["application/json"],
+  "produces": ["application/json"],
+  "paths": {
+    "/pets": {
+      "get": {
+        "description": "Returns all pets from the system that the user has access to\nNam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.\n\nSed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.\n",
+        "operationId": "findPets",
+        "parameters": [
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "tags to filter by",
+            "required": false,
+            "type": "array",
+            "collectionFormat": "csv",
+            "items": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "maximum number of results to return",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Pet"
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Creates a new pet in the store.  Duplicates are allowed",
+        "operationId": "addPet",
+        "parameters": [
+          {
+            "name": "pet",
+            "in": "body",
+            "description": "Pet to add to the store",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NewPet"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/pets/{id}": {
+      "get": {
+        "description": "Returns a user based on a single ID, if the user does not have access to the pet",
+        "operationId": "find pet by id",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of pet to fetch",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "deletes a single pet based on the ID supplied",
+        "operationId": "deletePet",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of pet to delete",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "pet deleted"
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Pet": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/NewPet"
+        },
+        {
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        }
+      ]
+    },
+    "NewPet": {
+      "type": "object",
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "Error": {
+      "type": "object",
+      "required": ["code", "message"],
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    },
+    "Page«TemplateResponseDto»": {
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TemplateResponseDto"
+          }
+        },
+        "empty": {
+          "type": "boolean"
+        },
+        "first": {
+          "type": "boolean"
+        },
+        "last": {
+          "type": "boolean"
+        },
+        "number": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "numberOfElements": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "pageable": {
+          "$ref": "#/definitions/Pageable"
+        },
+        "size": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "sort": {
+          "$ref": "#/definitions/Sort"
+        },
+        "totalElements": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "totalPages": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "title": "Page«TemplateResponseDto»"
+    }
+  }
+}

--- a/tests/spec/specProperty/schema.ts
+++ b/tests/spec/specProperty/schema.ts
@@ -1,0 +1,225 @@
+/* tslint:disable */
+/* eslint-disable */
+
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+export type Pet = NewPet & { id: number };
+
+export interface NewPet {
+  name: string;
+  tag?: string;
+}
+
+export interface Error {
+  code: number;
+  message: string;
+}
+
+export interface PageTemplateResponseDto {
+  content?: any[];
+  empty?: boolean;
+  first?: boolean;
+  last?: boolean;
+  number?: number;
+  numberOfElements?: number;
+  pageable?: any;
+  size?: number;
+  sort?: any;
+  totalElements?: number;
+  totalPages?: number;
+}
+
+export namespace pets {
+  /**
+   * @name findPets
+   * @request GET:/pets
+   * @description Returns all pets from the system that the user has access to Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia. Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.
+   */
+  export namespace FindPets {
+    export type RequestQuery = { tags?: string[]; limit?: number };
+    export type RequestBody = never;
+    export type ResponseBody = Pet[];
+  }
+
+  /**
+   * @name addPet
+   * @request POST:/pets
+   * @description Creates a new pet in the store.  Duplicates are allowed
+   */
+  export namespace AddPet {
+    export type RequestQuery = {};
+    export type RequestBody = NewPet;
+    export type ResponseBody = Pet;
+  }
+
+  /**
+   * @name find pet by id
+   * @request GET:/pets/{id}
+   * @description Returns a user based on a single ID, if the user does not have access to the pet
+   */
+  export namespace FindPetById {
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type ResponseBody = Pet;
+  }
+
+  /**
+   * @name deletePet
+   * @request DELETE:/pets/{id}
+   * @description deletes a single pet based on the ID supplied
+   */
+  export namespace DeletePet {
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type ResponseBody = any;
+  }
+}
+
+export type RequestParams = Omit<RequestInit, "body" | "method"> & {
+  secure?: boolean;
+};
+
+export type RequestQueryParamsType = Record<string | number, any>;
+
+type ApiConfig<SecurityDataType> = {
+  baseUrl?: string;
+  baseApiParams?: RequestParams;
+  securityWorker?: (securityData: SecurityDataType) => RequestParams;
+};
+
+const enum BodyType {
+  Json,
+}
+
+class HttpClient<SecurityDataType> {
+  public baseUrl: string = "http://petstore.swagger.io/api";
+  private securityData: SecurityDataType = null as any;
+  private securityWorker: ApiConfig<SecurityDataType>["securityWorker"] = (() => {}) as any;
+
+  private baseApiParams: RequestParams = {
+    credentials: "same-origin",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    redirect: "follow",
+    referrerPolicy: "no-referrer",
+  };
+
+  constructor({ baseUrl, baseApiParams, securityWorker }: ApiConfig<SecurityDataType> = {}) {
+    this.baseUrl = baseUrl || this.baseUrl;
+    this.baseApiParams = baseApiParams || this.baseApiParams;
+    this.securityWorker = securityWorker || this.securityWorker;
+  }
+
+  public setSecurityData = (data: SecurityDataType) => {
+    this.securityData = data;
+  };
+
+  private addQueryParam(query: RequestQueryParamsType, key: string) {
+    return (
+      encodeURIComponent(key) + "=" + encodeURIComponent(Array.isArray(query[key]) ? query[key].join(",") : query[key])
+    );
+  }
+
+  protected addQueryParams(rawQuery?: RequestQueryParamsType): string {
+    const query = rawQuery || {};
+    const keys = Object.keys(query).filter((key) => "undefined" !== typeof query[key]);
+    return keys.length
+      ? `?${keys
+          .map((key) =>
+            typeof query[key] === "object" && !Array.isArray(query[key])
+              ? this.addQueryParams(query[key] as object).substring(1)
+              : this.addQueryParam(query, key),
+          )
+          .join("&")}`
+      : "";
+  }
+
+  private bodyFormatters: Record<BodyType, (input: any) => any> = {
+    [BodyType.Json]: JSON.stringify,
+  };
+
+  private mergeRequestOptions(params: RequestParams, securityParams?: RequestParams): RequestParams {
+    return {
+      ...this.baseApiParams,
+      ...params,
+      ...(securityParams || {}),
+      headers: {
+        ...(this.baseApiParams.headers || {}),
+        ...(params.headers || {}),
+        ...((securityParams && securityParams.headers) || {}),
+      },
+    };
+  }
+
+  private safeParseResponse = <T = any, E = any>(response: Response): Promise<T> =>
+    response
+      .json()
+      .then((data) => data)
+      .catch((e) => response.text);
+
+  public request = <T = any, E = any>(
+    path: string,
+    method: string,
+    { secure, ...params }: RequestParams = {},
+    body?: any,
+    bodyType?: BodyType,
+    secureByDefault?: boolean,
+  ): Promise<T> =>
+    fetch(`${this.baseUrl}${path}`, {
+      // @ts-ignore
+      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+      method,
+      body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
+    }).then(async (response) => {
+      const data = await this.safeParseResponse<T, E>(response);
+      if (!response.ok) throw data;
+      return data;
+    });
+}
+
+/**
+ * @title Swagger Petstore
+ * @version 1.0.0
+ * @baseUrl http://petstore.swagger.io/api
+ * A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification
+ */
+export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
+  pets = {
+    /**
+     * @name findPets
+     * @request GET:/pets
+     * @description Returns all pets from the system that the user has access to Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia. Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.
+     */
+    findPets: (query?: { tags?: string[]; limit?: number }, params?: RequestParams) =>
+      this.request<Pet[], Error>(`/pets${this.addQueryParams(query)}`, "GET", params),
+
+    /**
+     * @name addPet
+     * @request POST:/pets
+     * @description Creates a new pet in the store.  Duplicates are allowed
+     */
+    addPet: (pet: NewPet, params?: RequestParams) => this.request<Pet, Error>(`/pets`, "POST", params, pet),
+
+    /**
+     * @name find pet by id
+     * @request GET:/pets/{id}
+     * @description Returns a user based on a single ID, if the user does not have access to the pet
+     */
+    findPetById: (id: number, params?: RequestParams) => this.request<Pet, Error>(`/pets/${id}`, "GET", params),
+
+    /**
+     * @name deletePet
+     * @request DELETE:/pets/{id}
+     * @description deletes a single pet based on the ID supplied
+     */
+    deletePet: (id: number, params?: RequestParams) => this.request<any, Error>(`/pets/${id}`, "DELETE", params),
+  };
+}

--- a/tests/spec/specProperty/test.js
+++ b/tests/spec/specProperty/test.js
@@ -1,0 +1,25 @@
+const { generateApi } = require("../../../src");
+const { resolve } = require("path");
+const validateGeneratedModule = require("../../helpers/validateGeneratedModule");
+const createSchemasInfos = require("../../helpers/createSchemaInfos");
+
+const schemas = createSchemasInfos({ absolutePathToSchemas: resolve(__dirname, "./") });
+
+schemas.forEach(({ absolutePath, apiFileName }) => {
+  generateApi({
+    name: apiFileName,
+    spec: require(absolutePath),
+    output: resolve(__dirname, "./"),
+    generateRouteTypes: true,
+  })
+    .then(() => {
+      const diagnostics = validateGeneratedModule({
+        pathToFile: resolve(__dirname, `./${apiFileName}`),
+      });
+      if (diagnostics.length) throw "Failed";
+    })
+    .catch((e) => {
+      console.error("routeTypes option test failed.");
+      throw e;
+    });
+});


### PR DESCRIPTION
Add a `spec` option to help converting schema object. Really require this as I am building a tool, which do not expect to read schema from a public url nor local path.