### PR TITLE
Add abort signal into fetch

### DIFF
--- a/src/templates/client.mustache
+++ b/src/templates/client.mustache
@@ -105,12 +105,14 @@ class HttpClient<{{#apiConfig.generic}}{{name}},{{/apiConfig.generic}}> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
+    signal? : AbortSignal,
   ): {{#generateResponses}}TPromise<T, E>{{/generateResponses}}{{^generateResponses}}Promise<T>{{/generateResponses}} =>
     fetch(`${this.baseUrl}${path}`, {
       // @ts-ignore
       ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
       method,
       body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
+      signal,
     }).then(async response => {
       const data = await this.safeParseResponse<T, E>(response);
       if (!response.ok) throw data


### PR DESCRIPTION
Allow aborting the request, add the `signal` property to the `fetch` configuration.