### PR TITLE
Release 2.0.0

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,4 @@
 tests/**/*.ts
+tests/**/schema.js
+tests/**/*.d.js
 *.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Fixes:
 - Remove const enum from default template #73  
 - enums with spaces throw an error #71  
 
+# 1.11.1  
+
+Fixes:  
+- handling `x-omitempty` property for definition properties ([#68 issue](https://github.com/acacode/swagger-typescript-api/issues/68))  
 
 # 1.11.0  
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # next release  
 
+Features:
+- `--js` CLI option. [[feature request]](https://github.com/acacode/swagger-typescript-api/issues/79)  
+
 
 # 1.12.0   
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,6 @@ Fixes:
 - Remove const enum from default template #73  
 - enums with spaces throw an error #71  
 
-# 1.11.1  
-
-Fixes:  
-- handling `x-omitempty` property for definition properties ([#68 issue](https://github.com/acacode/swagger-typescript-api/issues/68))  
 
 # 1.11.0  
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 Features:
 - `--js` CLI option. [[feature request]](https://github.com/acacode/swagger-typescript-api/issues/79)  
 
+BREAKING_CHANGES:  
+- Requests returns `Promise<HttpResponse<Data, Error>>` type.  
+  `HttpResponse` it is [Fetch.Response](https://developer.mozilla.org/en-US/docs/Web/API/Response) wrapper with fields `data` and `error`
+  Example:  
+  ```ts
+    const api = new Api()
+    
+    //
+    const response: HttpResponse<Data, Error> = await api.fruits.getAll()
+
+    response.data // Data (can be null if response.ok is false)
+    response.error // Error (can be null if response.ok is true)
+  ```
+
 
 # 1.12.0   
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ BREAKING_CHANGES:
 
     response.data // Data (can be null if response.ok is false)
     response.error // Error (can be null if response.ok is true)
-  ```
+  ```  
+- Breaking changes in the `client.mustache` template. Needs to update local custom templates.  
 
 
 # 1.12.0   

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Options:
   --union-enums             generate all "enum" types as union types (T1 | T2 | TN) (default: false)
   --route-types             generate type definitions for API routes (default: false)
   --no-client               do not generate an API class
+  --js                      generate js api module with declaration file (default: false)
   -h, --help                output usage information
 ```
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -50,6 +50,8 @@ interface GenerateApiParams {
    * also add typings for bad responses
    */
   generateResponses?: boolean;
+
+  toJS?: boolean;
 }
 
 export declare function generateApi(

--- a/index.d.ts
+++ b/index.d.ts
@@ -51,6 +51,9 @@ interface GenerateApiParams {
    */
   generateResponses?: boolean;
 
+  /**
+   * generate js api module with declaration file (default: false)
+   */
   toJS?: boolean;
 }
 

--- a/index.js
+++ b/index.js
@@ -32,11 +32,23 @@ program
   )
   .option("--union-enums", 'generate all "enum" types as union types (T1 | T2 | TN)', false)
   .option("--route-types", "generate type definitions for API routes", false)
-  .option("--no-client", "do not generate an API class", false);
+  .option("--no-client", "do not generate an API class", false)
+  .option("--js", "generate js api module with declaration file", false);
 
 program.parse(process.argv);
 
-const { path, output, name, templates, unionEnums, routeTypes, client, defaultAsSuccess, responses } = program;
+const {
+  path,
+  output,
+  name,
+  templates,
+  unionEnums,
+  routeTypes,
+  client,
+  defaultAsSuccess,
+  responses,
+  js,
+} = program;
 
 generateApi({
   name,
@@ -49,4 +61,5 @@ generateApi({
   input: resolve(process.cwd(), path),
   output: resolve(process.cwd(), output || "."),
   templates: resolve(templates ? process.cwd() : __dirname, templates || "./src/templates"),
+  toJS: !!js,
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1488,8 +1488,7 @@
     "typescript": {
       "version": "3.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.3.tgz",
-      "integrity": "sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==",
-      "dev": true
+      "integrity": "sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1486,9 +1486,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.3.tgz",
-      "integrity": "sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ=="
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
+      "integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "cli:debug:json": "node --nolazy index.js -p ./swagger-test-cli.json -n swagger-test-cli.ts --union-enums",
     "cli:debug:yaml": "node --nolazy index.js -p ./swagger-test-cli.yaml -n swagger-test-cli.ts",
     "cli:help": "node index.js -h",
-    "test:all": "npm-run-all generate validate test:routeTypes test:noClient test:defaultAsSuccess test:responses test:templates test:unionEnums test:specProperty --continue-on-error",
+    "test:all": "npm-run-all generate validate test:routeTypes test:noClient test:defaultAsSuccess test:responses test:templates test:unionEnums test:specProperty test:js --continue-on-error",
     "generate": "node tests/generate.js",
     "generate:debug": "node --nolazy tests/generate.js",
     "validate": "node tests/validate.js",
@@ -19,7 +19,8 @@
     "test:templates": "node tests/spec/templates/test.js",
     "test:unionEnums": "node tests/spec/unionEnums/test.js",
     "test:responses": "node tests/spec/responses/test.js",
-    "test:specProperty": "node tests/spec/specProperty/test.js"
+    "test:specProperty": "node tests/spec/specProperty/test.js",
+    "test:js": "node tests/spec/js/test.js"
   },
   "author": "acacode",
   "license": "MIT",
@@ -31,8 +32,7 @@
     "@types/prettier": "^2.0.1",
     "husky": "^4.2.3",
     "npm-run-all": "^4.1.5",
-    "pretty-quick": "^2.0.1",
-    "typescript": "^3.9.3"
+    "pretty-quick": "^2.0.1"
   },
   "dependencies": {
     "@types/swagger-schema-official": "2.0.21",
@@ -43,7 +43,8 @@
     "mustache": "^4.0.1",
     "prettier": "^2.0.5",
     "swagger-schema-official": "2.0.0-bab6bed",
-    "swagger2openapi": "^6.0.3"
+    "swagger2openapi": "^6.0.3",
+    "typescript": "^3.9.3"
   },
   "bin": {
     "swagger-typescript-api": "index.js",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "prettier": "^2.0.5",
     "swagger-schema-official": "2.0.0-bab6bed",
     "swagger2openapi": "^6.0.3",
-    "typescript": "^3.9.3"
+    "typescript": "^4.0.2"
   },
   "bin": {
     "swagger-typescript-api": "index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -22,12 +22,13 @@ const { getTemplates } = require("./templates");
 
 mustache.escape = (value) => value;
 
-const prettierConfig = {
-  printWidth: 120,
-  tabWidth: 2,
-  trailingComma: "all",
-  parser: "typescript",
-};
+const prettierFormat = (content) =>
+  prettier.format(content, {
+    printWidth: 120,
+    tabWidth: 2,
+    trailingComma: "all",
+    parser: "typescript",
+  });
 
 module.exports = {
   generateApi: ({
@@ -88,33 +89,35 @@ module.exports = {
             routes: groupRoutes(routes),
           };
 
-          let sourceFile = prettier.format(
-            [
-              mustache.render(apiTemplate, configuration),
-              generateRouteTypes ? mustache.render(routeTypesTemplate, configuration) : "",
-              generateClient ? mustache.render(clientTemplate, configuration) : "",
-            ].join(""),
-            prettierConfig,
-          );
+          let sourceFileContent = [
+            mustache.render(apiTemplate, configuration),
+            generateRouteTypes ? mustache.render(routeTypesTemplate, configuration) : "",
+            generateClient ? mustache.render(clientTemplate, configuration) : "",
+          ].join("");
 
           if (toJS) {
             const {
               sourceFile: sourceJsFile,
               declarationFile,
-            } = require("./translators/JavaScript").translate(name, sourceFile);
+            } = require("./translators/JavaScript").translate(name, sourceFileContent);
+
+            sourceJsFile.content = prettierFormat(sourceJsFile.content);
+            declarationFile.content = prettierFormat(declarationFile.content);
 
             if (pathIsExist(output)) {
               createFile(output, sourceJsFile.name, sourceJsFile.content);
               createFile(output, declarationFile.name, declarationFile.content);
-              console.log(`✔️  your JavaScript api file created in "${output}"`);
+              console.log(`✔️  your javascript api file created in "${output}"`);
             }
             resolve(sourceJsFile.content);
           } else {
+            sourceFileContent = prettierFormat(sourceFileContent);
+
             if (pathIsExist(output)) {
-              createFile(output, name, require("./translators/JavaScript").translate(sourceFile));
+              createFile(output, name, sourceFileContent);
               console.log(`✔️  your typescript api file created in "${output}"`);
             }
-            resolve(sourceFile);
+            resolve(sourceFileContent);
           }
         })
         .catch((e) => {

--- a/src/routes.js
+++ b/src/routes.js
@@ -191,7 +191,7 @@ const createRequestsMap = (requestInfoByMethodsMap) => {
   );
 };
 
-const parseRoutes = ({ paths }, parsedSchemas) =>
+const parseRoutes = ({ paths, security: globalSecurity }, parsedSchemas) =>
   _.entries(paths).reduce((routes, [route, requestInfoByMethodsMap]) => {
     if (route.startsWith("x-")) return routes;
 
@@ -210,7 +210,10 @@ const parseRoutes = ({ paths }, parsedSchemas) =>
           tags,
           responses,
         } = requestInfo;
-        const hasSecurity = !!(security && security.length);
+        const hasSecurity = !!(
+          (globalSecurity && globalSecurity.length) ||
+          (security && security.length)
+        );
 
         const formDataParams = getRouteParams(parameters, "formData");
         const pathParams = getRouteParams(parameters, "path");

--- a/src/templates/api.mustache
+++ b/src/templates/api.mustache
@@ -1,6 +1,5 @@
 /* tslint:disable */
 /* eslint-disable */
-
 /*
 * ---------------------------------------------------------------
 * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/src/templates/client.mustache
+++ b/src/templates/client.mustache
@@ -7,7 +7,7 @@ export type RequestParams = Omit<RequestInit, "body" | "method"> & {
 export type RequestQueryParamsType = Record<string | number, any>;
 {{/hasQueryRoutes}}
 
-type ApiConfig<{{#apiConfig.generic}}{{name}},{{/apiConfig.generic}}> = {
+interface ApiConfig<{{#apiConfig.generic}}{{name}},{{/apiConfig.generic}}> {
 {{#apiConfig.props}}
   {{name}}{{#optional}}?{{/optional}}: {{type}},
 {{/apiConfig.props}}
@@ -21,6 +21,10 @@ type TPromise<ResolveType, RejectType = any> = Omit<Promise<ResolveType>, "then"
 }
 {{/generateResponses}}
 
+interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+  data: D | null;
+  error: E | null;
+}
 
 enum BodyType {
   Json,
@@ -93,10 +97,26 @@ class HttpClient<{{#apiConfig.generic}}{{name}},{{/apiConfig.generic}}> {
     }
   }
   
-  private safeParseResponse = <T = any, E = any>(response: Response): {{#generateResponses}}TPromise<T, E>{{/generateResponses}}{{^generateResponses}}Promise<T>{{/generateResponses}} =>
-    response.json()
-      .then(data => data)
-      .catch(e => response.text);
+  private safeParseResponse = <T = any, E = any>(response: Response): Promise<HttpResponse<T, E>> => {
+    const r = response.clone() as HttpResponse<T, E>;
+    r.data = null;
+    r.error = null;
+
+    return response
+      .json()
+      .then((data) => {
+        if (r.ok) {
+          r.data = data;
+        } else {
+          r.error = data;
+        }
+        return r;
+      })
+      .catch((e) => {
+        r.error = e;
+        return r;
+      });
+  }
   
   public request = <T = any, E = any>(
     path: string,
@@ -105,7 +125,7 @@ class HttpClient<{{#apiConfig.generic}}{{name}},{{/apiConfig.generic}}> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): {{#generateResponses}}TPromise<T, E>{{/generateResponses}}{{^generateResponses}}Promise<T>{{/generateResponses}} =>
+  ): {{#generateResponses}}TPromise<HttpResponse<T, E>>{{/generateResponses}}{{^generateResponses}}Promise<HttpResponse<T>>{{/generateResponses}} =>
     fetch(`${this.baseUrl}${path}`, {
       // @ts-ignore
       ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),

--- a/src/templates/client.mustache
+++ b/src/templates/client.mustache
@@ -8,9 +8,9 @@ export type RequestQueryParamsType = Record<string | number, any>;
 {{/hasQueryRoutes}}
 
 interface ApiConfig<{{#apiConfig.generic}}{{name}},{{/apiConfig.generic}}> {
-{{#apiConfig.props}}
-  {{name}}{{#optional}}?{{/optional}}: {{type}},
-{{/apiConfig.props}}
+  baseUrl?: string;
+  baseApiParams?: RequestParams;
+  securityWorker?: (securityData: SecurityDataType) => RequestParams;
 }
 
 {{#generateResponses}}
@@ -36,7 +36,7 @@ enum BodyType {
 class HttpClient<{{#apiConfig.generic}}{{name}},{{/apiConfig.generic}}> {
   public baseUrl: string = "{{apiConfig.baseUrl}}";
   private securityData: SecurityDataType = (null as any);
-  private securityWorker: ApiConfig<{{#apiConfig.generic}}{{name}},{{/apiConfig.generic}}>["securityWorker"] = (() => {}) as any
+  private securityWorker: null | ApiConfig<{{#apiConfig.generic}}{{name}},{{/apiConfig.generic}}>["securityWorker"] = null;
   
   private baseApiParams: RequestParams = {
     credentials: 'same-origin',
@@ -47,10 +47,8 @@ class HttpClient<{{#apiConfig.generic}}{{name}},{{/apiConfig.generic}}> {
     referrerPolicy: 'no-referrer',
   }
 
-  constructor({ {{#apiConfig.props}}{{name}},{{/apiConfig.props}} }: ApiConfig<{{#apiConfig.generic}}{{name}},{{/apiConfig.generic}}> = {}) {
-  {{#apiConfig.props}}
-    this.{{name}} = {{name}} || this.{{name}};
-  {{/apiConfig.props}}
+  constructor(apiConfig: ApiConfig<{{#apiConfig.generic}}{{name}},{{/apiConfig.generic}}> = {}) {
+    Object.assign(this, apiConfig);
   }
 
   public setSecurityData = (data: SecurityDataType) => {
@@ -125,17 +123,21 @@ class HttpClient<{{#apiConfig.generic}}{{name}},{{/apiConfig.generic}}> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): {{#generateResponses}}TPromise<HttpResponse<T, E>>{{/generateResponses}}{{^generateResponses}}Promise<HttpResponse<T>>{{/generateResponses}} =>
-    fetch(`${this.baseUrl}${path}`, {
-      // @ts-ignore
-      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+  ): {{#generateResponses}}TPromise<HttpResponse<T, E>>{{/generateResponses}}{{^generateResponses}}Promise<HttpResponse<T>>{{/generateResponses}} => {
+    const requestUrl = `${this.baseUrl}${path}`;
+    const secureOptions = (secureByDefault || secure) && this.securityWorker ? this.securityWorker(this.securityData) : {};
+    const requestOptions = {
+      ...this.mergeRequestOptions(params, secureOptions),
       method,
       body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
-    }).then(async response => {
+    }
+
+    return fetch(requestUrl, requestOptions).then(async response => {
       const data = await this.safeParseResponse<T, E>(response);
       if (!response.ok) throw data
       return data
     })
+  }
 }
 
 {{#apiConfig.hasDescription}}

--- a/src/translators/JavaScript.js
+++ b/src/translators/JavaScript.js
@@ -1,0 +1,58 @@
+const ts = require("typescript");
+
+function translate(fileName, content, options) {
+  const output = {};
+  const host = ts.createCompilerHost(options);
+  const fileNames = [fileName];
+  const originalSourceFileGet = host.getSourceFile.bind(host);
+  host.getSourceFile = (sourceFileName, languageVersion, onError, shouldCreateNewSourceFile) => {
+    if (sourceFileName !== fileName)
+      return originalSourceFileGet(
+        sourceFileName,
+        languageVersion,
+        onError,
+        shouldCreateNewSourceFile,
+      );
+
+    return ts.createLanguageServiceSourceFile(
+      sourceFileName,
+      ts.ScriptSnapshot.fromString(content),
+      ts.ScriptTarget.ESNext,
+      ts.version,
+      false,
+      ts.ScriptKind.TS,
+    );
+  };
+
+  host.writeFile = (fileName, contents) => {
+    output[fileName] = contents;
+  };
+
+  ts.createProgram(fileNames, options, host).emit();
+
+  return output;
+}
+
+module.exports = {
+  translate: (fileName, sourceTypeScript) => {
+    const translated = translate(fileName, sourceTypeScript, {
+      target: ts.ScriptTarget.Latest,
+      declaration: true,
+      removeComments: false,
+    });
+
+    const sourceFileName = fileName.replace(".ts", ".js");
+    const declarationFileName = fileName.replace(".ts", ".d.ts");
+
+    return {
+      sourceFile: {
+        name: sourceFileName,
+        content: translated[sourceFileName],
+      },
+      declarationFile: {
+        name: declarationFileName,
+        content: translated[declarationFileName],
+      },
+    };
+  },
+};

--- a/src/translators/JavaScript.js
+++ b/src/translators/JavaScript.js
@@ -2,7 +2,7 @@ const ts = require("typescript");
 
 function translate(fileName, content, options) {
   const output = {};
-  const host = ts.createCompilerHost(options);
+  const host = ts.createCompilerHost(options, true);
   const fileNames = [fileName];
   const originalSourceFileGet = host.getSourceFile.bind(host);
   host.getSourceFile = (sourceFileName, languageVersion, onError, shouldCreateNewSourceFile) => {
@@ -14,13 +14,12 @@ function translate(fileName, content, options) {
         shouldCreateNewSourceFile,
       );
 
-    return ts.createLanguageServiceSourceFile(
+    return ts.createSourceFile(
       sourceFileName,
-      ts.ScriptSnapshot.fromString(content),
-      ts.ScriptTarget.ESNext,
-      ts.version,
-      false,
-      ts.ScriptKind.TS,
+      content,
+      languageVersion,
+      true,
+      ts.ScriptKind.External,
     );
   };
 
@@ -36,13 +35,22 @@ function translate(fileName, content, options) {
 module.exports = {
   translate: (fileName, sourceTypeScript) => {
     const translated = translate(fileName, sourceTypeScript, {
-      target: ts.ScriptTarget.Latest,
+      module: "ESNext",
+      noImplicitReturns: true,
+      alwaysStrict: true,
+      target: ts.ScriptTarget.ESNext,
       declaration: true,
+      noImplicitAny: false,
+      sourceMap: false,
       removeComments: false,
+      disableSizeLimit: true,
+      esModuleInterop: true,
+      emitDecoratorMetadata: true,
+      skipLibCheck: true,
     });
 
-    const sourceFileName = fileName.replace(".ts", ".js");
-    const declarationFileName = fileName.replace(".ts", ".d.ts");
+    const sourceFileName = fileName.replace(ts.Extension.Ts, ts.Extension.Js);
+    const declarationFileName = fileName.replace(ts.Extension.Ts, ts.Extension.Dts);
 
     return {
       sourceFile: {

--- a/tests/generated/v2.0/adafruit.ts
+++ b/tests/generated/v2.0/adafruit.ts
@@ -1,6 +1,5 @@
 /* tslint:disable */
 /* eslint-disable */
-
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/generated/v2.0/adafruit.ts
+++ b/tests/generated/v2.0/adafruit.ts
@@ -393,8 +393,9 @@ export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
      * @name currentUser
      * @summary Get information about the current user
      * @request GET:/user
+     * @secure
      */
-    currentUser: (params?: RequestParams) => this.request<User, any>(`/user`, "GET", params),
+    currentUser: (params?: RequestParams) => this.request<User, any>(`/user`, "GET", params, null, BodyType.Json, true),
   };
   webhooks = {
     /**
@@ -402,19 +403,21 @@ export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
      * @name createWebhookFeedData
      * @summary Send data to a feed via webhook URL.
      * @request POST:/webhooks/feed/:token
+     * @secure
      */
     createWebhookFeedData: (payload: { value?: string }, params?: RequestParams) =>
-      this.request<Data, any>(`/webhooks/feed/:token`, "POST", params, payload),
+      this.request<Data, any>(`/webhooks/feed/:token`, "POST", params, payload, BodyType.Json, true),
 
     /**
      * @tags Webhooks, Data
      * @name createRawWebhookFeedData
      * @summary Send arbitrary data to a feed via webhook URL.
      * @request POST:/webhooks/feed/:token/raw
+     * @secure
      * @description The raw data webhook receiver accepts POST requests and stores the raw request body on your feed. This is useful when you don't have control of the webhook sender. If feed history is turned on, payloads will be truncated at 1024 bytes. If feed history is turned off, payloads will be truncated at 100KB.
      */
     createRawWebhookFeedData: (params?: RequestParams) =>
-      this.request<Data, any>(`/webhooks/feed/:token/raw`, "POST", params),
+      this.request<Data, any>(`/webhooks/feed/:token/raw`, "POST", params, null, BodyType.Json, true),
   };
   username = {
     /**
@@ -422,29 +425,40 @@ export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
      * @name destroyActivities
      * @summary All activities for current user
      * @request DELETE:/{username}/activities
+     * @secure
      * @description Delete all your activities.
      */
     destroyActivities: (username: string, params?: RequestParams) =>
-      this.request<any, any>(`/${username}/activities`, "DELETE", params),
+      this.request<any, any>(`/${username}/activities`, "DELETE", params, null, BodyType.Json, true),
 
     /**
      * @tags Activities
      * @name allActivities
      * @summary All activities for current user
      * @request GET:/{username}/activities
+     * @secure
      * @description The Activities endpoint returns information about the user's activities.
      */
     allActivities: (
       username: string,
       query?: { start_time?: string; end_time?: string; limit?: number },
       params?: RequestParams,
-    ) => this.request<Activity[], any>(`/${username}/activities${this.addQueryParams(query)}`, "GET", params),
+    ) =>
+      this.request<Activity[], any>(
+        `/${username}/activities${this.addQueryParams(query)}`,
+        "GET",
+        params,
+        null,
+        BodyType.Json,
+        true,
+      ),
 
     /**
      * @tags Activities
      * @name getActivity
      * @summary Get activities by type for current user
      * @request GET:/{username}/activities/{type}
+     * @secure
      * @description The Activities endpoint returns information about the user's activities.
      */
     getActivity: (
@@ -452,69 +466,112 @@ export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
       type: string,
       query?: { start_time?: string; end_time?: string; limit?: number },
       params?: RequestParams,
-    ) => this.request<Activity[], any>(`/${username}/activities/${type}${this.addQueryParams(query)}`, "GET", params),
+    ) =>
+      this.request<Activity[], any>(
+        `/${username}/activities/${type}${this.addQueryParams(query)}`,
+        "GET",
+        params,
+        null,
+        BodyType.Json,
+        true,
+      ),
 
     /**
      * @tags Dashboards
      * @name allDashboards
      * @summary All dashboards for current user
      * @request GET:/{username}/dashboards
+     * @secure
      * @description The Dashboards endpoint returns information about the user's dashboards.
      */
     allDashboards: (username: string, params?: RequestParams) =>
-      this.request<Dashboard[], any>(`/${username}/dashboards`, "GET", params),
+      this.request<Dashboard[], any>(`/${username}/dashboards`, "GET", params, null, BodyType.Json, true),
 
     /**
      * @tags Dashboards
      * @name createDashboard
      * @summary Create a new Dashboard
      * @request POST:/{username}/dashboards
+     * @secure
      */
     createDashboard: (username: string, dashboard: Dashboard, params?: RequestParams) =>
-      this.request<Dashboard, any>(`/${username}/dashboards`, "POST", params, dashboard),
+      this.request<Dashboard, any>(`/${username}/dashboards`, "POST", params, dashboard, BodyType.Json, true),
 
     /**
      * @tags Blocks
      * @name allBlocks
      * @summary All blocks for current user
      * @request GET:/{username}/dashboards/{dashboard_id}/blocks
+     * @secure
      * @description The Blocks endpoint returns information about the user's blocks.
      */
     allBlocks: (username: string, dashboard_id: string, params?: RequestParams) =>
-      this.request<Block[], any>(`/${username}/dashboards/${dashboard_id}/blocks`, "GET", params),
+      this.request<Block[], any>(
+        `/${username}/dashboards/${dashboard_id}/blocks`,
+        "GET",
+        params,
+        null,
+        BodyType.Json,
+        true,
+      ),
 
     /**
      * @tags Blocks
      * @name createBlock
      * @summary Create a new Block
      * @request POST:/{username}/dashboards/{dashboard_id}/blocks
+     * @secure
      */
     createBlock: (username: string, dashboard_id: string, block: Block, params?: RequestParams) =>
-      this.request<Block, any>(`/${username}/dashboards/${dashboard_id}/blocks`, "POST", params, block),
+      this.request<Block, any>(
+        `/${username}/dashboards/${dashboard_id}/blocks`,
+        "POST",
+        params,
+        block,
+        BodyType.Json,
+        true,
+      ),
 
     /**
      * @tags Blocks
      * @name destroyBlock
      * @summary Delete an existing Block
      * @request DELETE:/{username}/dashboards/{dashboard_id}/blocks/{id}
+     * @secure
      */
     destroyBlock: (username: string, dashboard_id: string, id: string, params?: RequestParams) =>
-      this.request<string, any>(`/${username}/dashboards/${dashboard_id}/blocks/${id}`, "DELETE", params),
+      this.request<string, any>(
+        `/${username}/dashboards/${dashboard_id}/blocks/${id}`,
+        "DELETE",
+        params,
+        null,
+        BodyType.Json,
+        true,
+      ),
 
     /**
      * @tags Blocks
      * @name getBlock
      * @summary Returns Block based on ID
      * @request GET:/{username}/dashboards/{dashboard_id}/blocks/{id}
+     * @secure
      */
     getBlock: (username: string, dashboard_id: string, id: string, params?: RequestParams) =>
-      this.request<Block, any>(`/${username}/dashboards/${dashboard_id}/blocks/${id}`, "GET", params),
+      this.request<Block, any>(
+        `/${username}/dashboards/${dashboard_id}/blocks/${id}`,
+        "GET",
+        params,
+        null,
+        BodyType.Json,
+        true,
+      ),
 
     /**
      * @tags Blocks
      * @name updateBlock
      * @summary Update properties of an existing Block
      * @request PATCH:/{username}/dashboards/{dashboard_id}/blocks/{id}
+     * @secure
      */
     updateBlock: (
       username: string,
@@ -534,13 +591,22 @@ export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
         visual_type?: string;
       },
       params?: RequestParams,
-    ) => this.request<Block, any>(`/${username}/dashboards/${dashboard_id}/blocks/${id}`, "PATCH", params, block),
+    ) =>
+      this.request<Block, any>(
+        `/${username}/dashboards/${dashboard_id}/blocks/${id}`,
+        "PATCH",
+        params,
+        block,
+        BodyType.Json,
+        true,
+      ),
 
     /**
      * @tags Blocks
      * @name replaceBlock
      * @summary Replace an existing Block
      * @request PUT:/{username}/dashboards/{dashboard_id}/blocks/{id}
+     * @secure
      */
     replaceBlock: (
       username: string,
@@ -560,121 +626,147 @@ export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
         visual_type?: string;
       },
       params?: RequestParams,
-    ) => this.request<Block, any>(`/${username}/dashboards/${dashboard_id}/blocks/${id}`, "PUT", params, block),
+    ) =>
+      this.request<Block, any>(
+        `/${username}/dashboards/${dashboard_id}/blocks/${id}`,
+        "PUT",
+        params,
+        block,
+        BodyType.Json,
+        true,
+      ),
 
     /**
      * @tags Dashboards
      * @name destroyDashboard
      * @summary Delete an existing Dashboard
      * @request DELETE:/{username}/dashboards/{id}
+     * @secure
      */
     destroyDashboard: (username: string, id: string, params?: RequestParams) =>
-      this.request<string, any>(`/${username}/dashboards/${id}`, "DELETE", params),
+      this.request<string, any>(`/${username}/dashboards/${id}`, "DELETE", params, null, BodyType.Json, true),
 
     /**
      * @tags Dashboards
      * @name getDashboard
      * @summary Returns Dashboard based on ID
      * @request GET:/{username}/dashboards/{id}
+     * @secure
      */
     getDashboard: (username: string, id: string, params?: RequestParams) =>
-      this.request<Dashboard, any>(`/${username}/dashboards/${id}`, "GET", params),
+      this.request<Dashboard, any>(`/${username}/dashboards/${id}`, "GET", params, null, BodyType.Json, true),
 
     /**
      * @tags Dashboards
      * @name updateDashboard
      * @summary Update properties of an existing Dashboard
      * @request PATCH:/{username}/dashboards/{id}
+     * @secure
      */
     updateDashboard: (
       username: string,
       id: string,
       dashboard: { description?: string; key?: string; name?: string },
       params?: RequestParams,
-    ) => this.request<Dashboard, any>(`/${username}/dashboards/${id}`, "PATCH", params, dashboard),
+    ) => this.request<Dashboard, any>(`/${username}/dashboards/${id}`, "PATCH", params, dashboard, BodyType.Json, true),
 
     /**
      * @tags Dashboards
      * @name replaceDashboard
      * @summary Replace an existing Dashboard
      * @request PUT:/{username}/dashboards/{id}
+     * @secure
      */
     replaceDashboard: (
       username: string,
       id: string,
       dashboard: { description?: string; key?: string; name?: string },
       params?: RequestParams,
-    ) => this.request<Dashboard, any>(`/${username}/dashboards/${id}`, "PUT", params, dashboard),
+    ) => this.request<Dashboard, any>(`/${username}/dashboards/${id}`, "PUT", params, dashboard, BodyType.Json, true),
 
     /**
      * @tags Feeds
      * @name allFeeds
      * @summary All feeds for current user
      * @request GET:/{username}/feeds
+     * @secure
      * @description The Feeds endpoint returns information about the user's feeds. The response includes the latest value of each feed, and other metadata about each feed.
      */
     allFeeds: (username: string, params?: RequestParams) =>
-      this.request<Feed[], any>(`/${username}/feeds`, "GET", params),
+      this.request<Feed[], any>(`/${username}/feeds`, "GET", params, null, BodyType.Json, true),
 
     /**
      * @tags Feeds
      * @name createFeed
      * @summary Create a new Feed
      * @request POST:/{username}/feeds
+     * @secure
      */
     createFeed: (username: string, feed: Feed, query?: { group_key?: string }, params?: RequestParams) =>
-      this.request<Feed, any>(`/${username}/feeds${this.addQueryParams(query)}`, "POST", params, feed),
+      this.request<Feed, any>(
+        `/${username}/feeds${this.addQueryParams(query)}`,
+        "POST",
+        params,
+        feed,
+        BodyType.Json,
+        true,
+      ),
 
     /**
      * @tags Feeds
      * @name destroyFeed
      * @summary Delete an existing Feed
      * @request DELETE:/{username}/feeds/{feed_key}
+     * @secure
      */
     destroyFeed: (username: string, feed_key: string, params?: RequestParams) =>
-      this.request<any, any>(`/${username}/feeds/${feed_key}`, "DELETE", params),
+      this.request<any, any>(`/${username}/feeds/${feed_key}`, "DELETE", params, null, BodyType.Json, true),
 
     /**
      * @tags Feeds
      * @name getFeed
      * @summary Get feed by feed key
      * @request GET:/{username}/feeds/{feed_key}
+     * @secure
      * @description Returns feed based on the feed key
      */
     getFeed: (username: string, feed_key: string, params?: RequestParams) =>
-      this.request<Feed, any>(`/${username}/feeds/${feed_key}`, "GET", params),
+      this.request<Feed, any>(`/${username}/feeds/${feed_key}`, "GET", params, null, BodyType.Json, true),
 
     /**
      * @tags Feeds
      * @name updateFeed
      * @summary Update properties of an existing Feed
      * @request PATCH:/{username}/feeds/{feed_key}
+     * @secure
      */
     updateFeed: (
       username: string,
       feed_key: string,
       feed: { description?: string; key?: string; license?: string; name?: string },
       params?: RequestParams,
-    ) => this.request<Feed, any>(`/${username}/feeds/${feed_key}`, "PATCH", params, feed),
+    ) => this.request<Feed, any>(`/${username}/feeds/${feed_key}`, "PATCH", params, feed, BodyType.Json, true),
 
     /**
      * @tags Feeds
      * @name replaceFeed
      * @summary Replace an existing Feed
      * @request PUT:/{username}/feeds/{feed_key}
+     * @secure
      */
     replaceFeed: (
       username: string,
       feed_key: string,
       feed: { description?: string; key?: string; license?: string; name?: string },
       params?: RequestParams,
-    ) => this.request<Feed, any>(`/${username}/feeds/${feed_key}`, "PUT", params, feed),
+    ) => this.request<Feed, any>(`/${username}/feeds/${feed_key}`, "PUT", params, feed, BodyType.Json, true),
 
     /**
      * @tags Data
      * @name allData
      * @summary Get all data for the given feed
      * @request GET:/{username}/feeds/{feed_key}/data
+     * @secure
      */
     allData: (
       username: string,
@@ -686,6 +778,9 @@ export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
         `/${username}/feeds/${feed_key}/data${this.addQueryParams(query)}`,
         "GET",
         params,
+        null,
+        BodyType.Json,
+        true,
       ),
 
     /**
@@ -693,6 +788,7 @@ export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
      * @name createData
      * @summary Create new Data
      * @request POST:/{username}/feeds/{feed_key}/data
+     * @secure
      * @description Create new data records on the given feed. **NOTE:** when feed history is on, data `value` size is limited to 1KB, when feed history is turned off data value size is limited to 100KB.
      */
     createData: (
@@ -700,22 +796,31 @@ export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
       feed_key: string,
       datum: { created_at?: string; ele?: string; epoch?: number; lat?: string; lon?: string; value?: string },
       params?: RequestParams,
-    ) => this.request<Data, any>(`/${username}/feeds/${feed_key}/data`, "POST", params, datum),
+    ) => this.request<Data, any>(`/${username}/feeds/${feed_key}/data`, "POST", params, datum, BodyType.Json, true),
 
     /**
      * @tags Data
      * @name batchCreateData
      * @summary Create multiple new Data records
      * @request POST:/{username}/feeds/{feed_key}/data/batch
+     * @secure
      */
     batchCreateData: (username: string, feed_key: string, data: Data, params?: RequestParams) =>
-      this.request<DataResponse[], any>(`/${username}/feeds/${feed_key}/data/batch`, "POST", params, data),
+      this.request<DataResponse[], any>(
+        `/${username}/feeds/${feed_key}/data/batch`,
+        "POST",
+        params,
+        data,
+        BodyType.Json,
+        true,
+      ),
 
     /**
      * @tags Data
      * @name chartData
      * @summary Chart data for current feed
      * @request GET:/{username}/feeds/{feed_key}/data/chart
+     * @secure
      * @description The Chart API is what we use on io.adafruit.com to populate charts over varying timespans with a consistent number of data points. The maximum number of points returned is 480. This API works by aggregating slices of time into a single value by averaging. All time-based parameters are optional, if none are given it will default to 1 hour at the finest-grained resolution possible.
      */
     chartData: (
@@ -732,13 +837,21 @@ export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
           parameters?: object;
         },
         any
-      >(`/${username}/feeds/${feed_key}/data/chart${this.addQueryParams(query)}`, "GET", params),
+      >(
+        `/${username}/feeds/${feed_key}/data/chart${this.addQueryParams(query)}`,
+        "GET",
+        params,
+        null,
+        BodyType.Json,
+        true,
+      ),
 
     /**
      * @tags Data
      * @name firstData
      * @summary First Data in Queue
      * @request GET:/{username}/feeds/{feed_key}/data/first
+     * @secure
      * @description Get the oldest data point in the feed. This request sets the queue pointer to the beginning of the feed.
      */
     firstData: (username: string, feed_key: string, query?: { include?: string }, params?: RequestParams) =>
@@ -746,6 +859,9 @@ export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
         `/${username}/feeds/${feed_key}/data/first${this.addQueryParams(query)}`,
         "GET",
         params,
+        null,
+        BodyType.Json,
+        true,
       ),
 
     /**
@@ -753,6 +869,7 @@ export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
      * @name lastData
      * @summary Last Data in Queue
      * @request GET:/{username}/feeds/{feed_key}/data/last
+     * @secure
      * @description Get the most recent data point in the feed. This request sets the queue pointer to the end of the feed.
      */
     lastData: (username: string, feed_key: string, query?: { include?: string }, params?: RequestParams) =>
@@ -760,6 +877,9 @@ export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
         `/${username}/feeds/${feed_key}/data/last${this.addQueryParams(query)}`,
         "GET",
         params,
+        null,
+        BodyType.Json,
+        true,
       ),
 
     /**
@@ -767,6 +887,7 @@ export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
      * @name nextData
      * @summary Next Data in Queue
      * @request GET:/{username}/feeds/{feed_key}/data/next
+     * @secure
      * @description Get the next newest data point in the feed. If queue processing hasn't been started, the first data point in the feed will be returned.
      */
     nextData: (username: string, feed_key: string, query?: { include?: string }, params?: RequestParams) =>
@@ -774,6 +895,9 @@ export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
         `/${username}/feeds/${feed_key}/data/next${this.addQueryParams(query)}`,
         "GET",
         params,
+        null,
+        BodyType.Json,
+        true,
       ),
 
     /**
@@ -781,6 +905,7 @@ export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
      * @name previousData
      * @summary Previous Data in Queue
      * @request GET:/{username}/feeds/{feed_key}/data/previous
+     * @secure
      * @description Get the previously processed data point in the feed. NOTE: this method doesn't move the processing queue pointer.
      */
     previousData: (username: string, feed_key: string, query?: { include?: string }, params?: RequestParams) =>
@@ -788,6 +913,9 @@ export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
         `/${username}/feeds/${feed_key}/data/previous${this.addQueryParams(query)}`,
         "GET",
         params,
+        null,
+        BodyType.Json,
+        true,
       ),
 
     /**
@@ -795,31 +923,44 @@ export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
      * @name retainData
      * @summary Last Data in MQTT CSV format
      * @request GET:/{username}/feeds/{feed_key}/data/retain
+     * @secure
      * @description Get the most recent data point in the feed in an MQTT compatible CSV format: `value,lat,lon,ele`
      */
     retainData: (username: string, feed_key: string, params?: RequestParams) =>
-      this.request<string, any>(`/${username}/feeds/${feed_key}/data/retain`, "GET", params),
+      this.request<string, any>(`/${username}/feeds/${feed_key}/data/retain`, "GET", params, null, BodyType.Json, true),
 
     /**
      * @tags Data
      * @name destroyData
      * @summary Delete existing Data
      * @request DELETE:/{username}/feeds/{feed_key}/data/{id}
+     * @secure
      */
     destroyData: (username: string, feed_key: string, id: string, params?: RequestParams) =>
-      this.request<string, any>(`/${username}/feeds/${feed_key}/data/${id}`, "DELETE", params),
+      this.request<string, any>(
+        `/${username}/feeds/${feed_key}/data/${id}`,
+        "DELETE",
+        params,
+        null,
+        BodyType.Json,
+        true,
+      ),
 
     /**
      * @tags Data
      * @name getData
      * @summary Returns data based on feed key
      * @request GET:/{username}/feeds/{feed_key}/data/{id}
+     * @secure
      */
     getData: (username: string, feed_key: string, id: string, query?: { include?: string }, params?: RequestParams) =>
       this.request<DataResponse, any>(
         `/${username}/feeds/${feed_key}/data/${id}${this.addQueryParams(query)}`,
         "GET",
         params,
+        null,
+        BodyType.Json,
+        true,
       ),
 
     /**
@@ -827,6 +968,7 @@ export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
      * @name updateData
      * @summary Update properties of existing Data
      * @request PATCH:/{username}/feeds/{feed_key}/data/{id}
+     * @secure
      */
     updateData: (
       username: string,
@@ -834,13 +976,22 @@ export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
       id: string,
       datum: { created_at?: string; ele?: string; epoch?: number; lat?: string; lon?: string; value?: string },
       params?: RequestParams,
-    ) => this.request<DataResponse, any>(`/${username}/feeds/${feed_key}/data/${id}`, "PATCH", params, datum),
+    ) =>
+      this.request<DataResponse, any>(
+        `/${username}/feeds/${feed_key}/data/${id}`,
+        "PATCH",
+        params,
+        datum,
+        BodyType.Json,
+        true,
+      ),
 
     /**
      * @tags Data
      * @name replaceData
      * @summary Replace existing Data
      * @request PUT:/{username}/feeds/{feed_key}/data/{id}
+     * @secure
      */
     replaceData: (
       username: string,
@@ -848,95 +999,119 @@ export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
       id: string,
       datum: { created_at?: string; ele?: string; epoch?: number; lat?: string; lon?: string; value?: string },
       params?: RequestParams,
-    ) => this.request<DataResponse, any>(`/${username}/feeds/${feed_key}/data/${id}`, "PUT", params, datum),
+    ) =>
+      this.request<DataResponse, any>(
+        `/${username}/feeds/${feed_key}/data/${id}`,
+        "PUT",
+        params,
+        datum,
+        BodyType.Json,
+        true,
+      ),
 
     /**
      * @tags Feeds
      * @name getFeedDetails
      * @summary Get detailed feed by feed key
      * @request GET:/{username}/feeds/{feed_key}/details
+     * @secure
      * @description Returns more detailed feed record based on the feed key
      */
     getFeedDetails: (username: string, feed_key: string, params?: RequestParams) =>
-      this.request<Feed, any>(`/${username}/feeds/${feed_key}/details`, "GET", params),
+      this.request<Feed, any>(`/${username}/feeds/${feed_key}/details`, "GET", params, null, BodyType.Json, true),
 
     /**
      * @tags Groups
      * @name allGroups
      * @summary All groups for current user
      * @request GET:/{username}/groups
+     * @secure
      * @description The Groups endpoint returns information about the user's groups. The response includes the latest value of each feed in the group, and other metadata about the group.
      */
     allGroups: (username: string, params?: RequestParams) =>
-      this.request<Group[], any>(`/${username}/groups`, "GET", params),
+      this.request<Group[], any>(`/${username}/groups`, "GET", params, null, BodyType.Json, true),
 
     /**
      * @tags Groups
      * @name createGroup
      * @summary Create a new Group
      * @request POST:/{username}/groups
+     * @secure
      */
     createGroup: (username: string, group: Group, params?: RequestParams) =>
-      this.request<Group, any>(`/${username}/groups`, "POST", params, group),
+      this.request<Group, any>(`/${username}/groups`, "POST", params, group, BodyType.Json, true),
 
     /**
      * @tags Groups
      * @name destroyGroup
      * @summary Delete an existing Group
      * @request DELETE:/{username}/groups/{group_key}
+     * @secure
      */
     destroyGroup: (username: string, group_key: string, params?: RequestParams) =>
-      this.request<string, any>(`/${username}/groups/${group_key}`, "DELETE", params),
+      this.request<string, any>(`/${username}/groups/${group_key}`, "DELETE", params, null, BodyType.Json, true),
 
     /**
      * @tags Groups
      * @name getGroup
      * @summary Returns Group based on ID
      * @request GET:/{username}/groups/{group_key}
+     * @secure
      */
     getGroup: (username: string, group_key: string, params?: RequestParams) =>
-      this.request<Group, any>(`/${username}/groups/${group_key}`, "GET", params),
+      this.request<Group, any>(`/${username}/groups/${group_key}`, "GET", params, null, BodyType.Json, true),
 
     /**
      * @tags Groups
      * @name updateGroup
      * @summary Update properties of an existing Group
      * @request PATCH:/{username}/groups/{group_key}
+     * @secure
      */
     updateGroup: (
       username: string,
       group_key: string,
       group: { description?: string; key?: string; name?: string },
       params?: RequestParams,
-    ) => this.request<Group, any>(`/${username}/groups/${group_key}`, "PATCH", params, group),
+    ) => this.request<Group, any>(`/${username}/groups/${group_key}`, "PATCH", params, group, BodyType.Json, true),
 
     /**
      * @tags Groups
      * @name replaceGroup
      * @summary Replace an existing Group
      * @request PUT:/{username}/groups/{group_key}
+     * @secure
      */
     replaceGroup: (
       username: string,
       group_key: string,
       group: { description?: string; key?: string; name?: string },
       params?: RequestParams,
-    ) => this.request<Group, any>(`/${username}/groups/${group_key}`, "PUT", params, group),
+    ) => this.request<Group, any>(`/${username}/groups/${group_key}`, "PUT", params, group, BodyType.Json, true),
 
     /**
      * @tags Groups, Feeds
      * @name addFeedToGroup
      * @summary Add an existing Feed to a Group
      * @request POST:/{username}/groups/{group_key}/add
+     * @secure
      */
     addFeedToGroup: (group_key: string, username: string, query?: { feed_key?: string }, params?: RequestParams) =>
-      this.request<Group, any>(`/${username}/groups/${group_key}/add${this.addQueryParams(query)}`, "POST", params),
+      this.request<Group, any>(
+        `/${username}/groups/${group_key}/add${this.addQueryParams(query)}`,
+        "POST",
+        params,
+        null,
+        BodyType.Json,
+        true,
+      ),
 
     /**
      * @tags Data
      * @name createGroupData
      * @summary Create new data for multiple feeds in a group
      * @request POST:/{username}/groups/{group_key}/data
+     * @secure
      */
     createGroupData: (
       username: string,
@@ -947,36 +1122,47 @@ export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
         location: { ele?: number; lat: number; lon: number };
       },
       params?: RequestParams,
-    ) => this.request<DataResponse[], any>(`/${username}/groups/${group_key}/data`, "POST", params, group_feed_data),
+    ) =>
+      this.request<DataResponse[], any>(
+        `/${username}/groups/${group_key}/data`,
+        "POST",
+        params,
+        group_feed_data,
+        BodyType.Json,
+        true,
+      ),
 
     /**
      * @tags Groups, Feeds
      * @name allGroupFeeds
      * @summary All feeds for current user in a given group
      * @request GET:/{username}/groups/{group_key}/feeds
+     * @secure
      * @description The Group Feeds endpoint returns information about the user's feeds. The response includes the latest value of each feed, and other metadata about each feed, but only for feeds within the given group.
      */
     allGroupFeeds: (group_key: string, username: string, params?: RequestParams) =>
-      this.request<Feed[], any>(`/${username}/groups/${group_key}/feeds`, "GET", params),
+      this.request<Feed[], any>(`/${username}/groups/${group_key}/feeds`, "GET", params, null, BodyType.Json, true),
 
     /**
      * @tags Feeds
      * @name createGroupFeed
      * @summary Create a new Feed in a Group
      * @request POST:/{username}/groups/{group_key}/feeds
+     * @secure
      */
     createGroupFeed: (
       username: string,
       group_key: string,
       feed: { description?: string; key?: string; license?: string; name?: string },
       params?: RequestParams,
-    ) => this.request<Feed, any>(`/${username}/groups/${group_key}/feeds`, "POST", params, feed),
+    ) => this.request<Feed, any>(`/${username}/groups/${group_key}/feeds`, "POST", params, feed, BodyType.Json, true),
 
     /**
      * @tags Data
      * @name allGroupFeedData
      * @summary All data for current feed in a specific group
      * @request GET:/{username}/groups/{group_key}/feeds/{feed_key}/data
+     * @secure
      */
     allGroupFeedData: (
       username: string,
@@ -989,6 +1175,9 @@ export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
         `/${username}/groups/${group_key}/feeds/${feed_key}/data${this.addQueryParams(query)}`,
         "GET",
         params,
+        null,
+        BodyType.Json,
+        true,
       ),
 
     /**
@@ -996,6 +1185,7 @@ export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
      * @name createGroupFeedData
      * @summary Create new Data in a feed belonging to a particular group
      * @request POST:/{username}/groups/{group_key}/feeds/{feed_key}/data
+     * @secure
      */
     createGroupFeedData: (
       username: string,
@@ -1004,13 +1194,21 @@ export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
       datum: { created_at?: string; ele?: string; epoch?: number; lat?: string; lon?: string; value?: string },
       params?: RequestParams,
     ) =>
-      this.request<DataResponse, any>(`/${username}/groups/${group_key}/feeds/${feed_key}/data`, "POST", params, datum),
+      this.request<DataResponse, any>(
+        `/${username}/groups/${group_key}/feeds/${feed_key}/data`,
+        "POST",
+        params,
+        datum,
+        BodyType.Json,
+        true,
+      ),
 
     /**
      * @tags Data
      * @name batchCreateGroupFeedData
      * @summary Create multiple new Data records in a feed belonging to a particular group
      * @request POST:/{username}/groups/{group_key}/feeds/{feed_key}/data/batch
+     * @secure
      */
     batchCreateGroupFeedData: (
       username: string,
@@ -1024,6 +1222,8 @@ export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
         "POST",
         params,
         data,
+        BodyType.Json,
+        true,
       ),
 
     /**
@@ -1031,21 +1231,33 @@ export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
      * @name removeFeedFromGroup
      * @summary Remove a Feed from a Group
      * @request POST:/{username}/groups/{group_key}/remove
+     * @secure
      */
     removeFeedFromGroup: (group_key: string, username: string, query?: { feed_key?: string }, params?: RequestParams) =>
-      this.request<Group, any>(`/${username}/groups/${group_key}/remove${this.addQueryParams(query)}`, "POST", params),
+      this.request<Group, any>(
+        `/${username}/groups/${group_key}/remove${this.addQueryParams(query)}`,
+        "POST",
+        params,
+        null,
+        BodyType.Json,
+        true,
+      ),
 
     /**
      * @tags Users
      * @name getCurrentUserThrottle
      * @summary Get the user's data rate limit and current activity level.
      * @request GET:/{username}/throttle
+     * @secure
      */
     getCurrentUserThrottle: (username: string, params?: RequestParams) =>
       this.request<{ active_data_rate?: number; data_rate_limit?: number }, any>(
         `/${username}/throttle`,
         "GET",
         params,
+        null,
+        BodyType.Json,
+        true,
       ),
 
     /**
@@ -1053,126 +1265,140 @@ export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
      * @name allTokens
      * @summary All tokens for current user
      * @request GET:/{username}/tokens
+     * @secure
      * @description The Tokens endpoint returns information about the user's tokens.
      */
     allTokens: (username: string, params?: RequestParams) =>
-      this.request<Token[], any>(`/${username}/tokens`, "GET", params),
+      this.request<Token[], any>(`/${username}/tokens`, "GET", params, null, BodyType.Json, true),
 
     /**
      * @tags Tokens
      * @name createToken
      * @summary Create a new Token
      * @request POST:/{username}/tokens
+     * @secure
      */
     createToken: (username: string, token: Token, params?: RequestParams) =>
-      this.request<Token, any>(`/${username}/tokens`, "POST", params, token),
+      this.request<Token, any>(`/${username}/tokens`, "POST", params, token, BodyType.Json, true),
 
     /**
      * @tags Tokens
      * @name destroyToken
      * @summary Delete an existing Token
      * @request DELETE:/{username}/tokens/{id}
+     * @secure
      */
     destroyToken: (username: string, id: string, params?: RequestParams) =>
-      this.request<string, any>(`/${username}/tokens/${id}`, "DELETE", params),
+      this.request<string, any>(`/${username}/tokens/${id}`, "DELETE", params, null, BodyType.Json, true),
 
     /**
      * @tags Tokens
      * @name getToken
      * @summary Returns Token based on ID
      * @request GET:/{username}/tokens/{id}
+     * @secure
      */
     getToken: (username: string, id: string, params?: RequestParams) =>
-      this.request<Token, any>(`/${username}/tokens/${id}`, "GET", params),
+      this.request<Token, any>(`/${username}/tokens/${id}`, "GET", params, null, BodyType.Json, true),
 
     /**
      * @tags Tokens
      * @name updateToken
      * @summary Update properties of an existing Token
      * @request PATCH:/{username}/tokens/{id}
+     * @secure
      */
     updateToken: (username: string, id: string, token: { token?: string }, params?: RequestParams) =>
-      this.request<Token, any>(`/${username}/tokens/${id}`, "PATCH", params, token),
+      this.request<Token, any>(`/${username}/tokens/${id}`, "PATCH", params, token, BodyType.Json, true),
 
     /**
      * @tags Tokens
      * @name replaceToken
      * @summary Replace an existing Token
      * @request PUT:/{username}/tokens/{id}
+     * @secure
      */
     replaceToken: (username: string, id: string, token: { token?: string }, params?: RequestParams) =>
-      this.request<Token, any>(`/${username}/tokens/${id}`, "PUT", params, token),
+      this.request<Token, any>(`/${username}/tokens/${id}`, "PUT", params, token, BodyType.Json, true),
 
     /**
      * @tags Triggers
      * @name allTriggers
      * @summary All triggers for current user
      * @request GET:/{username}/triggers
+     * @secure
      * @description The Triggers endpoint returns information about the user's triggers.
      */
     allTriggers: (username: string, params?: RequestParams) =>
-      this.request<Trigger[], any>(`/${username}/triggers`, "GET", params),
+      this.request<Trigger[], any>(`/${username}/triggers`, "GET", params, null, BodyType.Json, true),
 
     /**
      * @tags Triggers
      * @name createTrigger
      * @summary Create a new Trigger
      * @request POST:/{username}/triggers
+     * @secure
      */
     createTrigger: (username: string, trigger: Trigger, params?: RequestParams) =>
-      this.request<Trigger, any>(`/${username}/triggers`, "POST", params, trigger),
+      this.request<Trigger, any>(`/${username}/triggers`, "POST", params, trigger, BodyType.Json, true),
 
     /**
      * @tags Triggers
      * @name destroyTrigger
      * @summary Delete an existing Trigger
      * @request DELETE:/{username}/triggers/{id}
+     * @secure
      */
     destroyTrigger: (username: string, id: string, params?: RequestParams) =>
-      this.request<string, any>(`/${username}/triggers/${id}`, "DELETE", params),
+      this.request<string, any>(`/${username}/triggers/${id}`, "DELETE", params, null, BodyType.Json, true),
 
     /**
      * @tags Triggers
      * @name getTrigger
      * @summary Returns Trigger based on ID
      * @request GET:/{username}/triggers/{id}
+     * @secure
      */
     getTrigger: (username: string, id: string, params?: RequestParams) =>
-      this.request<Trigger, any>(`/${username}/triggers/${id}`, "GET", params),
+      this.request<Trigger, any>(`/${username}/triggers/${id}`, "GET", params, null, BodyType.Json, true),
 
     /**
      * @tags Triggers
      * @name updateTrigger
      * @summary Update properties of an existing Trigger
      * @request PATCH:/{username}/triggers/{id}
+     * @secure
      */
     updateTrigger: (username: string, id: string, trigger: { name?: string }, params?: RequestParams) =>
-      this.request<Trigger, any>(`/${username}/triggers/${id}`, "PATCH", params, trigger),
+      this.request<Trigger, any>(`/${username}/triggers/${id}`, "PATCH", params, trigger, BodyType.Json, true),
 
     /**
      * @tags Triggers
      * @name replaceTrigger
      * @summary Replace an existing Trigger
      * @request PUT:/{username}/triggers/{id}
+     * @secure
      */
     replaceTrigger: (username: string, id: string, trigger: { name?: string }, params?: RequestParams) =>
-      this.request<Trigger, any>(`/${username}/triggers/${id}`, "PUT", params, trigger),
+      this.request<Trigger, any>(`/${username}/triggers/${id}`, "PUT", params, trigger, BodyType.Json, true),
 
     /**
      * @tags Permissions
      * @name allPermissions
      * @summary All permissions for current user and type
      * @request GET:/{username}/{type}/{type_id}/acl
+     * @secure
      * @description The Permissions endpoint returns information about the user's permissions.
      */
     allPermissions: (username: string, type: string, type_id: string, params?: RequestParams) =>
-      this.request<Permission[], any>(`/${username}/${type}/${type_id}/acl`, "GET", params),
+      this.request<Permission[], any>(`/${username}/${type}/${type_id}/acl`, "GET", params, null, BodyType.Json, true),
 
     /**
      * @tags Permissions
      * @name createPermission
      * @summary Create a new Permission
      * @request POST:/{username}/{type}/{type_id}/acl
+     * @secure
      */
     createPermission: (
       username: string,
@@ -1180,31 +1406,56 @@ export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
       type_id: string,
       permission: Permission,
       params?: RequestParams,
-    ) => this.request<Permission, any>(`/${username}/${type}/${type_id}/acl`, "POST", params, permission),
+    ) =>
+      this.request<Permission, any>(
+        `/${username}/${type}/${type_id}/acl`,
+        "POST",
+        params,
+        permission,
+        BodyType.Json,
+        true,
+      ),
 
     /**
      * @tags Permissions
      * @name destroyPermission
      * @summary Delete an existing Permission
      * @request DELETE:/{username}/{type}/{type_id}/acl/{id}
+     * @secure
      */
     destroyPermission: (username: string, type: string, type_id: string, id: string, params?: RequestParams) =>
-      this.request<string, any>(`/${username}/${type}/${type_id}/acl/${id}`, "DELETE", params),
+      this.request<string, any>(
+        `/${username}/${type}/${type_id}/acl/${id}`,
+        "DELETE",
+        params,
+        null,
+        BodyType.Json,
+        true,
+      ),
 
     /**
      * @tags Permissions
      * @name getPermission
      * @summary Returns Permission based on ID
      * @request GET:/{username}/{type}/{type_id}/acl/{id}
+     * @secure
      */
     getPermission: (username: string, type: string, type_id: string, id: string, params?: RequestParams) =>
-      this.request<Permission, any>(`/${username}/${type}/${type_id}/acl/${id}`, "GET", params),
+      this.request<Permission, any>(
+        `/${username}/${type}/${type_id}/acl/${id}`,
+        "GET",
+        params,
+        null,
+        BodyType.Json,
+        true,
+      ),
 
     /**
      * @tags Permissions
      * @name updatePermission
      * @summary Update properties of an existing Permission
      * @request PATCH:/{username}/{type}/{type_id}/acl/{id}
+     * @secure
      */
     updatePermission: (
       username: string,
@@ -1217,13 +1468,22 @@ export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
         scope_value?: string;
       },
       params?: RequestParams,
-    ) => this.request<Permission, any>(`/${username}/${type}/${type_id}/acl/${id}`, "PATCH", params, permission),
+    ) =>
+      this.request<Permission, any>(
+        `/${username}/${type}/${type_id}/acl/${id}`,
+        "PATCH",
+        params,
+        permission,
+        BodyType.Json,
+        true,
+      ),
 
     /**
      * @tags Permissions
      * @name replacePermission
      * @summary Replace an existing Permission
      * @request PUT:/{username}/{type}/{type_id}/acl/{id}
+     * @secure
      */
     replacePermission: (
       username: string,
@@ -1236,6 +1496,14 @@ export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
         scope_value?: string;
       },
       params?: RequestParams,
-    ) => this.request<Permission, any>(`/${username}/${type}/${type_id}/acl/${id}`, "PUT", params, permission),
+    ) =>
+      this.request<Permission, any>(
+        `/${username}/${type}/${type_id}/acl/${id}`,
+        "PUT",
+        params,
+        permission,
+        BodyType.Json,
+        true,
+      ),
   };
 }

--- a/tests/generated/v2.0/adafruit.ts
+++ b/tests/generated/v2.0/adafruit.ts
@@ -180,7 +180,7 @@ enum BodyType {
 class HttpClient<SecurityDataType> {
   public baseUrl: string = "https://io.adafruit.com/api/v2";
   private securityData: SecurityDataType = null as any;
-  private securityWorker: ApiConfig<SecurityDataType>["securityWorker"] = (() => {}) as any;
+  private securityWorker: null | ApiConfig<SecurityDataType>["securityWorker"] = null;
 
   private baseApiParams: RequestParams = {
     credentials: "same-origin",
@@ -191,10 +191,8 @@ class HttpClient<SecurityDataType> {
     referrerPolicy: "no-referrer",
   };
 
-  constructor({ baseUrl, baseApiParams, securityWorker }: ApiConfig<SecurityDataType> = {}) {
-    this.baseUrl = baseUrl || this.baseUrl;
-    this.baseApiParams = baseApiParams || this.baseApiParams;
-    this.securityWorker = securityWorker || this.securityWorker;
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
   }
 
   public setSecurityData = (data: SecurityDataType) => {
@@ -266,17 +264,22 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<HttpResponse<T>> =>
-    fetch(`${this.baseUrl}${path}`, {
-      // @ts-ignore
-      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+  ): Promise<HttpResponse<T>> => {
+    const requestUrl = `${this.baseUrl}${path}`;
+    const secureOptions =
+      (secureByDefault || secure) && this.securityWorker ? this.securityWorker(this.securityData) : {};
+    const requestOptions = {
+      ...this.mergeRequestOptions(params, secureOptions),
       method,
       body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
-    }).then(async (response) => {
+    };
+
+    return fetch(requestUrl, requestOptions).then(async (response) => {
       const data = await this.safeParseResponse<T, E>(response);
       if (!response.ok) throw data;
       return data;
     });
+  };
 }
 
 /**

--- a/tests/generated/v2.0/adafruit.ts
+++ b/tests/generated/v2.0/adafruit.ts
@@ -162,11 +162,16 @@ export type RequestParams = Omit<RequestInit, "body" | "method"> & {
 
 export type RequestQueryParamsType = Record<string | number, any>;
 
-type ApiConfig<SecurityDataType> = {
+interface ApiConfig<SecurityDataType> {
   baseUrl?: string;
   baseApiParams?: RequestParams;
   securityWorker?: (securityData: SecurityDataType) => RequestParams;
-};
+}
+
+interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+  data: D | null;
+  error: E | null;
+}
 
 enum BodyType {
   Json,
@@ -233,11 +238,26 @@ class HttpClient<SecurityDataType> {
     };
   }
 
-  private safeParseResponse = <T = any, E = any>(response: Response): Promise<T> =>
-    response
+  private safeParseResponse = <T = any, E = any>(response: Response): Promise<HttpResponse<T, E>> => {
+    const r = response.clone() as HttpResponse<T, E>;
+    r.data = null;
+    r.error = null;
+
+    return response
       .json()
-      .then((data) => data)
-      .catch((e) => response.text);
+      .then((data) => {
+        if (r.ok) {
+          r.data = data;
+        } else {
+          r.error = data;
+        }
+        return r;
+      })
+      .catch((e) => {
+        r.error = e;
+        return r;
+      });
+  };
 
   public request = <T = any, E = any>(
     path: string,
@@ -246,7 +266,7 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<T> =>
+  ): Promise<HttpResponse<T>> =>
     fetch(`${this.baseUrl}${path}`, {
       // @ts-ignore
       ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),

--- a/tests/generated/v2.0/another-example.ts
+++ b/tests/generated/v2.0/another-example.ts
@@ -1,6 +1,5 @@
 /* tslint:disable */
 /* eslint-disable */
-
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/generated/v2.0/another-example.ts
+++ b/tests/generated/v2.0/another-example.ts
@@ -128,7 +128,7 @@ enum BodyType {
 class HttpClient<SecurityDataType> {
   public baseUrl: string = "http://petstore.swagger.io/v2";
   private securityData: SecurityDataType = null as any;
-  private securityWorker: ApiConfig<SecurityDataType>["securityWorker"] = (() => {}) as any;
+  private securityWorker: null | ApiConfig<SecurityDataType>["securityWorker"] = null;
 
   private baseApiParams: RequestParams = {
     credentials: "same-origin",
@@ -139,10 +139,8 @@ class HttpClient<SecurityDataType> {
     referrerPolicy: "no-referrer",
   };
 
-  constructor({ baseUrl, baseApiParams, securityWorker }: ApiConfig<SecurityDataType> = {}) {
-    this.baseUrl = baseUrl || this.baseUrl;
-    this.baseApiParams = baseApiParams || this.baseApiParams;
-    this.securityWorker = securityWorker || this.securityWorker;
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
   }
 
   public setSecurityData = (data: SecurityDataType) => {
@@ -219,17 +217,22 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<HttpResponse<T>> =>
-    fetch(`${this.baseUrl}${path}`, {
-      // @ts-ignore
-      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+  ): Promise<HttpResponse<T>> => {
+    const requestUrl = `${this.baseUrl}${path}`;
+    const secureOptions =
+      (secureByDefault || secure) && this.securityWorker ? this.securityWorker(this.securityData) : {};
+    const requestOptions = {
+      ...this.mergeRequestOptions(params, secureOptions),
       method,
       body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
-    }).then(async (response) => {
+    };
+
+    return fetch(requestUrl, requestOptions).then(async (response) => {
       const data = await this.safeParseResponse<T, E>(response);
       if (!response.ok) throw data;
       return data;
     });
+  };
 }
 
 /**

--- a/tests/generated/v2.0/another-example.ts
+++ b/tests/generated/v2.0/another-example.ts
@@ -109,11 +109,16 @@ export type RequestParams = Omit<RequestInit, "body" | "method"> & {
 
 export type RequestQueryParamsType = Record<string | number, any>;
 
-type ApiConfig<SecurityDataType> = {
+interface ApiConfig<SecurityDataType> {
   baseUrl?: string;
   baseApiParams?: RequestParams;
   securityWorker?: (securityData: SecurityDataType) => RequestParams;
-};
+}
+
+interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+  data: D | null;
+  error: E | null;
+}
 
 enum BodyType {
   Json,
@@ -186,11 +191,26 @@ class HttpClient<SecurityDataType> {
     };
   }
 
-  private safeParseResponse = <T = any, E = any>(response: Response): Promise<T> =>
-    response
+  private safeParseResponse = <T = any, E = any>(response: Response): Promise<HttpResponse<T, E>> => {
+    const r = response.clone() as HttpResponse<T, E>;
+    r.data = null;
+    r.error = null;
+
+    return response
       .json()
-      .then((data) => data)
-      .catch((e) => response.text);
+      .then((data) => {
+        if (r.ok) {
+          r.data = data;
+        } else {
+          r.error = data;
+        }
+        return r;
+      })
+      .catch((e) => {
+        r.error = e;
+        return r;
+      });
+  };
 
   public request = <T = any, E = any>(
     path: string,
@@ -199,7 +219,7 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<T> =>
+  ): Promise<HttpResponse<T>> =>
     fetch(`${this.baseUrl}${path}`, {
       // @ts-ignore
       ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),

--- a/tests/generated/v2.0/api-with-examples.ts
+++ b/tests/generated/v2.0/api-with-examples.ts
@@ -1,6 +1,5 @@
 /* tslint:disable */
 /* eslint-disable */
-
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/generated/v2.0/api-with-examples.ts
+++ b/tests/generated/v2.0/api-with-examples.ts
@@ -13,11 +13,16 @@ export type RequestParams = Omit<RequestInit, "body" | "method"> & {
   secure?: boolean;
 };
 
-type ApiConfig<SecurityDataType> = {
+interface ApiConfig<SecurityDataType> {
   baseUrl?: string;
   baseApiParams?: RequestParams;
   securityWorker?: (securityData: SecurityDataType) => RequestParams;
-};
+}
+
+interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+  data: D | null;
+  error: E | null;
+}
 
 enum BodyType {
   Json,
@@ -64,11 +69,26 @@ class HttpClient<SecurityDataType> {
     };
   }
 
-  private safeParseResponse = <T = any, E = any>(response: Response): Promise<T> =>
-    response
+  private safeParseResponse = <T = any, E = any>(response: Response): Promise<HttpResponse<T, E>> => {
+    const r = response.clone() as HttpResponse<T, E>;
+    r.data = null;
+    r.error = null;
+
+    return response
       .json()
-      .then((data) => data)
-      .catch((e) => response.text);
+      .then((data) => {
+        if (r.ok) {
+          r.data = data;
+        } else {
+          r.error = data;
+        }
+        return r;
+      })
+      .catch((e) => {
+        r.error = e;
+        return r;
+      });
+  };
 
   public request = <T = any, E = any>(
     path: string,
@@ -77,7 +97,7 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<T> =>
+  ): Promise<HttpResponse<T>> =>
     fetch(`${this.baseUrl}${path}`, {
       // @ts-ignore
       ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),

--- a/tests/generated/v2.0/api-with-examples.ts
+++ b/tests/generated/v2.0/api-with-examples.ts
@@ -31,7 +31,7 @@ enum BodyType {
 class HttpClient<SecurityDataType> {
   public baseUrl: string = "";
   private securityData: SecurityDataType = null as any;
-  private securityWorker: ApiConfig<SecurityDataType>["securityWorker"] = (() => {}) as any;
+  private securityWorker: null | ApiConfig<SecurityDataType>["securityWorker"] = null;
 
   private baseApiParams: RequestParams = {
     credentials: "same-origin",
@@ -42,10 +42,8 @@ class HttpClient<SecurityDataType> {
     referrerPolicy: "no-referrer",
   };
 
-  constructor({ baseUrl, baseApiParams, securityWorker }: ApiConfig<SecurityDataType> = {}) {
-    this.baseUrl = baseUrl || this.baseUrl;
-    this.baseApiParams = baseApiParams || this.baseApiParams;
-    this.securityWorker = securityWorker || this.securityWorker;
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
   }
 
   public setSecurityData = (data: SecurityDataType) => {
@@ -97,17 +95,22 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<HttpResponse<T>> =>
-    fetch(`${this.baseUrl}${path}`, {
-      // @ts-ignore
-      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+  ): Promise<HttpResponse<T>> => {
+    const requestUrl = `${this.baseUrl}${path}`;
+    const secureOptions =
+      (secureByDefault || secure) && this.securityWorker ? this.securityWorker(this.securityData) : {};
+    const requestOptions = {
+      ...this.mergeRequestOptions(params, secureOptions),
       method,
       body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
-    }).then(async (response) => {
+    };
+
+    return fetch(requestUrl, requestOptions).then(async (response) => {
       const data = await this.safeParseResponse<T, E>(response);
       if (!response.ok) throw data;
       return data;
     });
+  };
 }
 
 /**

--- a/tests/generated/v2.0/authentiq.ts
+++ b/tests/generated/v2.0/authentiq.ts
@@ -1,6 +1,5 @@
 /* tslint:disable */
 /* eslint-disable */
-
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/generated/v2.0/authentiq.ts
+++ b/tests/generated/v2.0/authentiq.ts
@@ -85,7 +85,7 @@ enum BodyType {
 class HttpClient<SecurityDataType> {
   public baseUrl: string = "https://6-dot-authentiqio.appspot.com/";
   private securityData: SecurityDataType = null as any;
-  private securityWorker: ApiConfig<SecurityDataType>["securityWorker"] = (() => {}) as any;
+  private securityWorker: null | ApiConfig<SecurityDataType>["securityWorker"] = null;
 
   private baseApiParams: RequestParams = {
     credentials: "same-origin",
@@ -96,10 +96,8 @@ class HttpClient<SecurityDataType> {
     referrerPolicy: "no-referrer",
   };
 
-  constructor({ baseUrl, baseApiParams, securityWorker }: ApiConfig<SecurityDataType> = {}) {
-    this.baseUrl = baseUrl || this.baseUrl;
-    this.baseApiParams = baseApiParams || this.baseApiParams;
-    this.securityWorker = securityWorker || this.securityWorker;
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
   }
 
   public setSecurityData = (data: SecurityDataType) => {
@@ -171,17 +169,22 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<HttpResponse<T>> =>
-    fetch(`${this.baseUrl}${path}`, {
-      // @ts-ignore
-      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+  ): Promise<HttpResponse<T>> => {
+    const requestUrl = `${this.baseUrl}${path}`;
+    const secureOptions =
+      (secureByDefault || secure) && this.securityWorker ? this.securityWorker(this.securityData) : {};
+    const requestOptions = {
+      ...this.mergeRequestOptions(params, secureOptions),
       method,
       body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
-    }).then(async (response) => {
+    };
+
+    return fetch(requestUrl, requestOptions).then(async (response) => {
       const data = await this.safeParseResponse<T, E>(response);
       if (!response.ok) throw data;
       return data;
     });
+  };
 }
 
 /**

--- a/tests/generated/v2.0/authentiq.ts
+++ b/tests/generated/v2.0/authentiq.ts
@@ -67,11 +67,16 @@ export type RequestParams = Omit<RequestInit, "body" | "method"> & {
 
 export type RequestQueryParamsType = Record<string | number, any>;
 
-type ApiConfig<SecurityDataType> = {
+interface ApiConfig<SecurityDataType> {
   baseUrl?: string;
   baseApiParams?: RequestParams;
   securityWorker?: (securityData: SecurityDataType) => RequestParams;
-};
+}
+
+interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+  data: D | null;
+  error: E | null;
+}
 
 enum BodyType {
   Json,
@@ -138,11 +143,26 @@ class HttpClient<SecurityDataType> {
     };
   }
 
-  private safeParseResponse = <T = any, E = any>(response: Response): Promise<T> =>
-    response
+  private safeParseResponse = <T = any, E = any>(response: Response): Promise<HttpResponse<T, E>> => {
+    const r = response.clone() as HttpResponse<T, E>;
+    r.data = null;
+    r.error = null;
+
+    return response
       .json()
-      .then((data) => data)
-      .catch((e) => response.text);
+      .then((data) => {
+        if (r.ok) {
+          r.data = data;
+        } else {
+          r.error = data;
+        }
+        return r;
+      })
+      .catch((e) => {
+        r.error = e;
+        return r;
+      });
+  };
 
   public request = <T = any, E = any>(
     path: string,
@@ -151,7 +171,7 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<T> =>
+  ): Promise<HttpResponse<T>> =>
     fetch(`${this.baseUrl}${path}`, {
       // @ts-ignore
       ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),

--- a/tests/generated/v2.0/example1.ts
+++ b/tests/generated/v2.0/example1.ts
@@ -1,6 +1,5 @@
 /* tslint:disable */
 /* eslint-disable */
-
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/generated/v2.0/example1.ts
+++ b/tests/generated/v2.0/example1.ts
@@ -52,7 +52,7 @@ enum BodyType {
 class HttpClient<SecurityDataType> {
   public baseUrl: string = "https://management.azure.com";
   private securityData: SecurityDataType = null as any;
-  private securityWorker: ApiConfig<SecurityDataType>["securityWorker"] = (() => {}) as any;
+  private securityWorker: null | ApiConfig<SecurityDataType>["securityWorker"] = null;
 
   private baseApiParams: RequestParams = {
     credentials: "same-origin",
@@ -63,10 +63,8 @@ class HttpClient<SecurityDataType> {
     referrerPolicy: "no-referrer",
   };
 
-  constructor({ baseUrl, baseApiParams, securityWorker }: ApiConfig<SecurityDataType> = {}) {
-    this.baseUrl = baseUrl || this.baseUrl;
-    this.baseApiParams = baseApiParams || this.baseApiParams;
-    this.securityWorker = securityWorker || this.securityWorker;
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
   }
 
   public setSecurityData = (data: SecurityDataType) => {
@@ -138,17 +136,22 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<HttpResponse<T>> =>
-    fetch(`${this.baseUrl}${path}`, {
-      // @ts-ignore
-      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+  ): Promise<HttpResponse<T>> => {
+    const requestUrl = `${this.baseUrl}${path}`;
+    const secureOptions =
+      (secureByDefault || secure) && this.securityWorker ? this.securityWorker(this.securityData) : {};
+    const requestOptions = {
+      ...this.mergeRequestOptions(params, secureOptions),
       method,
       body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
-    }).then(async (response) => {
+    };
+
+    return fetch(requestUrl, requestOptions).then(async (response) => {
       const data = await this.safeParseResponse<T, E>(response);
       if (!response.ok) throw data;
       return data;
     });
+  };
 }
 
 /**

--- a/tests/generated/v2.0/example1.ts
+++ b/tests/generated/v2.0/example1.ts
@@ -34,11 +34,16 @@ export type RequestParams = Omit<RequestInit, "body" | "method"> & {
 
 export type RequestQueryParamsType = Record<string | number, any>;
 
-type ApiConfig<SecurityDataType> = {
+interface ApiConfig<SecurityDataType> {
   baseUrl?: string;
   baseApiParams?: RequestParams;
   securityWorker?: (securityData: SecurityDataType) => RequestParams;
-};
+}
+
+interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+  data: D | null;
+  error: E | null;
+}
 
 enum BodyType {
   Json,
@@ -105,11 +110,26 @@ class HttpClient<SecurityDataType> {
     };
   }
 
-  private safeParseResponse = <T = any, E = any>(response: Response): Promise<T> =>
-    response
+  private safeParseResponse = <T = any, E = any>(response: Response): Promise<HttpResponse<T, E>> => {
+    const r = response.clone() as HttpResponse<T, E>;
+    r.data = null;
+    r.error = null;
+
+    return response
       .json()
-      .then((data) => data)
-      .catch((e) => response.text);
+      .then((data) => {
+        if (r.ok) {
+          r.data = data;
+        } else {
+          r.error = data;
+        }
+        return r;
+      })
+      .catch((e) => {
+        r.error = e;
+        return r;
+      });
+  };
 
   public request = <T = any, E = any>(
     path: string,
@@ -118,7 +138,7 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<T> =>
+  ): Promise<HttpResponse<T>> =>
     fetch(`${this.baseUrl}${path}`, {
       // @ts-ignore
       ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),

--- a/tests/generated/v2.0/file-formdata-example.ts
+++ b/tests/generated/v2.0/file-formdata-example.ts
@@ -1,6 +1,5 @@
 /* tslint:disable */
 /* eslint-disable */
-
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/generated/v2.0/file-formdata-example.ts
+++ b/tests/generated/v2.0/file-formdata-example.ts
@@ -13,11 +13,16 @@ export type RequestParams = Omit<RequestInit, "body" | "method"> & {
   secure?: boolean;
 };
 
-type ApiConfig<SecurityDataType> = {
+interface ApiConfig<SecurityDataType> {
   baseUrl?: string;
   baseApiParams?: RequestParams;
   securityWorker?: (securityData: SecurityDataType) => RequestParams;
-};
+}
+
+interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+  data: D | null;
+  error: E | null;
+}
 
 enum BodyType {
   Json,
@@ -70,11 +75,26 @@ class HttpClient<SecurityDataType> {
     };
   }
 
-  private safeParseResponse = <T = any, E = any>(response: Response): Promise<T> =>
-    response
+  private safeParseResponse = <T = any, E = any>(response: Response): Promise<HttpResponse<T, E>> => {
+    const r = response.clone() as HttpResponse<T, E>;
+    r.data = null;
+    r.error = null;
+
+    return response
       .json()
-      .then((data) => data)
-      .catch((e) => response.text);
+      .then((data) => {
+        if (r.ok) {
+          r.data = data;
+        } else {
+          r.error = data;
+        }
+        return r;
+      })
+      .catch((e) => {
+        r.error = e;
+        return r;
+      });
+  };
 
   public request = <T = any, E = any>(
     path: string,
@@ -83,7 +103,7 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<T> =>
+  ): Promise<HttpResponse<T>> =>
     fetch(`${this.baseUrl}${path}`, {
       // @ts-ignore
       ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),

--- a/tests/generated/v2.0/file-formdata-example.ts
+++ b/tests/generated/v2.0/file-formdata-example.ts
@@ -32,7 +32,7 @@ enum BodyType {
 class HttpClient<SecurityDataType> {
   public baseUrl: string = "";
   private securityData: SecurityDataType = null as any;
-  private securityWorker: ApiConfig<SecurityDataType>["securityWorker"] = (() => {}) as any;
+  private securityWorker: null | ApiConfig<SecurityDataType>["securityWorker"] = null;
 
   private baseApiParams: RequestParams = {
     credentials: "same-origin",
@@ -43,10 +43,8 @@ class HttpClient<SecurityDataType> {
     referrerPolicy: "no-referrer",
   };
 
-  constructor({ baseUrl, baseApiParams, securityWorker }: ApiConfig<SecurityDataType> = {}) {
-    this.baseUrl = baseUrl || this.baseUrl;
-    this.baseApiParams = baseApiParams || this.baseApiParams;
-    this.securityWorker = securityWorker || this.securityWorker;
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
   }
 
   public setSecurityData = (data: SecurityDataType) => {
@@ -103,17 +101,22 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<HttpResponse<T>> =>
-    fetch(`${this.baseUrl}${path}`, {
-      // @ts-ignore
-      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+  ): Promise<HttpResponse<T>> => {
+    const requestUrl = `${this.baseUrl}${path}`;
+    const secureOptions =
+      (secureByDefault || secure) && this.securityWorker ? this.securityWorker(this.securityData) : {};
+    const requestOptions = {
+      ...this.mergeRequestOptions(params, secureOptions),
       method,
       body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
-    }).then(async (response) => {
+    };
+
+    return fetch(requestUrl, requestOptions).then(async (response) => {
       const data = await this.safeParseResponse<T, E>(response);
       if (!response.ok) throw data;
       return data;
     });
+  };
 }
 
 /**

--- a/tests/generated/v2.0/furkot-example.ts
+++ b/tests/generated/v2.0/furkot-example.ts
@@ -1,6 +1,5 @@
 /* tslint:disable */
 /* eslint-disable */
-
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/generated/v2.0/furkot-example.ts
+++ b/tests/generated/v2.0/furkot-example.ts
@@ -152,16 +152,18 @@ export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
     /**
      * @name tripList
      * @request GET:/trip
+     * @secure
      * @description list user's trips
      */
-    tripList: (params?: RequestParams) => this.request<Trip[], any>(`/trip`, "GET", params),
+    tripList: (params?: RequestParams) => this.request<Trip[], any>(`/trip`, "GET", params, null, BodyType.Json, true),
 
     /**
      * @name stopDetail
      * @request GET:/trip/{trip_id}/stop
+     * @secure
      * @description list stops for a trip identified by {trip_id}
      */
     stopDetail: (trip_id: string, params?: RequestParams) =>
-      this.request<Step[], any>(`/trip/${trip_id}/stop`, "GET", params),
+      this.request<Step[], any>(`/trip/${trip_id}/stop`, "GET", params, null, BodyType.Json, true),
   };
 }

--- a/tests/generated/v2.0/furkot-example.ts
+++ b/tests/generated/v2.0/furkot-example.ts
@@ -79,7 +79,7 @@ enum BodyType {
 class HttpClient<SecurityDataType> {
   public baseUrl: string = "https://trips.furkot.com/pub/api";
   private securityData: SecurityDataType = null as any;
-  private securityWorker: ApiConfig<SecurityDataType>["securityWorker"] = (() => {}) as any;
+  private securityWorker: null | ApiConfig<SecurityDataType>["securityWorker"] = null;
 
   private baseApiParams: RequestParams = {
     credentials: "same-origin",
@@ -90,10 +90,8 @@ class HttpClient<SecurityDataType> {
     referrerPolicy: "no-referrer",
   };
 
-  constructor({ baseUrl, baseApiParams, securityWorker }: ApiConfig<SecurityDataType> = {}) {
-    this.baseUrl = baseUrl || this.baseUrl;
-    this.baseApiParams = baseApiParams || this.baseApiParams;
-    this.securityWorker = securityWorker || this.securityWorker;
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
   }
 
   public setSecurityData = (data: SecurityDataType) => {
@@ -145,17 +143,22 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<HttpResponse<T>> =>
-    fetch(`${this.baseUrl}${path}`, {
-      // @ts-ignore
-      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+  ): Promise<HttpResponse<T>> => {
+    const requestUrl = `${this.baseUrl}${path}`;
+    const secureOptions =
+      (secureByDefault || secure) && this.securityWorker ? this.securityWorker(this.securityData) : {};
+    const requestOptions = {
+      ...this.mergeRequestOptions(params, secureOptions),
       method,
       body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
-    }).then(async (response) => {
+    };
+
+    return fetch(requestUrl, requestOptions).then(async (response) => {
       const data = await this.safeParseResponse<T, E>(response);
       if (!response.ok) throw data;
       return data;
     });
+  };
 }
 
 /**

--- a/tests/generated/v2.0/furkot-example.ts
+++ b/tests/generated/v2.0/furkot-example.ts
@@ -61,11 +61,16 @@ export type RequestParams = Omit<RequestInit, "body" | "method"> & {
   secure?: boolean;
 };
 
-type ApiConfig<SecurityDataType> = {
+interface ApiConfig<SecurityDataType> {
   baseUrl?: string;
   baseApiParams?: RequestParams;
   securityWorker?: (securityData: SecurityDataType) => RequestParams;
-};
+}
+
+interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+  data: D | null;
+  error: E | null;
+}
 
 enum BodyType {
   Json,
@@ -112,11 +117,26 @@ class HttpClient<SecurityDataType> {
     };
   }
 
-  private safeParseResponse = <T = any, E = any>(response: Response): Promise<T> =>
-    response
+  private safeParseResponse = <T = any, E = any>(response: Response): Promise<HttpResponse<T, E>> => {
+    const r = response.clone() as HttpResponse<T, E>;
+    r.data = null;
+    r.error = null;
+
+    return response
       .json()
-      .then((data) => data)
-      .catch((e) => response.text);
+      .then((data) => {
+        if (r.ok) {
+          r.data = data;
+        } else {
+          r.error = data;
+        }
+        return r;
+      })
+      .catch((e) => {
+        r.error = e;
+        return r;
+      });
+  };
 
   public request = <T = any, E = any>(
     path: string,
@@ -125,7 +145,7 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<T> =>
+  ): Promise<HttpResponse<T>> =>
     fetch(`${this.baseUrl}${path}`, {
       // @ts-ignore
       ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),

--- a/tests/generated/v2.0/giphy.ts
+++ b/tests/generated/v2.0/giphy.ts
@@ -1,6 +1,5 @@
 /* tslint:disable */
 /* eslint-disable */
-
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/generated/v2.0/giphy.ts
+++ b/tests/generated/v2.0/giphy.ts
@@ -200,7 +200,7 @@ enum BodyType {
 class HttpClient<SecurityDataType> {
   public baseUrl: string = "https://api.giphy.com/v1";
   private securityData: SecurityDataType = null as any;
-  private securityWorker: ApiConfig<SecurityDataType>["securityWorker"] = (() => {}) as any;
+  private securityWorker: null | ApiConfig<SecurityDataType>["securityWorker"] = null;
 
   private baseApiParams: RequestParams = {
     credentials: "same-origin",
@@ -211,10 +211,8 @@ class HttpClient<SecurityDataType> {
     referrerPolicy: "no-referrer",
   };
 
-  constructor({ baseUrl, baseApiParams, securityWorker }: ApiConfig<SecurityDataType> = {}) {
-    this.baseUrl = baseUrl || this.baseUrl;
-    this.baseApiParams = baseApiParams || this.baseApiParams;
-    this.securityWorker = securityWorker || this.securityWorker;
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
   }
 
   public setSecurityData = (data: SecurityDataType) => {
@@ -286,17 +284,22 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<HttpResponse<T>> =>
-    fetch(`${this.baseUrl}${path}`, {
-      // @ts-ignore
-      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+  ): Promise<HttpResponse<T>> => {
+    const requestUrl = `${this.baseUrl}${path}`;
+    const secureOptions =
+      (secureByDefault || secure) && this.securityWorker ? this.securityWorker(this.securityData) : {};
+    const requestOptions = {
+      ...this.mergeRequestOptions(params, secureOptions),
       method,
       body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
-    }).then(async (response) => {
+    };
+
+    return fetch(requestUrl, requestOptions).then(async (response) => {
       const data = await this.safeParseResponse<T, E>(response);
       if (!response.ok) throw data;
       return data;
     });
+  };
 }
 
 /**

--- a/tests/generated/v2.0/giphy.ts
+++ b/tests/generated/v2.0/giphy.ts
@@ -293,6 +293,7 @@ export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
      * @name getGifsById
      * @summary Get GIFs by ID
      * @request GET:/gifs
+     * @secure
      * @description A multiget version of the get GIF by ID endpoint.
      */
     getGifsById: (query?: { ids?: string }, params?: RequestParams) =>
@@ -300,6 +301,9 @@ export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
         `/gifs${this.addQueryParams(query)}`,
         "GET",
         params,
+        null,
+        BodyType.Json,
+        true,
       ),
 
     /**
@@ -307,16 +311,25 @@ export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
      * @name randomGif
      * @summary Random GIF
      * @request GET:/gifs/random
+     * @secure
      * @description Returns a random GIF, limited by tag. Excluding the tag parameter will return a random GIF from the GIPHY catalog.
      */
     randomGif: (query?: { tag?: string; rating?: string }, params?: RequestParams) =>
-      this.request<{ data?: Gif; meta?: Meta }, any>(`/gifs/random${this.addQueryParams(query)}`, "GET", params),
+      this.request<{ data?: Gif; meta?: Meta }, any>(
+        `/gifs/random${this.addQueryParams(query)}`,
+        "GET",
+        params,
+        null,
+        BodyType.Json,
+        true,
+      ),
 
     /**
      * @tags gifs
      * @name searchGifs
      * @summary Search GIFs
      * @request GET:/gifs/search
+     * @secure
      * @description Search all GIPHY GIFs for a word or phrase. Punctuation will be stripped and ignored.  Use a plus or url encode for phrases. Example paul+rudd, ryan+gosling or american+psycho.
      */
     searchGifs: (
@@ -327,6 +340,9 @@ export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
         `/gifs/search${this.addQueryParams(query)}`,
         "GET",
         params,
+        null,
+        BodyType.Json,
+        true,
       ),
 
     /**
@@ -334,16 +350,25 @@ export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
      * @name translateGif
      * @summary Translate phrase to GIF
      * @request GET:/gifs/translate
+     * @secure
      * @description The translate API draws on search, but uses the GIPHY `special sauce` to handle translating from one vocabulary to another. In this case, words and phrases to GIF
      */
     translateGif: (query: { s: string }, params?: RequestParams) =>
-      this.request<{ data?: Gif; meta?: Meta }, any>(`/gifs/translate${this.addQueryParams(query)}`, "GET", params),
+      this.request<{ data?: Gif; meta?: Meta }, any>(
+        `/gifs/translate${this.addQueryParams(query)}`,
+        "GET",
+        params,
+        null,
+        BodyType.Json,
+        true,
+      ),
 
     /**
      * @tags gifs
      * @name trendingGifs
      * @summary Trending GIFs
      * @request GET:/gifs/trending
+     * @secure
      * @description Fetch GIFs currently trending online. Hand curated by the GIPHY editorial team.  The data returned mirrors the GIFs showcased on the GIPHY homepage. Returns 25 results by default.
      */
     trendingGifs: (query?: { limit?: number; offset?: number; rating?: string }, params?: RequestParams) =>
@@ -351,6 +376,9 @@ export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
         `/gifs/trending${this.addQueryParams(query)}`,
         "GET",
         params,
+        null,
+        BodyType.Json,
+        true,
       ),
 
     /**
@@ -358,10 +386,11 @@ export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
      * @name getGifById
      * @summary Get GIF by Id
      * @request GET:/gifs/{gifId}
+     * @secure
      * @description Returns a GIF given that GIF's unique ID
      */
     getGifById: (gifId: number, params?: RequestParams) =>
-      this.request<{ data?: Gif; meta?: Meta }, any>(`/gifs/${gifId}`, "GET", params),
+      this.request<{ data?: Gif; meta?: Meta }, any>(`/gifs/${gifId}`, "GET", params, null, BodyType.Json, true),
   };
   stickers = {
     /**
@@ -369,16 +398,25 @@ export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
      * @name randomSticker
      * @summary Random Sticker
      * @request GET:/stickers/random
+     * @secure
      * @description Returns a random GIF, limited by tag. Excluding the tag parameter will return a random GIF from the GIPHY catalog.
      */
     randomSticker: (query?: { tag?: string; rating?: string }, params?: RequestParams) =>
-      this.request<{ data?: Gif; meta?: Meta }, any>(`/stickers/random${this.addQueryParams(query)}`, "GET", params),
+      this.request<{ data?: Gif; meta?: Meta }, any>(
+        `/stickers/random${this.addQueryParams(query)}`,
+        "GET",
+        params,
+        null,
+        BodyType.Json,
+        true,
+      ),
 
     /**
      * @tags stickers
      * @name searchStickers
      * @summary Search Stickers
      * @request GET:/stickers/search
+     * @secure
      * @description Replicates the functionality and requirements of the classic GIPHY search, but returns animated stickers rather than GIFs.
      */
     searchStickers: (
@@ -389,6 +427,9 @@ export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
         `/stickers/search${this.addQueryParams(query)}`,
         "GET",
         params,
+        null,
+        BodyType.Json,
+        true,
       ),
 
     /**
@@ -396,16 +437,25 @@ export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
      * @name translateSticker
      * @summary Translate phrase to Sticker
      * @request GET:/stickers/translate
+     * @secure
      * @description The translate API draws on search, but uses the GIPHY `special sauce` to handle translating from one vocabulary to another. In this case, words and phrases to GIFs.
      */
     translateSticker: (query: { s: string }, params?: RequestParams) =>
-      this.request<{ data?: Gif; meta?: Meta }, any>(`/stickers/translate${this.addQueryParams(query)}`, "GET", params),
+      this.request<{ data?: Gif; meta?: Meta }, any>(
+        `/stickers/translate${this.addQueryParams(query)}`,
+        "GET",
+        params,
+        null,
+        BodyType.Json,
+        true,
+      ),
 
     /**
      * @tags stickers
      * @name trendingStickers
      * @summary Trending Stickers
      * @request GET:/stickers/trending
+     * @secure
      * @description Fetch Stickers currently trending online. Hand curated by the GIPHY editorial team. Returns 25 results by default.
      */
     trendingStickers: (query?: { limit?: number; offset?: number; rating?: string }, params?: RequestParams) =>
@@ -413,6 +463,9 @@ export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
         `/stickers/trending${this.addQueryParams(query)}`,
         "GET",
         params,
+        null,
+        BodyType.Json,
+        true,
       ),
   };
 }

--- a/tests/generated/v2.0/giphy.ts
+++ b/tests/generated/v2.0/giphy.ts
@@ -182,11 +182,16 @@ export type RequestParams = Omit<RequestInit, "body" | "method"> & {
 
 export type RequestQueryParamsType = Record<string | number, any>;
 
-type ApiConfig<SecurityDataType> = {
+interface ApiConfig<SecurityDataType> {
   baseUrl?: string;
   baseApiParams?: RequestParams;
   securityWorker?: (securityData: SecurityDataType) => RequestParams;
-};
+}
+
+interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+  data: D | null;
+  error: E | null;
+}
 
 enum BodyType {
   Json,
@@ -253,11 +258,26 @@ class HttpClient<SecurityDataType> {
     };
   }
 
-  private safeParseResponse = <T = any, E = any>(response: Response): Promise<T> =>
-    response
+  private safeParseResponse = <T = any, E = any>(response: Response): Promise<HttpResponse<T, E>> => {
+    const r = response.clone() as HttpResponse<T, E>;
+    r.data = null;
+    r.error = null;
+
+    return response
       .json()
-      .then((data) => data)
-      .catch((e) => response.text);
+      .then((data) => {
+        if (r.ok) {
+          r.data = data;
+        } else {
+          r.error = data;
+        }
+        return r;
+      })
+      .catch((e) => {
+        r.error = e;
+        return r;
+      });
+  };
 
   public request = <T = any, E = any>(
     path: string,
@@ -266,7 +286,7 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<T> =>
+  ): Promise<HttpResponse<T>> =>
     fetch(`${this.baseUrl}${path}`, {
       // @ts-ignore
       ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),

--- a/tests/generated/v2.0/github-swagger.ts
+++ b/tests/generated/v2.0/github-swagger.ts
@@ -1,6 +1,5 @@
 /* tslint:disable */
 /* eslint-disable */
-
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/generated/v2.0/github-swagger.ts
+++ b/tests/generated/v2.0/github-swagger.ts
@@ -1429,7 +1429,7 @@ enum BodyType {
 class HttpClient<SecurityDataType> {
   public baseUrl: string = "https://api.github.com/";
   private securityData: SecurityDataType = null as any;
-  private securityWorker: ApiConfig<SecurityDataType>["securityWorker"] = (() => {}) as any;
+  private securityWorker: null | ApiConfig<SecurityDataType>["securityWorker"] = null;
 
   private baseApiParams: RequestParams = {
     credentials: "same-origin",
@@ -1440,10 +1440,8 @@ class HttpClient<SecurityDataType> {
     referrerPolicy: "no-referrer",
   };
 
-  constructor({ baseUrl, baseApiParams, securityWorker }: ApiConfig<SecurityDataType> = {}) {
-    this.baseUrl = baseUrl || this.baseUrl;
-    this.baseApiParams = baseApiParams || this.baseApiParams;
-    this.securityWorker = securityWorker || this.securityWorker;
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
   }
 
   public setSecurityData = (data: SecurityDataType) => {
@@ -1515,17 +1513,22 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<HttpResponse<T>> =>
-    fetch(`${this.baseUrl}${path}`, {
-      // @ts-ignore
-      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+  ): Promise<HttpResponse<T>> => {
+    const requestUrl = `${this.baseUrl}${path}`;
+    const secureOptions =
+      (secureByDefault || secure) && this.securityWorker ? this.securityWorker(this.securityData) : {};
+    const requestOptions = {
+      ...this.mergeRequestOptions(params, secureOptions),
       method,
       body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
-    }).then(async (response) => {
+    };
+
+    return fetch(requestUrl, requestOptions).then(async (response) => {
       const data = await this.safeParseResponse<T, E>(response);
       if (!response.ok) throw data;
       return data;
     });
+  };
 }
 
 /**

--- a/tests/generated/v2.0/github-swagger.ts
+++ b/tests/generated/v2.0/github-swagger.ts
@@ -1411,11 +1411,16 @@ export type RequestParams = Omit<RequestInit, "body" | "method"> & {
 
 export type RequestQueryParamsType = Record<string | number, any>;
 
-type ApiConfig<SecurityDataType> = {
+interface ApiConfig<SecurityDataType> {
   baseUrl?: string;
   baseApiParams?: RequestParams;
   securityWorker?: (securityData: SecurityDataType) => RequestParams;
-};
+}
+
+interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+  data: D | null;
+  error: E | null;
+}
 
 enum BodyType {
   Json,
@@ -1482,11 +1487,26 @@ class HttpClient<SecurityDataType> {
     };
   }
 
-  private safeParseResponse = <T = any, E = any>(response: Response): Promise<T> =>
-    response
+  private safeParseResponse = <T = any, E = any>(response: Response): Promise<HttpResponse<T, E>> => {
+    const r = response.clone() as HttpResponse<T, E>;
+    r.data = null;
+    r.error = null;
+
+    return response
       .json()
-      .then((data) => data)
-      .catch((e) => response.text);
+      .then((data) => {
+        if (r.ok) {
+          r.data = data;
+        } else {
+          r.error = data;
+        }
+        return r;
+      })
+      .catch((e) => {
+        r.error = e;
+        return r;
+      });
+  };
 
   public request = <T = any, E = any>(
     path: string,
@@ -1495,7 +1515,7 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<T> =>
+  ): Promise<HttpResponse<T>> =>
     fetch(`${this.baseUrl}${path}`, {
       // @ts-ignore
       ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),

--- a/tests/generated/v2.0/path-args.ts
+++ b/tests/generated/v2.0/path-args.ts
@@ -1,6 +1,5 @@
 /* tslint:disable */
 /* eslint-disable */
-
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/generated/v2.0/path-args.ts
+++ b/tests/generated/v2.0/path-args.ts
@@ -15,11 +15,16 @@ export type RequestParams = Omit<RequestInit, "body" | "method"> & {
 
 export type RequestQueryParamsType = Record<string | number, any>;
 
-type ApiConfig<SecurityDataType> = {
+interface ApiConfig<SecurityDataType> {
   baseUrl?: string;
   baseApiParams?: RequestParams;
   securityWorker?: (securityData: SecurityDataType) => RequestParams;
-};
+}
+
+interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+  data: D | null;
+  error: E | null;
+}
 
 enum BodyType {
   Json,
@@ -86,11 +91,26 @@ class HttpClient<SecurityDataType> {
     };
   }
 
-  private safeParseResponse = <T = any, E = any>(response: Response): Promise<T> =>
-    response
+  private safeParseResponse = <T = any, E = any>(response: Response): Promise<HttpResponse<T, E>> => {
+    const r = response.clone() as HttpResponse<T, E>;
+    r.data = null;
+    r.error = null;
+
+    return response
       .json()
-      .then((data) => data)
-      .catch((e) => response.text);
+      .then((data) => {
+        if (r.ok) {
+          r.data = data;
+        } else {
+          r.error = data;
+        }
+        return r;
+      })
+      .catch((e) => {
+        r.error = e;
+        return r;
+      });
+  };
 
   public request = <T = any, E = any>(
     path: string,
@@ -99,7 +119,7 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<T> =>
+  ): Promise<HttpResponse<T>> =>
     fetch(`${this.baseUrl}${path}`, {
       // @ts-ignore
       ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),

--- a/tests/generated/v2.0/path-args.ts
+++ b/tests/generated/v2.0/path-args.ts
@@ -33,7 +33,7 @@ enum BodyType {
 class HttpClient<SecurityDataType> {
   public baseUrl: string = "http://unknown.io/v666";
   private securityData: SecurityDataType = null as any;
-  private securityWorker: ApiConfig<SecurityDataType>["securityWorker"] = (() => {}) as any;
+  private securityWorker: null | ApiConfig<SecurityDataType>["securityWorker"] = null;
 
   private baseApiParams: RequestParams = {
     credentials: "same-origin",
@@ -44,10 +44,8 @@ class HttpClient<SecurityDataType> {
     referrerPolicy: "no-referrer",
   };
 
-  constructor({ baseUrl, baseApiParams, securityWorker }: ApiConfig<SecurityDataType> = {}) {
-    this.baseUrl = baseUrl || this.baseUrl;
-    this.baseApiParams = baseApiParams || this.baseApiParams;
-    this.securityWorker = securityWorker || this.securityWorker;
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
   }
 
   public setSecurityData = (data: SecurityDataType) => {
@@ -119,17 +117,22 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<HttpResponse<T>> =>
-    fetch(`${this.baseUrl}${path}`, {
-      // @ts-ignore
-      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+  ): Promise<HttpResponse<T>> => {
+    const requestUrl = `${this.baseUrl}${path}`;
+    const secureOptions =
+      (secureByDefault || secure) && this.securityWorker ? this.securityWorker(this.securityData) : {};
+    const requestOptions = {
+      ...this.mergeRequestOptions(params, secureOptions),
       method,
       body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
-    }).then(async (response) => {
+    };
+
+    return fetch(requestUrl, requestOptions).then(async (response) => {
       const data = await this.safeParseResponse<T, E>(response);
       if (!response.ok) throw data;
       return data;
     });
+  };
 }
 
 /**

--- a/tests/generated/v2.0/petstore-expanded.ts
+++ b/tests/generated/v2.0/petstore-expanded.ts
@@ -1,6 +1,5 @@
 /* tslint:disable */
 /* eslint-disable */
-
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/generated/v2.0/petstore-expanded.ts
+++ b/tests/generated/v2.0/petstore-expanded.ts
@@ -41,11 +41,16 @@ export type RequestParams = Omit<RequestInit, "body" | "method"> & {
 
 export type RequestQueryParamsType = Record<string | number, any>;
 
-type ApiConfig<SecurityDataType> = {
+interface ApiConfig<SecurityDataType> {
   baseUrl?: string;
   baseApiParams?: RequestParams;
   securityWorker?: (securityData: SecurityDataType) => RequestParams;
-};
+}
+
+interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+  data: D | null;
+  error: E | null;
+}
 
 enum BodyType {
   Json,
@@ -112,11 +117,26 @@ class HttpClient<SecurityDataType> {
     };
   }
 
-  private safeParseResponse = <T = any, E = any>(response: Response): Promise<T> =>
-    response
+  private safeParseResponse = <T = any, E = any>(response: Response): Promise<HttpResponse<T, E>> => {
+    const r = response.clone() as HttpResponse<T, E>;
+    r.data = null;
+    r.error = null;
+
+    return response
       .json()
-      .then((data) => data)
-      .catch((e) => response.text);
+      .then((data) => {
+        if (r.ok) {
+          r.data = data;
+        } else {
+          r.error = data;
+        }
+        return r;
+      })
+      .catch((e) => {
+        r.error = e;
+        return r;
+      });
+  };
 
   public request = <T = any, E = any>(
     path: string,
@@ -125,7 +145,7 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<T> =>
+  ): Promise<HttpResponse<T>> =>
     fetch(`${this.baseUrl}${path}`, {
       // @ts-ignore
       ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),

--- a/tests/generated/v2.0/petstore-expanded.ts
+++ b/tests/generated/v2.0/petstore-expanded.ts
@@ -59,7 +59,7 @@ enum BodyType {
 class HttpClient<SecurityDataType> {
   public baseUrl: string = "http://petstore.swagger.io/api";
   private securityData: SecurityDataType = null as any;
-  private securityWorker: ApiConfig<SecurityDataType>["securityWorker"] = (() => {}) as any;
+  private securityWorker: null | ApiConfig<SecurityDataType>["securityWorker"] = null;
 
   private baseApiParams: RequestParams = {
     credentials: "same-origin",
@@ -70,10 +70,8 @@ class HttpClient<SecurityDataType> {
     referrerPolicy: "no-referrer",
   };
 
-  constructor({ baseUrl, baseApiParams, securityWorker }: ApiConfig<SecurityDataType> = {}) {
-    this.baseUrl = baseUrl || this.baseUrl;
-    this.baseApiParams = baseApiParams || this.baseApiParams;
-    this.securityWorker = securityWorker || this.securityWorker;
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
   }
 
   public setSecurityData = (data: SecurityDataType) => {
@@ -145,17 +143,22 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<HttpResponse<T>> =>
-    fetch(`${this.baseUrl}${path}`, {
-      // @ts-ignore
-      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+  ): Promise<HttpResponse<T>> => {
+    const requestUrl = `${this.baseUrl}${path}`;
+    const secureOptions =
+      (secureByDefault || secure) && this.securityWorker ? this.securityWorker(this.securityData) : {};
+    const requestOptions = {
+      ...this.mergeRequestOptions(params, secureOptions),
       method,
       body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
-    }).then(async (response) => {
+    };
+
+    return fetch(requestUrl, requestOptions).then(async (response) => {
       const data = await this.safeParseResponse<T, E>(response);
       if (!response.ok) throw data;
       return data;
     });
+  };
 }
 
 /**

--- a/tests/generated/v2.0/petstore-minimal.ts
+++ b/tests/generated/v2.0/petstore-minimal.ts
@@ -1,6 +1,5 @@
 /* tslint:disable */
 /* eslint-disable */
-
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/generated/v2.0/petstore-minimal.ts
+++ b/tests/generated/v2.0/petstore-minimal.ts
@@ -20,11 +20,16 @@ export type RequestParams = Omit<RequestInit, "body" | "method"> & {
   secure?: boolean;
 };
 
-type ApiConfig<SecurityDataType> = {
+interface ApiConfig<SecurityDataType> {
   baseUrl?: string;
   baseApiParams?: RequestParams;
   securityWorker?: (securityData: SecurityDataType) => RequestParams;
-};
+}
+
+interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+  data: D | null;
+  error: E | null;
+}
 
 enum BodyType {
   Json,
@@ -71,11 +76,26 @@ class HttpClient<SecurityDataType> {
     };
   }
 
-  private safeParseResponse = <T = any, E = any>(response: Response): Promise<T> =>
-    response
+  private safeParseResponse = <T = any, E = any>(response: Response): Promise<HttpResponse<T, E>> => {
+    const r = response.clone() as HttpResponse<T, E>;
+    r.data = null;
+    r.error = null;
+
+    return response
       .json()
-      .then((data) => data)
-      .catch((e) => response.text);
+      .then((data) => {
+        if (r.ok) {
+          r.data = data;
+        } else {
+          r.error = data;
+        }
+        return r;
+      })
+      .catch((e) => {
+        r.error = e;
+        return r;
+      });
+  };
 
   public request = <T = any, E = any>(
     path: string,
@@ -84,7 +104,7 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<T> =>
+  ): Promise<HttpResponse<T>> =>
     fetch(`${this.baseUrl}${path}`, {
       // @ts-ignore
       ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),

--- a/tests/generated/v2.0/petstore-minimal.ts
+++ b/tests/generated/v2.0/petstore-minimal.ts
@@ -38,7 +38,7 @@ enum BodyType {
 class HttpClient<SecurityDataType> {
   public baseUrl: string = "http://petstore.swagger.io/api";
   private securityData: SecurityDataType = null as any;
-  private securityWorker: ApiConfig<SecurityDataType>["securityWorker"] = (() => {}) as any;
+  private securityWorker: null | ApiConfig<SecurityDataType>["securityWorker"] = null;
 
   private baseApiParams: RequestParams = {
     credentials: "same-origin",
@@ -49,10 +49,8 @@ class HttpClient<SecurityDataType> {
     referrerPolicy: "no-referrer",
   };
 
-  constructor({ baseUrl, baseApiParams, securityWorker }: ApiConfig<SecurityDataType> = {}) {
-    this.baseUrl = baseUrl || this.baseUrl;
-    this.baseApiParams = baseApiParams || this.baseApiParams;
-    this.securityWorker = securityWorker || this.securityWorker;
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
   }
 
   public setSecurityData = (data: SecurityDataType) => {
@@ -104,17 +102,22 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<HttpResponse<T>> =>
-    fetch(`${this.baseUrl}${path}`, {
-      // @ts-ignore
-      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+  ): Promise<HttpResponse<T>> => {
+    const requestUrl = `${this.baseUrl}${path}`;
+    const secureOptions =
+      (secureByDefault || secure) && this.securityWorker ? this.securityWorker(this.securityData) : {};
+    const requestOptions = {
+      ...this.mergeRequestOptions(params, secureOptions),
       method,
       body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
-    }).then(async (response) => {
+    };
+
+    return fetch(requestUrl, requestOptions).then(async (response) => {
       const data = await this.safeParseResponse<T, E>(response);
       if (!response.ok) throw data;
       return data;
     });
+  };
 }
 
 /**

--- a/tests/generated/v2.0/petstore-simple.ts
+++ b/tests/generated/v2.0/petstore-simple.ts
@@ -1,6 +1,5 @@
 /* tslint:disable */
 /* eslint-disable */
-
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/generated/v2.0/petstore-simple.ts
+++ b/tests/generated/v2.0/petstore-simple.ts
@@ -37,11 +37,16 @@ export type RequestParams = Omit<RequestInit, "body" | "method"> & {
 
 export type RequestQueryParamsType = Record<string | number, any>;
 
-type ApiConfig<SecurityDataType> = {
+interface ApiConfig<SecurityDataType> {
   baseUrl?: string;
   baseApiParams?: RequestParams;
   securityWorker?: (securityData: SecurityDataType) => RequestParams;
-};
+}
+
+interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+  data: D | null;
+  error: E | null;
+}
 
 enum BodyType {
   Json,
@@ -108,11 +113,26 @@ class HttpClient<SecurityDataType> {
     };
   }
 
-  private safeParseResponse = <T = any, E = any>(response: Response): Promise<T> =>
-    response
+  private safeParseResponse = <T = any, E = any>(response: Response): Promise<HttpResponse<T, E>> => {
+    const r = response.clone() as HttpResponse<T, E>;
+    r.data = null;
+    r.error = null;
+
+    return response
       .json()
-      .then((data) => data)
-      .catch((e) => response.text);
+      .then((data) => {
+        if (r.ok) {
+          r.data = data;
+        } else {
+          r.error = data;
+        }
+        return r;
+      })
+      .catch((e) => {
+        r.error = e;
+        return r;
+      });
+  };
 
   public request = <T = any, E = any>(
     path: string,
@@ -121,7 +141,7 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<T> =>
+  ): Promise<HttpResponse<T>> =>
     fetch(`${this.baseUrl}${path}`, {
       // @ts-ignore
       ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),

--- a/tests/generated/v2.0/petstore-simple.ts
+++ b/tests/generated/v2.0/petstore-simple.ts
@@ -55,7 +55,7 @@ enum BodyType {
 class HttpClient<SecurityDataType> {
   public baseUrl: string = "http://petstore.swagger.io/api";
   private securityData: SecurityDataType = null as any;
-  private securityWorker: ApiConfig<SecurityDataType>["securityWorker"] = (() => {}) as any;
+  private securityWorker: null | ApiConfig<SecurityDataType>["securityWorker"] = null;
 
   private baseApiParams: RequestParams = {
     credentials: "same-origin",
@@ -66,10 +66,8 @@ class HttpClient<SecurityDataType> {
     referrerPolicy: "no-referrer",
   };
 
-  constructor({ baseUrl, baseApiParams, securityWorker }: ApiConfig<SecurityDataType> = {}) {
-    this.baseUrl = baseUrl || this.baseUrl;
-    this.baseApiParams = baseApiParams || this.baseApiParams;
-    this.securityWorker = securityWorker || this.securityWorker;
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
   }
 
   public setSecurityData = (data: SecurityDataType) => {
@@ -141,17 +139,22 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<HttpResponse<T>> =>
-    fetch(`${this.baseUrl}${path}`, {
-      // @ts-ignore
-      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+  ): Promise<HttpResponse<T>> => {
+    const requestUrl = `${this.baseUrl}${path}`;
+    const secureOptions =
+      (secureByDefault || secure) && this.securityWorker ? this.securityWorker(this.securityData) : {};
+    const requestOptions = {
+      ...this.mergeRequestOptions(params, secureOptions),
       method,
       body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
-    }).then(async (response) => {
+    };
+
+    return fetch(requestUrl, requestOptions).then(async (response) => {
       const data = await this.safeParseResponse<T, E>(response);
       if (!response.ok) throw data;
       return data;
     });
+  };
 }
 
 /**

--- a/tests/generated/v2.0/petstore-swagger-io.ts
+++ b/tests/generated/v2.0/petstore-swagger-io.ts
@@ -1,6 +1,5 @@
 /* tslint:disable */
 /* eslint-disable */
-
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/generated/v2.0/petstore-swagger-io.ts
+++ b/tests/generated/v2.0/petstore-swagger-io.ts
@@ -66,11 +66,16 @@ export type RequestParams = Omit<RequestInit, "body" | "method"> & {
 
 export type RequestQueryParamsType = Record<string | number, any>;
 
-type ApiConfig<SecurityDataType> = {
+interface ApiConfig<SecurityDataType> {
   baseUrl?: string;
   baseApiParams?: RequestParams;
   securityWorker?: (securityData: SecurityDataType) => RequestParams;
-};
+}
+
+interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+  data: D | null;
+  error: E | null;
+}
 
 enum BodyType {
   Json,
@@ -143,11 +148,26 @@ class HttpClient<SecurityDataType> {
     };
   }
 
-  private safeParseResponse = <T = any, E = any>(response: Response): Promise<T> =>
-    response
+  private safeParseResponse = <T = any, E = any>(response: Response): Promise<HttpResponse<T, E>> => {
+    const r = response.clone() as HttpResponse<T, E>;
+    r.data = null;
+    r.error = null;
+
+    return response
       .json()
-      .then((data) => data)
-      .catch((e) => response.text);
+      .then((data) => {
+        if (r.ok) {
+          r.data = data;
+        } else {
+          r.error = data;
+        }
+        return r;
+      })
+      .catch((e) => {
+        r.error = e;
+        return r;
+      });
+  };
 
   public request = <T = any, E = any>(
     path: string,
@@ -156,7 +176,7 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<T> =>
+  ): Promise<HttpResponse<T>> =>
     fetch(`${this.baseUrl}${path}`, {
       // @ts-ignore
       ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),

--- a/tests/generated/v2.0/petstore-with-external-docs.ts
+++ b/tests/generated/v2.0/petstore-with-external-docs.ts
@@ -1,6 +1,5 @@
 /* tslint:disable */
 /* eslint-disable */
-
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/generated/v2.0/petstore-with-external-docs.ts
+++ b/tests/generated/v2.0/petstore-with-external-docs.ts
@@ -27,11 +27,16 @@ export type RequestParams = Omit<RequestInit, "body" | "method"> & {
 
 export type RequestQueryParamsType = Record<string | number, any>;
 
-type ApiConfig<SecurityDataType> = {
+interface ApiConfig<SecurityDataType> {
   baseUrl?: string;
   baseApiParams?: RequestParams;
   securityWorker?: (securityData: SecurityDataType) => RequestParams;
-};
+}
+
+interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+  data: D | null;
+  error: E | null;
+}
 
 enum BodyType {
   Json,
@@ -98,11 +103,26 @@ class HttpClient<SecurityDataType> {
     };
   }
 
-  private safeParseResponse = <T = any, E = any>(response: Response): Promise<T> =>
-    response
+  private safeParseResponse = <T = any, E = any>(response: Response): Promise<HttpResponse<T, E>> => {
+    const r = response.clone() as HttpResponse<T, E>;
+    r.data = null;
+    r.error = null;
+
+    return response
       .json()
-      .then((data) => data)
-      .catch((e) => response.text);
+      .then((data) => {
+        if (r.ok) {
+          r.data = data;
+        } else {
+          r.error = data;
+        }
+        return r;
+      })
+      .catch((e) => {
+        r.error = e;
+        return r;
+      });
+  };
 
   public request = <T = any, E = any>(
     path: string,
@@ -111,7 +131,7 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<T> =>
+  ): Promise<HttpResponse<T>> =>
     fetch(`${this.baseUrl}${path}`, {
       // @ts-ignore
       ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),

--- a/tests/generated/v2.0/petstore-with-external-docs.ts
+++ b/tests/generated/v2.0/petstore-with-external-docs.ts
@@ -45,7 +45,7 @@ enum BodyType {
 class HttpClient<SecurityDataType> {
   public baseUrl: string = "http://petstore.swagger.io/api";
   private securityData: SecurityDataType = null as any;
-  private securityWorker: ApiConfig<SecurityDataType>["securityWorker"] = (() => {}) as any;
+  private securityWorker: null | ApiConfig<SecurityDataType>["securityWorker"] = null;
 
   private baseApiParams: RequestParams = {
     credentials: "same-origin",
@@ -56,10 +56,8 @@ class HttpClient<SecurityDataType> {
     referrerPolicy: "no-referrer",
   };
 
-  constructor({ baseUrl, baseApiParams, securityWorker }: ApiConfig<SecurityDataType> = {}) {
-    this.baseUrl = baseUrl || this.baseUrl;
-    this.baseApiParams = baseApiParams || this.baseApiParams;
-    this.securityWorker = securityWorker || this.securityWorker;
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
   }
 
   public setSecurityData = (data: SecurityDataType) => {
@@ -131,17 +129,22 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<HttpResponse<T>> =>
-    fetch(`${this.baseUrl}${path}`, {
-      // @ts-ignore
-      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+  ): Promise<HttpResponse<T>> => {
+    const requestUrl = `${this.baseUrl}${path}`;
+    const secureOptions =
+      (secureByDefault || secure) && this.securityWorker ? this.securityWorker(this.securityData) : {};
+    const requestOptions = {
+      ...this.mergeRequestOptions(params, secureOptions),
       method,
       body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
-    }).then(async (response) => {
+    };
+
+    return fetch(requestUrl, requestOptions).then(async (response) => {
       const data = await this.safeParseResponse<T, E>(response);
       if (!response.ok) throw data;
       return data;
     });
+  };
 }
 
 /**

--- a/tests/generated/v2.0/petstore.ts
+++ b/tests/generated/v2.0/petstore.ts
@@ -1,6 +1,5 @@
 /* tslint:disable */
 /* eslint-disable */
-
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/generated/v2.0/petstore.ts
+++ b/tests/generated/v2.0/petstore.ts
@@ -46,7 +46,7 @@ enum BodyType {
 class HttpClient<SecurityDataType> {
   public baseUrl: string = "http://petstore.swagger.io/v1";
   private securityData: SecurityDataType = null as any;
-  private securityWorker: ApiConfig<SecurityDataType>["securityWorker"] = (() => {}) as any;
+  private securityWorker: null | ApiConfig<SecurityDataType>["securityWorker"] = null;
 
   private baseApiParams: RequestParams = {
     credentials: "same-origin",
@@ -57,10 +57,8 @@ class HttpClient<SecurityDataType> {
     referrerPolicy: "no-referrer",
   };
 
-  constructor({ baseUrl, baseApiParams, securityWorker }: ApiConfig<SecurityDataType> = {}) {
-    this.baseUrl = baseUrl || this.baseUrl;
-    this.baseApiParams = baseApiParams || this.baseApiParams;
-    this.securityWorker = securityWorker || this.securityWorker;
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
   }
 
   public setSecurityData = (data: SecurityDataType) => {
@@ -132,17 +130,22 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<HttpResponse<T>> =>
-    fetch(`${this.baseUrl}${path}`, {
-      // @ts-ignore
-      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+  ): Promise<HttpResponse<T>> => {
+    const requestUrl = `${this.baseUrl}${path}`;
+    const secureOptions =
+      (secureByDefault || secure) && this.securityWorker ? this.securityWorker(this.securityData) : {};
+    const requestOptions = {
+      ...this.mergeRequestOptions(params, secureOptions),
       method,
       body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
-    }).then(async (response) => {
+    };
+
+    return fetch(requestUrl, requestOptions).then(async (response) => {
       const data = await this.safeParseResponse<T, E>(response);
       if (!response.ok) throw data;
       return data;
     });
+  };
 }
 
 /**

--- a/tests/generated/v2.0/petstore.ts
+++ b/tests/generated/v2.0/petstore.ts
@@ -28,11 +28,16 @@ export type RequestParams = Omit<RequestInit, "body" | "method"> & {
 
 export type RequestQueryParamsType = Record<string | number, any>;
 
-type ApiConfig<SecurityDataType> = {
+interface ApiConfig<SecurityDataType> {
   baseUrl?: string;
   baseApiParams?: RequestParams;
   securityWorker?: (securityData: SecurityDataType) => RequestParams;
-};
+}
+
+interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+  data: D | null;
+  error: E | null;
+}
 
 enum BodyType {
   Json,
@@ -99,11 +104,26 @@ class HttpClient<SecurityDataType> {
     };
   }
 
-  private safeParseResponse = <T = any, E = any>(response: Response): Promise<T> =>
-    response
+  private safeParseResponse = <T = any, E = any>(response: Response): Promise<HttpResponse<T, E>> => {
+    const r = response.clone() as HttpResponse<T, E>;
+    r.data = null;
+    r.error = null;
+
+    return response
       .json()
-      .then((data) => data)
-      .catch((e) => response.text);
+      .then((data) => {
+        if (r.ok) {
+          r.data = data;
+        } else {
+          r.error = data;
+        }
+        return r;
+      })
+      .catch((e) => {
+        r.error = e;
+        return r;
+      });
+  };
 
   public request = <T = any, E = any>(
     path: string,
@@ -112,7 +132,7 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<T> =>
+  ): Promise<HttpResponse<T>> =>
     fetch(`${this.baseUrl}${path}`, {
       // @ts-ignore
       ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),

--- a/tests/generated/v2.0/query-path-param.ts
+++ b/tests/generated/v2.0/query-path-param.ts
@@ -1,6 +1,5 @@
 /* tslint:disable */
 /* eslint-disable */
-
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/generated/v2.0/query-path-param.ts
+++ b/tests/generated/v2.0/query-path-param.ts
@@ -15,11 +15,16 @@ export type RequestParams = Omit<RequestInit, "body" | "method"> & {
 
 export type RequestQueryParamsType = Record<string | number, any>;
 
-type ApiConfig<SecurityDataType> = {
+interface ApiConfig<SecurityDataType> {
   baseUrl?: string;
   baseApiParams?: RequestParams;
   securityWorker?: (securityData: SecurityDataType) => RequestParams;
-};
+}
+
+interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+  data: D | null;
+  error: E | null;
+}
 
 enum BodyType {
   Json,
@@ -86,11 +91,26 @@ class HttpClient<SecurityDataType> {
     };
   }
 
-  private safeParseResponse = <T = any, E = any>(response: Response): Promise<T> =>
-    response
+  private safeParseResponse = <T = any, E = any>(response: Response): Promise<HttpResponse<T, E>> => {
+    const r = response.clone() as HttpResponse<T, E>;
+    r.data = null;
+    r.error = null;
+
+    return response
       .json()
-      .then((data) => data)
-      .catch((e) => response.text);
+      .then((data) => {
+        if (r.ok) {
+          r.data = data;
+        } else {
+          r.error = data;
+        }
+        return r;
+      })
+      .catch((e) => {
+        r.error = e;
+        return r;
+      });
+  };
 
   public request = <T = any, E = any>(
     path: string,
@@ -99,7 +119,7 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<T> =>
+  ): Promise<HttpResponse<T>> =>
     fetch(`${this.baseUrl}${path}`, {
       // @ts-ignore
       ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),

--- a/tests/generated/v2.0/query-path-param.ts
+++ b/tests/generated/v2.0/query-path-param.ts
@@ -33,7 +33,7 @@ enum BodyType {
 class HttpClient<SecurityDataType> {
   public baseUrl: string = "http://unknown.io/v666";
   private securityData: SecurityDataType = null as any;
-  private securityWorker: ApiConfig<SecurityDataType>["securityWorker"] = (() => {}) as any;
+  private securityWorker: null | ApiConfig<SecurityDataType>["securityWorker"] = null;
 
   private baseApiParams: RequestParams = {
     credentials: "same-origin",
@@ -44,10 +44,8 @@ class HttpClient<SecurityDataType> {
     referrerPolicy: "no-referrer",
   };
 
-  constructor({ baseUrl, baseApiParams, securityWorker }: ApiConfig<SecurityDataType> = {}) {
-    this.baseUrl = baseUrl || this.baseUrl;
-    this.baseApiParams = baseApiParams || this.baseApiParams;
-    this.securityWorker = securityWorker || this.securityWorker;
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
   }
 
   public setSecurityData = (data: SecurityDataType) => {
@@ -119,17 +117,22 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<HttpResponse<T>> =>
-    fetch(`${this.baseUrl}${path}`, {
-      // @ts-ignore
-      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+  ): Promise<HttpResponse<T>> => {
+    const requestUrl = `${this.baseUrl}${path}`;
+    const secureOptions =
+      (secureByDefault || secure) && this.securityWorker ? this.securityWorker(this.securityData) : {};
+    const requestOptions = {
+      ...this.mergeRequestOptions(params, secureOptions),
       method,
       body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
-    }).then(async (response) => {
+    };
+
+    return fetch(requestUrl, requestOptions).then(async (response) => {
       const data = await this.safeParseResponse<T, E>(response);
       if (!response.ok) throw data;
       return data;
     });
+  };
 }
 
 /**

--- a/tests/generated/v2.0/uber.ts
+++ b/tests/generated/v2.0/uber.ts
@@ -1,6 +1,5 @@
 /* tslint:disable */
 /* eslint-disable */
-
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/generated/v2.0/uber.ts
+++ b/tests/generated/v2.0/uber.ts
@@ -118,7 +118,7 @@ enum BodyType {
 class HttpClient<SecurityDataType> {
   public baseUrl: string = "https://api.uber.com/v1";
   private securityData: SecurityDataType = null as any;
-  private securityWorker: ApiConfig<SecurityDataType>["securityWorker"] = (() => {}) as any;
+  private securityWorker: null | ApiConfig<SecurityDataType>["securityWorker"] = null;
 
   private baseApiParams: RequestParams = {
     credentials: "same-origin",
@@ -129,10 +129,8 @@ class HttpClient<SecurityDataType> {
     referrerPolicy: "no-referrer",
   };
 
-  constructor({ baseUrl, baseApiParams, securityWorker }: ApiConfig<SecurityDataType> = {}) {
-    this.baseUrl = baseUrl || this.baseUrl;
-    this.baseApiParams = baseApiParams || this.baseApiParams;
-    this.securityWorker = securityWorker || this.securityWorker;
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
   }
 
   public setSecurityData = (data: SecurityDataType) => {
@@ -204,17 +202,22 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<HttpResponse<T>> =>
-    fetch(`${this.baseUrl}${path}`, {
-      // @ts-ignore
-      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+  ): Promise<HttpResponse<T>> => {
+    const requestUrl = `${this.baseUrl}${path}`;
+    const secureOptions =
+      (secureByDefault || secure) && this.securityWorker ? this.securityWorker(this.securityData) : {};
+    const requestOptions = {
+      ...this.mergeRequestOptions(params, secureOptions),
       method,
       body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
-    }).then(async (response) => {
+    };
+
+    return fetch(requestUrl, requestOptions).then(async (response) => {
       const data = await this.safeParseResponse<T, E>(response);
       if (!response.ok) throw data;
       return data;
     });
+  };
 }
 
 /**

--- a/tests/generated/v2.0/uber.ts
+++ b/tests/generated/v2.0/uber.ts
@@ -100,11 +100,16 @@ export type RequestParams = Omit<RequestInit, "body" | "method"> & {
 
 export type RequestQueryParamsType = Record<string | number, any>;
 
-type ApiConfig<SecurityDataType> = {
+interface ApiConfig<SecurityDataType> {
   baseUrl?: string;
   baseApiParams?: RequestParams;
   securityWorker?: (securityData: SecurityDataType) => RequestParams;
-};
+}
+
+interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+  data: D | null;
+  error: E | null;
+}
 
 enum BodyType {
   Json,
@@ -171,11 +176,26 @@ class HttpClient<SecurityDataType> {
     };
   }
 
-  private safeParseResponse = <T = any, E = any>(response: Response): Promise<T> =>
-    response
+  private safeParseResponse = <T = any, E = any>(response: Response): Promise<HttpResponse<T, E>> => {
+    const r = response.clone() as HttpResponse<T, E>;
+    r.data = null;
+    r.error = null;
+
+    return response
       .json()
-      .then((data) => data)
-      .catch((e) => response.text);
+      .then((data) => {
+        if (r.ok) {
+          r.data = data;
+        } else {
+          r.error = data;
+        }
+        return r;
+      })
+      .catch((e) => {
+        r.error = e;
+        return r;
+      });
+  };
 
   public request = <T = any, E = any>(
     path: string,
@@ -184,7 +204,7 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<T> =>
+  ): Promise<HttpResponse<T>> =>
     fetch(`${this.baseUrl}${path}`, {
       // @ts-ignore
       ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),

--- a/tests/generated/v3.0/additional-properties.ts
+++ b/tests/generated/v3.0/additional-properties.ts
@@ -1,6 +1,5 @@
 /* tslint:disable */
 /* eslint-disable */
-
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/generated/v3.0/additional-properties.ts
+++ b/tests/generated/v3.0/additional-properties.ts
@@ -20,11 +20,16 @@ export type RequestParams = Omit<RequestInit, "body" | "method"> & {
   secure?: boolean;
 };
 
-type ApiConfig<SecurityDataType> = {
+interface ApiConfig<SecurityDataType> {
   baseUrl?: string;
   baseApiParams?: RequestParams;
   securityWorker?: (securityData: SecurityDataType) => RequestParams;
-};
+}
+
+interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+  data: D | null;
+  error: E | null;
+}
 
 enum BodyType {
   Json,
@@ -71,11 +76,26 @@ class HttpClient<SecurityDataType> {
     };
   }
 
-  private safeParseResponse = <T = any, E = any>(response: Response): Promise<T> =>
-    response
+  private safeParseResponse = <T = any, E = any>(response: Response): Promise<HttpResponse<T, E>> => {
+    const r = response.clone() as HttpResponse<T, E>;
+    r.data = null;
+    r.error = null;
+
+    return response
       .json()
-      .then((data) => data)
-      .catch((e) => response.text);
+      .then((data) => {
+        if (r.ok) {
+          r.data = data;
+        } else {
+          r.error = data;
+        }
+        return r;
+      })
+      .catch((e) => {
+        r.error = e;
+        return r;
+      });
+  };
 
   public request = <T = any, E = any>(
     path: string,
@@ -84,7 +104,7 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<T> =>
+  ): Promise<HttpResponse<T>> =>
     fetch(`${this.baseUrl}${path}`, {
       // @ts-ignore
       ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),

--- a/tests/generated/v3.0/additional-properties.ts
+++ b/tests/generated/v3.0/additional-properties.ts
@@ -38,7 +38,7 @@ enum BodyType {
 class HttpClient<SecurityDataType> {
   public baseUrl: string = "";
   private securityData: SecurityDataType = null as any;
-  private securityWorker: ApiConfig<SecurityDataType>["securityWorker"] = (() => {}) as any;
+  private securityWorker: null | ApiConfig<SecurityDataType>["securityWorker"] = null;
 
   private baseApiParams: RequestParams = {
     credentials: "same-origin",
@@ -49,10 +49,8 @@ class HttpClient<SecurityDataType> {
     referrerPolicy: "no-referrer",
   };
 
-  constructor({ baseUrl, baseApiParams, securityWorker }: ApiConfig<SecurityDataType> = {}) {
-    this.baseUrl = baseUrl || this.baseUrl;
-    this.baseApiParams = baseApiParams || this.baseApiParams;
-    this.securityWorker = securityWorker || this.securityWorker;
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
   }
 
   public setSecurityData = (data: SecurityDataType) => {
@@ -104,17 +102,22 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<HttpResponse<T>> =>
-    fetch(`${this.baseUrl}${path}`, {
-      // @ts-ignore
-      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+  ): Promise<HttpResponse<T>> => {
+    const requestUrl = `${this.baseUrl}${path}`;
+    const secureOptions =
+      (secureByDefault || secure) && this.securityWorker ? this.securityWorker(this.securityData) : {};
+    const requestOptions = {
+      ...this.mergeRequestOptions(params, secureOptions),
       method,
       body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
-    }).then(async (response) => {
+    };
+
+    return fetch(requestUrl, requestOptions).then(async (response) => {
       const data = await this.safeParseResponse<T, E>(response);
       if (!response.ok) throw data;
       return data;
     });
+  };
 }
 
 /**

--- a/tests/generated/v3.0/additional-properties2.ts
+++ b/tests/generated/v3.0/additional-properties2.ts
@@ -1,6 +1,5 @@
 /* tslint:disable */
 /* eslint-disable */
-
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/generated/v3.0/additional-properties2.ts
+++ b/tests/generated/v3.0/additional-properties2.ts
@@ -35,7 +35,7 @@ enum BodyType {
 class HttpClient<SecurityDataType> {
   public baseUrl: string = "";
   private securityData: SecurityDataType = null as any;
-  private securityWorker: ApiConfig<SecurityDataType>["securityWorker"] = (() => {}) as any;
+  private securityWorker: null | ApiConfig<SecurityDataType>["securityWorker"] = null;
 
   private baseApiParams: RequestParams = {
     credentials: "same-origin",
@@ -46,10 +46,8 @@ class HttpClient<SecurityDataType> {
     referrerPolicy: "no-referrer",
   };
 
-  constructor({ baseUrl, baseApiParams, securityWorker }: ApiConfig<SecurityDataType> = {}) {
-    this.baseUrl = baseUrl || this.baseUrl;
-    this.baseApiParams = baseApiParams || this.baseApiParams;
-    this.securityWorker = securityWorker || this.securityWorker;
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
   }
 
   public setSecurityData = (data: SecurityDataType) => {
@@ -101,17 +99,22 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<HttpResponse<T>> =>
-    fetch(`${this.baseUrl}${path}`, {
-      // @ts-ignore
-      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+  ): Promise<HttpResponse<T>> => {
+    const requestUrl = `${this.baseUrl}${path}`;
+    const secureOptions =
+      (secureByDefault || secure) && this.securityWorker ? this.securityWorker(this.securityData) : {};
+    const requestOptions = {
+      ...this.mergeRequestOptions(params, secureOptions),
       method,
       body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
-    }).then(async (response) => {
+    };
+
+    return fetch(requestUrl, requestOptions).then(async (response) => {
       const data = await this.safeParseResponse<T, E>(response);
       if (!response.ok) throw data;
       return data;
     });
+  };
 }
 
 /**

--- a/tests/generated/v3.0/additional-properties2.ts
+++ b/tests/generated/v3.0/additional-properties2.ts
@@ -17,11 +17,16 @@ export type RequestParams = Omit<RequestInit, "body" | "method"> & {
   secure?: boolean;
 };
 
-type ApiConfig<SecurityDataType> = {
+interface ApiConfig<SecurityDataType> {
   baseUrl?: string;
   baseApiParams?: RequestParams;
   securityWorker?: (securityData: SecurityDataType) => RequestParams;
-};
+}
+
+interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+  data: D | null;
+  error: E | null;
+}
 
 enum BodyType {
   Json,
@@ -68,11 +73,26 @@ class HttpClient<SecurityDataType> {
     };
   }
 
-  private safeParseResponse = <T = any, E = any>(response: Response): Promise<T> =>
-    response
+  private safeParseResponse = <T = any, E = any>(response: Response): Promise<HttpResponse<T, E>> => {
+    const r = response.clone() as HttpResponse<T, E>;
+    r.data = null;
+    r.error = null;
+
+    return response
       .json()
-      .then((data) => data)
-      .catch((e) => response.text);
+      .then((data) => {
+        if (r.ok) {
+          r.data = data;
+        } else {
+          r.error = data;
+        }
+        return r;
+      })
+      .catch((e) => {
+        r.error = e;
+        return r;
+      });
+  };
 
   public request = <T = any, E = any>(
     path: string,
@@ -81,7 +101,7 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<T> =>
+  ): Promise<HttpResponse<T>> =>
     fetch(`${this.baseUrl}${path}`, {
       // @ts-ignore
       ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),

--- a/tests/generated/v3.0/allof-example.ts
+++ b/tests/generated/v3.0/allof-example.ts
@@ -1,6 +1,5 @@
 /* tslint:disable */
 /* eslint-disable */
-
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/generated/v3.0/allof-example.ts
+++ b/tests/generated/v3.0/allof-example.ts
@@ -21,11 +21,16 @@ export type RequestParams = Omit<RequestInit, "body" | "method"> & {
   secure?: boolean;
 };
 
-type ApiConfig<SecurityDataType> = {
+interface ApiConfig<SecurityDataType> {
   baseUrl?: string;
   baseApiParams?: RequestParams;
   securityWorker?: (securityData: SecurityDataType) => RequestParams;
-};
+}
+
+interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+  data: D | null;
+  error: E | null;
+}
 
 enum BodyType {
   Json,
@@ -72,11 +77,26 @@ class HttpClient<SecurityDataType> {
     };
   }
 
-  private safeParseResponse = <T = any, E = any>(response: Response): Promise<T> =>
-    response
+  private safeParseResponse = <T = any, E = any>(response: Response): Promise<HttpResponse<T, E>> => {
+    const r = response.clone() as HttpResponse<T, E>;
+    r.data = null;
+    r.error = null;
+
+    return response
       .json()
-      .then((data) => data)
-      .catch((e) => response.text);
+      .then((data) => {
+        if (r.ok) {
+          r.data = data;
+        } else {
+          r.error = data;
+        }
+        return r;
+      })
+      .catch((e) => {
+        r.error = e;
+        return r;
+      });
+  };
 
   public request = <T = any, E = any>(
     path: string,
@@ -85,7 +105,7 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<T> =>
+  ): Promise<HttpResponse<T>> =>
     fetch(`${this.baseUrl}${path}`, {
       // @ts-ignore
       ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),

--- a/tests/generated/v3.0/allof-example.ts
+++ b/tests/generated/v3.0/allof-example.ts
@@ -39,7 +39,7 @@ enum BodyType {
 class HttpClient<SecurityDataType> {
   public baseUrl: string = "";
   private securityData: SecurityDataType = null as any;
-  private securityWorker: ApiConfig<SecurityDataType>["securityWorker"] = (() => {}) as any;
+  private securityWorker: null | ApiConfig<SecurityDataType>["securityWorker"] = null;
 
   private baseApiParams: RequestParams = {
     credentials: "same-origin",
@@ -50,10 +50,8 @@ class HttpClient<SecurityDataType> {
     referrerPolicy: "no-referrer",
   };
 
-  constructor({ baseUrl, baseApiParams, securityWorker }: ApiConfig<SecurityDataType> = {}) {
-    this.baseUrl = baseUrl || this.baseUrl;
-    this.baseApiParams = baseApiParams || this.baseApiParams;
-    this.securityWorker = securityWorker || this.securityWorker;
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
   }
 
   public setSecurityData = (data: SecurityDataType) => {
@@ -105,17 +103,22 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<HttpResponse<T>> =>
-    fetch(`${this.baseUrl}${path}`, {
-      // @ts-ignore
-      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+  ): Promise<HttpResponse<T>> => {
+    const requestUrl = `${this.baseUrl}${path}`;
+    const secureOptions =
+      (secureByDefault || secure) && this.securityWorker ? this.securityWorker(this.securityData) : {};
+    const requestOptions = {
+      ...this.mergeRequestOptions(params, secureOptions),
       method,
       body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
-    }).then(async (response) => {
+    };
+
+    return fetch(requestUrl, requestOptions).then(async (response) => {
       const data = await this.safeParseResponse<T, E>(response);
       if (!response.ok) throw data;
       return data;
     });
+  };
 }
 
 /**

--- a/tests/generated/v3.0/anyof-example.ts
+++ b/tests/generated/v3.0/anyof-example.ts
@@ -1,6 +1,5 @@
 /* tslint:disable */
 /* eslint-disable */
-
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/generated/v3.0/anyof-example.ts
+++ b/tests/generated/v3.0/anyof-example.ts
@@ -41,7 +41,7 @@ enum BodyType {
 class HttpClient<SecurityDataType> {
   public baseUrl: string = "";
   private securityData: SecurityDataType = null as any;
-  private securityWorker: ApiConfig<SecurityDataType>["securityWorker"] = (() => {}) as any;
+  private securityWorker: null | ApiConfig<SecurityDataType>["securityWorker"] = null;
 
   private baseApiParams: RequestParams = {
     credentials: "same-origin",
@@ -52,10 +52,8 @@ class HttpClient<SecurityDataType> {
     referrerPolicy: "no-referrer",
   };
 
-  constructor({ baseUrl, baseApiParams, securityWorker }: ApiConfig<SecurityDataType> = {}) {
-    this.baseUrl = baseUrl || this.baseUrl;
-    this.baseApiParams = baseApiParams || this.baseApiParams;
-    this.securityWorker = securityWorker || this.securityWorker;
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
   }
 
   public setSecurityData = (data: SecurityDataType) => {
@@ -107,17 +105,22 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<HttpResponse<T>> =>
-    fetch(`${this.baseUrl}${path}`, {
-      // @ts-ignore
-      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+  ): Promise<HttpResponse<T>> => {
+    const requestUrl = `${this.baseUrl}${path}`;
+    const secureOptions =
+      (secureByDefault || secure) && this.securityWorker ? this.securityWorker(this.securityData) : {};
+    const requestOptions = {
+      ...this.mergeRequestOptions(params, secureOptions),
       method,
       body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
-    }).then(async (response) => {
+    };
+
+    return fetch(requestUrl, requestOptions).then(async (response) => {
       const data = await this.safeParseResponse<T, E>(response);
       if (!response.ok) throw data;
       return data;
     });
+  };
 }
 
 /**

--- a/tests/generated/v3.0/anyof-example.ts
+++ b/tests/generated/v3.0/anyof-example.ts
@@ -23,11 +23,16 @@ export type RequestParams = Omit<RequestInit, "body" | "method"> & {
   secure?: boolean;
 };
 
-type ApiConfig<SecurityDataType> = {
+interface ApiConfig<SecurityDataType> {
   baseUrl?: string;
   baseApiParams?: RequestParams;
   securityWorker?: (securityData: SecurityDataType) => RequestParams;
-};
+}
+
+interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+  data: D | null;
+  error: E | null;
+}
 
 enum BodyType {
   Json,
@@ -74,11 +79,26 @@ class HttpClient<SecurityDataType> {
     };
   }
 
-  private safeParseResponse = <T = any, E = any>(response: Response): Promise<T> =>
-    response
+  private safeParseResponse = <T = any, E = any>(response: Response): Promise<HttpResponse<T, E>> => {
+    const r = response.clone() as HttpResponse<T, E>;
+    r.data = null;
+    r.error = null;
+
+    return response
       .json()
-      .then((data) => data)
-      .catch((e) => response.text);
+      .then((data) => {
+        if (r.ok) {
+          r.data = data;
+        } else {
+          r.error = data;
+        }
+        return r;
+      })
+      .catch((e) => {
+        r.error = e;
+        return r;
+      });
+  };
 
   public request = <T = any, E = any>(
     path: string,
@@ -87,7 +107,7 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<T> =>
+  ): Promise<HttpResponse<T>> =>
     fetch(`${this.baseUrl}${path}`, {
       // @ts-ignore
       ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),

--- a/tests/generated/v3.0/api-with-examples.ts
+++ b/tests/generated/v3.0/api-with-examples.ts
@@ -1,6 +1,5 @@
 /* tslint:disable */
 /* eslint-disable */
-
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/generated/v3.0/api-with-examples.ts
+++ b/tests/generated/v3.0/api-with-examples.ts
@@ -13,11 +13,16 @@ export type RequestParams = Omit<RequestInit, "body" | "method"> & {
   secure?: boolean;
 };
 
-type ApiConfig<SecurityDataType> = {
+interface ApiConfig<SecurityDataType> {
   baseUrl?: string;
   baseApiParams?: RequestParams;
   securityWorker?: (securityData: SecurityDataType) => RequestParams;
-};
+}
+
+interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+  data: D | null;
+  error: E | null;
+}
 
 enum BodyType {
   Json,
@@ -64,11 +69,26 @@ class HttpClient<SecurityDataType> {
     };
   }
 
-  private safeParseResponse = <T = any, E = any>(response: Response): Promise<T> =>
-    response
+  private safeParseResponse = <T = any, E = any>(response: Response): Promise<HttpResponse<T, E>> => {
+    const r = response.clone() as HttpResponse<T, E>;
+    r.data = null;
+    r.error = null;
+
+    return response
       .json()
-      .then((data) => data)
-      .catch((e) => response.text);
+      .then((data) => {
+        if (r.ok) {
+          r.data = data;
+        } else {
+          r.error = data;
+        }
+        return r;
+      })
+      .catch((e) => {
+        r.error = e;
+        return r;
+      });
+  };
 
   public request = <T = any, E = any>(
     path: string,
@@ -77,7 +97,7 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<T> =>
+  ): Promise<HttpResponse<T>> =>
     fetch(`${this.baseUrl}${path}`, {
       // @ts-ignore
       ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),

--- a/tests/generated/v3.0/api-with-examples.ts
+++ b/tests/generated/v3.0/api-with-examples.ts
@@ -31,7 +31,7 @@ enum BodyType {
 class HttpClient<SecurityDataType> {
   public baseUrl: string = "";
   private securityData: SecurityDataType = null as any;
-  private securityWorker: ApiConfig<SecurityDataType>["securityWorker"] = (() => {}) as any;
+  private securityWorker: null | ApiConfig<SecurityDataType>["securityWorker"] = null;
 
   private baseApiParams: RequestParams = {
     credentials: "same-origin",
@@ -42,10 +42,8 @@ class HttpClient<SecurityDataType> {
     referrerPolicy: "no-referrer",
   };
 
-  constructor({ baseUrl, baseApiParams, securityWorker }: ApiConfig<SecurityDataType> = {}) {
-    this.baseUrl = baseUrl || this.baseUrl;
-    this.baseApiParams = baseApiParams || this.baseApiParams;
-    this.securityWorker = securityWorker || this.securityWorker;
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
   }
 
   public setSecurityData = (data: SecurityDataType) => {
@@ -97,17 +95,22 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<HttpResponse<T>> =>
-    fetch(`${this.baseUrl}${path}`, {
-      // @ts-ignore
-      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+  ): Promise<HttpResponse<T>> => {
+    const requestUrl = `${this.baseUrl}${path}`;
+    const secureOptions =
+      (secureByDefault || secure) && this.securityWorker ? this.securityWorker(this.securityData) : {};
+    const requestOptions = {
+      ...this.mergeRequestOptions(params, secureOptions),
       method,
       body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
-    }).then(async (response) => {
+    };
+
+    return fetch(requestUrl, requestOptions).then(async (response) => {
       const data = await this.safeParseResponse<T, E>(response);
       if (!response.ok) throw data;
       return data;
     });
+  };
 }
 
 /**

--- a/tests/generated/v3.0/callback-example.ts
+++ b/tests/generated/v3.0/callback-example.ts
@@ -1,6 +1,5 @@
 /* tslint:disable */
 /* eslint-disable */
-
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/generated/v3.0/callback-example.ts
+++ b/tests/generated/v3.0/callback-example.ts
@@ -15,11 +15,16 @@ export type RequestParams = Omit<RequestInit, "body" | "method"> & {
 
 export type RequestQueryParamsType = Record<string | number, any>;
 
-type ApiConfig<SecurityDataType> = {
+interface ApiConfig<SecurityDataType> {
   baseUrl?: string;
   baseApiParams?: RequestParams;
   securityWorker?: (securityData: SecurityDataType) => RequestParams;
-};
+}
+
+interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+  data: D | null;
+  error: E | null;
+}
 
 enum BodyType {
   Json,
@@ -86,11 +91,26 @@ class HttpClient<SecurityDataType> {
     };
   }
 
-  private safeParseResponse = <T = any, E = any>(response: Response): Promise<T> =>
-    response
+  private safeParseResponse = <T = any, E = any>(response: Response): Promise<HttpResponse<T, E>> => {
+    const r = response.clone() as HttpResponse<T, E>;
+    r.data = null;
+    r.error = null;
+
+    return response
       .json()
-      .then((data) => data)
-      .catch((e) => response.text);
+      .then((data) => {
+        if (r.ok) {
+          r.data = data;
+        } else {
+          r.error = data;
+        }
+        return r;
+      })
+      .catch((e) => {
+        r.error = e;
+        return r;
+      });
+  };
 
   public request = <T = any, E = any>(
     path: string,
@@ -99,7 +119,7 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<T> =>
+  ): Promise<HttpResponse<T>> =>
     fetch(`${this.baseUrl}${path}`, {
       // @ts-ignore
       ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),

--- a/tests/generated/v3.0/callback-example.ts
+++ b/tests/generated/v3.0/callback-example.ts
@@ -33,7 +33,7 @@ enum BodyType {
 class HttpClient<SecurityDataType> {
   public baseUrl: string = "";
   private securityData: SecurityDataType = null as any;
-  private securityWorker: ApiConfig<SecurityDataType>["securityWorker"] = (() => {}) as any;
+  private securityWorker: null | ApiConfig<SecurityDataType>["securityWorker"] = null;
 
   private baseApiParams: RequestParams = {
     credentials: "same-origin",
@@ -44,10 +44,8 @@ class HttpClient<SecurityDataType> {
     referrerPolicy: "no-referrer",
   };
 
-  constructor({ baseUrl, baseApiParams, securityWorker }: ApiConfig<SecurityDataType> = {}) {
-    this.baseUrl = baseUrl || this.baseUrl;
-    this.baseApiParams = baseApiParams || this.baseApiParams;
-    this.securityWorker = securityWorker || this.securityWorker;
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
   }
 
   public setSecurityData = (data: SecurityDataType) => {
@@ -119,17 +117,22 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<HttpResponse<T>> =>
-    fetch(`${this.baseUrl}${path}`, {
-      // @ts-ignore
-      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+  ): Promise<HttpResponse<T>> => {
+    const requestUrl = `${this.baseUrl}${path}`;
+    const secureOptions =
+      (secureByDefault || secure) && this.securityWorker ? this.securityWorker(this.securityData) : {};
+    const requestOptions = {
+      ...this.mergeRequestOptions(params, secureOptions),
       method,
       body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
-    }).then(async (response) => {
+    };
+
+    return fetch(requestUrl, requestOptions).then(async (response) => {
       const data = await this.safeParseResponse<T, E>(response);
       if (!response.ok) throw data;
       return data;
     });
+  };
 }
 
 /**

--- a/tests/generated/v3.0/components-responses.ts
+++ b/tests/generated/v3.0/components-responses.ts
@@ -1,6 +1,5 @@
 /* tslint:disable */
 /* eslint-disable */
-
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/generated/v3.0/components-responses.ts
+++ b/tests/generated/v3.0/components-responses.ts
@@ -13,11 +13,16 @@ export type RequestParams = Omit<RequestInit, "body" | "method"> & {
   secure?: boolean;
 };
 
-type ApiConfig<SecurityDataType> = {
+interface ApiConfig<SecurityDataType> {
   baseUrl?: string;
   baseApiParams?: RequestParams;
   securityWorker?: (securityData: SecurityDataType) => RequestParams;
-};
+}
+
+interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+  data: D | null;
+  error: E | null;
+}
 
 enum BodyType {
   Json,
@@ -64,11 +69,26 @@ class HttpClient<SecurityDataType> {
     };
   }
 
-  private safeParseResponse = <T = any, E = any>(response: Response): Promise<T> =>
-    response
+  private safeParseResponse = <T = any, E = any>(response: Response): Promise<HttpResponse<T, E>> => {
+    const r = response.clone() as HttpResponse<T, E>;
+    r.data = null;
+    r.error = null;
+
+    return response
       .json()
-      .then((data) => data)
-      .catch((e) => response.text);
+      .then((data) => {
+        if (r.ok) {
+          r.data = data;
+        } else {
+          r.error = data;
+        }
+        return r;
+      })
+      .catch((e) => {
+        r.error = e;
+        return r;
+      });
+  };
 
   public request = <T = any, E = any>(
     path: string,
@@ -77,7 +97,7 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<T> =>
+  ): Promise<HttpResponse<T>> =>
     fetch(`${this.baseUrl}${path}`, {
       // @ts-ignore
       ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),

--- a/tests/generated/v3.0/components-responses.ts
+++ b/tests/generated/v3.0/components-responses.ts
@@ -31,7 +31,7 @@ enum BodyType {
 class HttpClient<SecurityDataType> {
   public baseUrl: string = "";
   private securityData: SecurityDataType = null as any;
-  private securityWorker: ApiConfig<SecurityDataType>["securityWorker"] = (() => {}) as any;
+  private securityWorker: null | ApiConfig<SecurityDataType>["securityWorker"] = null;
 
   private baseApiParams: RequestParams = {
     credentials: "same-origin",
@@ -42,10 +42,8 @@ class HttpClient<SecurityDataType> {
     referrerPolicy: "no-referrer",
   };
 
-  constructor({ baseUrl, baseApiParams, securityWorker }: ApiConfig<SecurityDataType> = {}) {
-    this.baseUrl = baseUrl || this.baseUrl;
-    this.baseApiParams = baseApiParams || this.baseApiParams;
-    this.securityWorker = securityWorker || this.securityWorker;
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
   }
 
   public setSecurityData = (data: SecurityDataType) => {
@@ -97,17 +95,22 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<HttpResponse<T>> =>
-    fetch(`${this.baseUrl}${path}`, {
-      // @ts-ignore
-      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+  ): Promise<HttpResponse<T>> => {
+    const requestUrl = `${this.baseUrl}${path}`;
+    const secureOptions =
+      (secureByDefault || secure) && this.securityWorker ? this.securityWorker(this.securityData) : {};
+    const requestOptions = {
+      ...this.mergeRequestOptions(params, secureOptions),
       method,
       body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
-    }).then(async (response) => {
+    };
+
+    return fetch(requestUrl, requestOptions).then(async (response) => {
       const data = await this.safeParseResponse<T, E>(response);
       if (!response.ok) throw data;
       return data;
     });
+  };
 }
 
 /**

--- a/tests/generated/v3.0/explode-param-3.0.1.ts
+++ b/tests/generated/v3.0/explode-param-3.0.1.ts
@@ -1,6 +1,5 @@
 /* tslint:disable */
 /* eslint-disable */
-
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/generated/v3.0/explode-param-3.0.1.ts
+++ b/tests/generated/v3.0/explode-param-3.0.1.ts
@@ -23,11 +23,16 @@ export type RequestParams = Omit<RequestInit, "body" | "method"> & {
 
 export type RequestQueryParamsType = Record<string | number, any>;
 
-type ApiConfig<SecurityDataType> = {
+interface ApiConfig<SecurityDataType> {
   baseUrl?: string;
   baseApiParams?: RequestParams;
   securityWorker?: (securityData: SecurityDataType) => RequestParams;
-};
+}
+
+interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+  data: D | null;
+  error: E | null;
+}
 
 enum BodyType {
   Json,
@@ -94,11 +99,26 @@ class HttpClient<SecurityDataType> {
     };
   }
 
-  private safeParseResponse = <T = any, E = any>(response: Response): Promise<T> =>
-    response
+  private safeParseResponse = <T = any, E = any>(response: Response): Promise<HttpResponse<T, E>> => {
+    const r = response.clone() as HttpResponse<T, E>;
+    r.data = null;
+    r.error = null;
+
+    return response
       .json()
-      .then((data) => data)
-      .catch((e) => response.text);
+      .then((data) => {
+        if (r.ok) {
+          r.data = data;
+        } else {
+          r.error = data;
+        }
+        return r;
+      })
+      .catch((e) => {
+        r.error = e;
+        return r;
+      });
+  };
 
   public request = <T = any, E = any>(
     path: string,
@@ -107,7 +127,7 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<T> =>
+  ): Promise<HttpResponse<T>> =>
     fetch(`${this.baseUrl}${path}`, {
       // @ts-ignore
       ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),

--- a/tests/generated/v3.0/explode-param-3.0.1.ts
+++ b/tests/generated/v3.0/explode-param-3.0.1.ts
@@ -41,7 +41,7 @@ enum BodyType {
 class HttpClient<SecurityDataType> {
   public baseUrl: string = "";
   private securityData: SecurityDataType = null as any;
-  private securityWorker: ApiConfig<SecurityDataType>["securityWorker"] = (() => {}) as any;
+  private securityWorker: null | ApiConfig<SecurityDataType>["securityWorker"] = null;
 
   private baseApiParams: RequestParams = {
     credentials: "same-origin",
@@ -52,10 +52,8 @@ class HttpClient<SecurityDataType> {
     referrerPolicy: "no-referrer",
   };
 
-  constructor({ baseUrl, baseApiParams, securityWorker }: ApiConfig<SecurityDataType> = {}) {
-    this.baseUrl = baseUrl || this.baseUrl;
-    this.baseApiParams = baseApiParams || this.baseApiParams;
-    this.securityWorker = securityWorker || this.securityWorker;
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
   }
 
   public setSecurityData = (data: SecurityDataType) => {
@@ -127,17 +125,22 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<HttpResponse<T>> =>
-    fetch(`${this.baseUrl}${path}`, {
-      // @ts-ignore
-      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+  ): Promise<HttpResponse<T>> => {
+    const requestUrl = `${this.baseUrl}${path}`;
+    const secureOptions =
+      (secureByDefault || secure) && this.securityWorker ? this.securityWorker(this.securityData) : {};
+    const requestOptions = {
+      ...this.mergeRequestOptions(params, secureOptions),
       method,
       body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
-    }).then(async (response) => {
+    };
+
+    return fetch(requestUrl, requestOptions).then(async (response) => {
       const data = await this.safeParseResponse<T, E>(response);
       if (!response.ok) throw data;
       return data;
     });
+  };
 }
 
 /**

--- a/tests/generated/v3.0/link-example.ts
+++ b/tests/generated/v3.0/link-example.ts
@@ -1,6 +1,5 @@
 /* tslint:disable */
 /* eslint-disable */
-
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/generated/v3.0/link-example.ts
+++ b/tests/generated/v3.0/link-example.ts
@@ -32,11 +32,16 @@ export type RequestParams = Omit<RequestInit, "body" | "method"> & {
 
 export type RequestQueryParamsType = Record<string | number, any>;
 
-type ApiConfig<SecurityDataType> = {
+interface ApiConfig<SecurityDataType> {
   baseUrl?: string;
   baseApiParams?: RequestParams;
   securityWorker?: (securityData: SecurityDataType) => RequestParams;
-};
+}
+
+interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+  data: D | null;
+  error: E | null;
+}
 
 enum BodyType {
   Json,
@@ -103,11 +108,26 @@ class HttpClient<SecurityDataType> {
     };
   }
 
-  private safeParseResponse = <T = any, E = any>(response: Response): Promise<T> =>
-    response
+  private safeParseResponse = <T = any, E = any>(response: Response): Promise<HttpResponse<T, E>> => {
+    const r = response.clone() as HttpResponse<T, E>;
+    r.data = null;
+    r.error = null;
+
+    return response
       .json()
-      .then((data) => data)
-      .catch((e) => response.text);
+      .then((data) => {
+        if (r.ok) {
+          r.data = data;
+        } else {
+          r.error = data;
+        }
+        return r;
+      })
+      .catch((e) => {
+        r.error = e;
+        return r;
+      });
+  };
 
   public request = <T = any, E = any>(
     path: string,
@@ -116,7 +136,7 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<T> =>
+  ): Promise<HttpResponse<T>> =>
     fetch(`${this.baseUrl}${path}`, {
       // @ts-ignore
       ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),

--- a/tests/generated/v3.0/link-example.ts
+++ b/tests/generated/v3.0/link-example.ts
@@ -50,7 +50,7 @@ enum BodyType {
 class HttpClient<SecurityDataType> {
   public baseUrl: string = "";
   private securityData: SecurityDataType = null as any;
-  private securityWorker: ApiConfig<SecurityDataType>["securityWorker"] = (() => {}) as any;
+  private securityWorker: null | ApiConfig<SecurityDataType>["securityWorker"] = null;
 
   private baseApiParams: RequestParams = {
     credentials: "same-origin",
@@ -61,10 +61,8 @@ class HttpClient<SecurityDataType> {
     referrerPolicy: "no-referrer",
   };
 
-  constructor({ baseUrl, baseApiParams, securityWorker }: ApiConfig<SecurityDataType> = {}) {
-    this.baseUrl = baseUrl || this.baseUrl;
-    this.baseApiParams = baseApiParams || this.baseApiParams;
-    this.securityWorker = securityWorker || this.securityWorker;
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
   }
 
   public setSecurityData = (data: SecurityDataType) => {
@@ -136,17 +134,22 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<HttpResponse<T>> =>
-    fetch(`${this.baseUrl}${path}`, {
-      // @ts-ignore
-      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+  ): Promise<HttpResponse<T>> => {
+    const requestUrl = `${this.baseUrl}${path}`;
+    const secureOptions =
+      (secureByDefault || secure) && this.securityWorker ? this.securityWorker(this.securityData) : {};
+    const requestOptions = {
+      ...this.mergeRequestOptions(params, secureOptions),
       method,
       body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
-    }).then(async (response) => {
+    };
+
+    return fetch(requestUrl, requestOptions).then(async (response) => {
       const data = await this.safeParseResponse<T, E>(response);
       if (!response.ok) throw data;
       return data;
     });
+  };
 }
 
 /**

--- a/tests/generated/v3.0/no-definitions-schema.ts
+++ b/tests/generated/v3.0/no-definitions-schema.ts
@@ -1,6 +1,5 @@
 /* tslint:disable */
 /* eslint-disable */
-
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/generated/v3.0/no-definitions-schema.ts
+++ b/tests/generated/v3.0/no-definitions-schema.ts
@@ -20,11 +20,16 @@ export type RequestParams = Omit<RequestInit, "body" | "method"> & {
   secure?: boolean;
 };
 
-type ApiConfig<SecurityDataType> = {
+interface ApiConfig<SecurityDataType> {
   baseUrl?: string;
   baseApiParams?: RequestParams;
   securityWorker?: (securityData: SecurityDataType) => RequestParams;
-};
+}
+
+interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+  data: D | null;
+  error: E | null;
+}
 
 enum BodyType {
   Json,
@@ -71,11 +76,26 @@ class HttpClient<SecurityDataType> {
     };
   }
 
-  private safeParseResponse = <T = any, E = any>(response: Response): Promise<T> =>
-    response
+  private safeParseResponse = <T = any, E = any>(response: Response): Promise<HttpResponse<T, E>> => {
+    const r = response.clone() as HttpResponse<T, E>;
+    r.data = null;
+    r.error = null;
+
+    return response
       .json()
-      .then((data) => data)
-      .catch((e) => response.text);
+      .then((data) => {
+        if (r.ok) {
+          r.data = data;
+        } else {
+          r.error = data;
+        }
+        return r;
+      })
+      .catch((e) => {
+        r.error = e;
+        return r;
+      });
+  };
 
   public request = <T = any, E = any>(
     path: string,
@@ -84,7 +104,7 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<T> =>
+  ): Promise<HttpResponse<T>> =>
     fetch(`${this.baseUrl}${path}`, {
       // @ts-ignore
       ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),

--- a/tests/generated/v3.0/no-definitions-schema.ts
+++ b/tests/generated/v3.0/no-definitions-schema.ts
@@ -38,7 +38,7 @@ enum BodyType {
 class HttpClient<SecurityDataType> {
   public baseUrl: string = "";
   private securityData: SecurityDataType = null as any;
-  private securityWorker: ApiConfig<SecurityDataType>["securityWorker"] = (() => {}) as any;
+  private securityWorker: null | ApiConfig<SecurityDataType>["securityWorker"] = null;
 
   private baseApiParams: RequestParams = {
     credentials: "same-origin",
@@ -49,10 +49,8 @@ class HttpClient<SecurityDataType> {
     referrerPolicy: "no-referrer",
   };
 
-  constructor({ baseUrl, baseApiParams, securityWorker }: ApiConfig<SecurityDataType> = {}) {
-    this.baseUrl = baseUrl || this.baseUrl;
-    this.baseApiParams = baseApiParams || this.baseApiParams;
-    this.securityWorker = securityWorker || this.securityWorker;
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
   }
 
   public setSecurityData = (data: SecurityDataType) => {
@@ -104,17 +102,22 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<HttpResponse<T>> =>
-    fetch(`${this.baseUrl}${path}`, {
-      // @ts-ignore
-      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+  ): Promise<HttpResponse<T>> => {
+    const requestUrl = `${this.baseUrl}${path}`;
+    const secureOptions =
+      (secureByDefault || secure) && this.securityWorker ? this.securityWorker(this.securityData) : {};
+    const requestOptions = {
+      ...this.mergeRequestOptions(params, secureOptions),
       method,
       body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
-    }).then(async (response) => {
+    };
+
+    return fetch(requestUrl, requestOptions).then(async (response) => {
       const data = await this.safeParseResponse<T, E>(response);
       if (!response.ok) throw data;
       return data;
     });
+  };
 }
 
 /**

--- a/tests/generated/v3.0/nullable-refs.ts
+++ b/tests/generated/v3.0/nullable-refs.ts
@@ -1,6 +1,5 @@
 /* tslint:disable */
 /* eslint-disable */
-
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/generated/v3.0/nullable-refs.ts
+++ b/tests/generated/v3.0/nullable-refs.ts
@@ -27,11 +27,16 @@ export type RequestParams = Omit<RequestInit, "body" | "method"> & {
   secure?: boolean;
 };
 
-type ApiConfig<SecurityDataType> = {
+interface ApiConfig<SecurityDataType> {
   baseUrl?: string;
   baseApiParams?: RequestParams;
   securityWorker?: (securityData: SecurityDataType) => RequestParams;
-};
+}
+
+interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+  data: D | null;
+  error: E | null;
+}
 
 enum BodyType {
   Json,
@@ -78,11 +83,26 @@ class HttpClient<SecurityDataType> {
     };
   }
 
-  private safeParseResponse = <T = any, E = any>(response: Response): Promise<T> =>
-    response
+  private safeParseResponse = <T = any, E = any>(response: Response): Promise<HttpResponse<T, E>> => {
+    const r = response.clone() as HttpResponse<T, E>;
+    r.data = null;
+    r.error = null;
+
+    return response
       .json()
-      .then((data) => data)
-      .catch((e) => response.text);
+      .then((data) => {
+        if (r.ok) {
+          r.data = data;
+        } else {
+          r.error = data;
+        }
+        return r;
+      })
+      .catch((e) => {
+        r.error = e;
+        return r;
+      });
+  };
 
   public request = <T = any, E = any>(
     path: string,
@@ -91,7 +111,7 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<T> =>
+  ): Promise<HttpResponse<T>> =>
     fetch(`${this.baseUrl}${path}`, {
       // @ts-ignore
       ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),

--- a/tests/generated/v3.0/nullable-refs.ts
+++ b/tests/generated/v3.0/nullable-refs.ts
@@ -45,7 +45,7 @@ enum BodyType {
 class HttpClient<SecurityDataType> {
   public baseUrl: string = "";
   private securityData: SecurityDataType = null as any;
-  private securityWorker: ApiConfig<SecurityDataType>["securityWorker"] = (() => {}) as any;
+  private securityWorker: null | ApiConfig<SecurityDataType>["securityWorker"] = null;
 
   private baseApiParams: RequestParams = {
     credentials: "same-origin",
@@ -56,10 +56,8 @@ class HttpClient<SecurityDataType> {
     referrerPolicy: "no-referrer",
   };
 
-  constructor({ baseUrl, baseApiParams, securityWorker }: ApiConfig<SecurityDataType> = {}) {
-    this.baseUrl = baseUrl || this.baseUrl;
-    this.baseApiParams = baseApiParams || this.baseApiParams;
-    this.securityWorker = securityWorker || this.securityWorker;
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
   }
 
   public setSecurityData = (data: SecurityDataType) => {
@@ -111,17 +109,22 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<HttpResponse<T>> =>
-    fetch(`${this.baseUrl}${path}`, {
-      // @ts-ignore
-      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+  ): Promise<HttpResponse<T>> => {
+    const requestUrl = `${this.baseUrl}${path}`;
+    const secureOptions =
+      (secureByDefault || secure) && this.securityWorker ? this.securityWorker(this.securityData) : {};
+    const requestOptions = {
+      ...this.mergeRequestOptions(params, secureOptions),
       method,
       body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
-    }).then(async (response) => {
+    };
+
+    return fetch(requestUrl, requestOptions).then(async (response) => {
       const data = await this.safeParseResponse<T, E>(response);
       if (!response.ok) throw data;
       return data;
     });
+  };
 }
 
 /**

--- a/tests/generated/v3.0/oneof-example.ts
+++ b/tests/generated/v3.0/oneof-example.ts
@@ -1,6 +1,5 @@
 /* tslint:disable */
 /* eslint-disable */
-
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/generated/v3.0/oneof-example.ts
+++ b/tests/generated/v3.0/oneof-example.ts
@@ -41,7 +41,7 @@ enum BodyType {
 class HttpClient<SecurityDataType> {
   public baseUrl: string = "";
   private securityData: SecurityDataType = null as any;
-  private securityWorker: ApiConfig<SecurityDataType>["securityWorker"] = (() => {}) as any;
+  private securityWorker: null | ApiConfig<SecurityDataType>["securityWorker"] = null;
 
   private baseApiParams: RequestParams = {
     credentials: "same-origin",
@@ -52,10 +52,8 @@ class HttpClient<SecurityDataType> {
     referrerPolicy: "no-referrer",
   };
 
-  constructor({ baseUrl, baseApiParams, securityWorker }: ApiConfig<SecurityDataType> = {}) {
-    this.baseUrl = baseUrl || this.baseUrl;
-    this.baseApiParams = baseApiParams || this.baseApiParams;
-    this.securityWorker = securityWorker || this.securityWorker;
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
   }
 
   public setSecurityData = (data: SecurityDataType) => {
@@ -107,17 +105,22 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<HttpResponse<T>> =>
-    fetch(`${this.baseUrl}${path}`, {
-      // @ts-ignore
-      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+  ): Promise<HttpResponse<T>> => {
+    const requestUrl = `${this.baseUrl}${path}`;
+    const secureOptions =
+      (secureByDefault || secure) && this.securityWorker ? this.securityWorker(this.securityData) : {};
+    const requestOptions = {
+      ...this.mergeRequestOptions(params, secureOptions),
       method,
       body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
-    }).then(async (response) => {
+    };
+
+    return fetch(requestUrl, requestOptions).then(async (response) => {
       const data = await this.safeParseResponse<T, E>(response);
       if (!response.ok) throw data;
       return data;
     });
+  };
 }
 
 /**

--- a/tests/generated/v3.0/oneof-example.ts
+++ b/tests/generated/v3.0/oneof-example.ts
@@ -23,11 +23,16 @@ export type RequestParams = Omit<RequestInit, "body" | "method"> & {
   secure?: boolean;
 };
 
-type ApiConfig<SecurityDataType> = {
+interface ApiConfig<SecurityDataType> {
   baseUrl?: string;
   baseApiParams?: RequestParams;
   securityWorker?: (securityData: SecurityDataType) => RequestParams;
-};
+}
+
+interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+  data: D | null;
+  error: E | null;
+}
 
 enum BodyType {
   Json,
@@ -74,11 +79,26 @@ class HttpClient<SecurityDataType> {
     };
   }
 
-  private safeParseResponse = <T = any, E = any>(response: Response): Promise<T> =>
-    response
+  private safeParseResponse = <T = any, E = any>(response: Response): Promise<HttpResponse<T, E>> => {
+    const r = response.clone() as HttpResponse<T, E>;
+    r.data = null;
+    r.error = null;
+
+    return response
       .json()
-      .then((data) => data)
-      .catch((e) => response.text);
+      .then((data) => {
+        if (r.ok) {
+          r.data = data;
+        } else {
+          r.error = data;
+        }
+        return r;
+      })
+      .catch((e) => {
+        r.error = e;
+        return r;
+      });
+  };
 
   public request = <T = any, E = any>(
     path: string,
@@ -87,7 +107,7 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<T> =>
+  ): Promise<HttpResponse<T>> =>
     fetch(`${this.baseUrl}${path}`, {
       // @ts-ignore
       ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),

--- a/tests/generated/v3.0/personal-api-example.ts
+++ b/tests/generated/v3.0/personal-api-example.ts
@@ -1,6 +1,5 @@
 /* tslint:disable */
 /* eslint-disable */
-
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/generated/v3.0/personal-api-example.ts
+++ b/tests/generated/v3.0/personal-api-example.ts
@@ -151,11 +151,16 @@ export type RequestParams = Omit<RequestInit, "body" | "method"> & {
   secure?: boolean;
 };
 
-type ApiConfig<SecurityDataType> = {
+interface ApiConfig<SecurityDataType> {
   baseUrl?: string;
   baseApiParams?: RequestParams;
   securityWorker?: (securityData: SecurityDataType) => RequestParams;
-};
+}
+
+interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+  data: D | null;
+  error: E | null;
+}
 
 enum BodyType {
   Json,
@@ -202,11 +207,26 @@ class HttpClient<SecurityDataType> {
     };
   }
 
-  private safeParseResponse = <T = any, E = any>(response: Response): Promise<T> =>
-    response
+  private safeParseResponse = <T = any, E = any>(response: Response): Promise<HttpResponse<T, E>> => {
+    const r = response.clone() as HttpResponse<T, E>;
+    r.data = null;
+    r.error = null;
+
+    return response
       .json()
-      .then((data) => data)
-      .catch((e) => response.text);
+      .then((data) => {
+        if (r.ok) {
+          r.data = data;
+        } else {
+          r.error = data;
+        }
+        return r;
+      })
+      .catch((e) => {
+        r.error = e;
+        return r;
+      });
+  };
 
   public request = <T = any, E = any>(
     path: string,
@@ -215,7 +235,7 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<T> =>
+  ): Promise<HttpResponse<T>> =>
     fetch(`${this.baseUrl}${path}`, {
       // @ts-ignore
       ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),

--- a/tests/generated/v3.0/personal-api-example.ts
+++ b/tests/generated/v3.0/personal-api-example.ts
@@ -169,7 +169,7 @@ enum BodyType {
 class HttpClient<SecurityDataType> {
   public baseUrl: string = "http://localhost:8080/api/v1";
   private securityData: SecurityDataType = null as any;
-  private securityWorker: ApiConfig<SecurityDataType>["securityWorker"] = (() => {}) as any;
+  private securityWorker: null | ApiConfig<SecurityDataType>["securityWorker"] = null;
 
   private baseApiParams: RequestParams = {
     credentials: "same-origin",
@@ -180,10 +180,8 @@ class HttpClient<SecurityDataType> {
     referrerPolicy: "no-referrer",
   };
 
-  constructor({ baseUrl, baseApiParams, securityWorker }: ApiConfig<SecurityDataType> = {}) {
-    this.baseUrl = baseUrl || this.baseUrl;
-    this.baseApiParams = baseApiParams || this.baseApiParams;
-    this.securityWorker = securityWorker || this.securityWorker;
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
   }
 
   public setSecurityData = (data: SecurityDataType) => {
@@ -235,17 +233,22 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<HttpResponse<T>> =>
-    fetch(`${this.baseUrl}${path}`, {
-      // @ts-ignore
-      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+  ): Promise<HttpResponse<T>> => {
+    const requestUrl = `${this.baseUrl}${path}`;
+    const secureOptions =
+      (secureByDefault || secure) && this.securityWorker ? this.securityWorker(this.securityData) : {};
+    const requestOptions = {
+      ...this.mergeRequestOptions(params, secureOptions),
       method,
       body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
-    }).then(async (response) => {
+    };
+
+    return fetch(requestUrl, requestOptions).then(async (response) => {
       const data = await this.safeParseResponse<T, E>(response);
       if (!response.ok) throw data;
       return data;
     });
+  };
 }
 
 /**

--- a/tests/generated/v3.0/petstore-expanded.ts
+++ b/tests/generated/v3.0/petstore-expanded.ts
@@ -1,6 +1,5 @@
 /* tslint:disable */
 /* eslint-disable */
-
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/generated/v3.0/petstore-expanded.ts
+++ b/tests/generated/v3.0/petstore-expanded.ts
@@ -27,11 +27,16 @@ export type RequestParams = Omit<RequestInit, "body" | "method"> & {
 
 export type RequestQueryParamsType = Record<string | number, any>;
 
-type ApiConfig<SecurityDataType> = {
+interface ApiConfig<SecurityDataType> {
   baseUrl?: string;
   baseApiParams?: RequestParams;
   securityWorker?: (securityData: SecurityDataType) => RequestParams;
-};
+}
+
+interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+  data: D | null;
+  error: E | null;
+}
 
 enum BodyType {
   Json,
@@ -98,11 +103,26 @@ class HttpClient<SecurityDataType> {
     };
   }
 
-  private safeParseResponse = <T = any, E = any>(response: Response): Promise<T> =>
-    response
+  private safeParseResponse = <T = any, E = any>(response: Response): Promise<HttpResponse<T, E>> => {
+    const r = response.clone() as HttpResponse<T, E>;
+    r.data = null;
+    r.error = null;
+
+    return response
       .json()
-      .then((data) => data)
-      .catch((e) => response.text);
+      .then((data) => {
+        if (r.ok) {
+          r.data = data;
+        } else {
+          r.error = data;
+        }
+        return r;
+      })
+      .catch((e) => {
+        r.error = e;
+        return r;
+      });
+  };
 
   public request = <T = any, E = any>(
     path: string,
@@ -111,7 +131,7 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<T> =>
+  ): Promise<HttpResponse<T>> =>
     fetch(`${this.baseUrl}${path}`, {
       // @ts-ignore
       ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),

--- a/tests/generated/v3.0/petstore-expanded.ts
+++ b/tests/generated/v3.0/petstore-expanded.ts
@@ -45,7 +45,7 @@ enum BodyType {
 class HttpClient<SecurityDataType> {
   public baseUrl: string = "http://petstore.swagger.io/api";
   private securityData: SecurityDataType = null as any;
-  private securityWorker: ApiConfig<SecurityDataType>["securityWorker"] = (() => {}) as any;
+  private securityWorker: null | ApiConfig<SecurityDataType>["securityWorker"] = null;
 
   private baseApiParams: RequestParams = {
     credentials: "same-origin",
@@ -56,10 +56,8 @@ class HttpClient<SecurityDataType> {
     referrerPolicy: "no-referrer",
   };
 
-  constructor({ baseUrl, baseApiParams, securityWorker }: ApiConfig<SecurityDataType> = {}) {
-    this.baseUrl = baseUrl || this.baseUrl;
-    this.baseApiParams = baseApiParams || this.baseApiParams;
-    this.securityWorker = securityWorker || this.securityWorker;
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
   }
 
   public setSecurityData = (data: SecurityDataType) => {
@@ -131,17 +129,22 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<HttpResponse<T>> =>
-    fetch(`${this.baseUrl}${path}`, {
-      // @ts-ignore
-      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+  ): Promise<HttpResponse<T>> => {
+    const requestUrl = `${this.baseUrl}${path}`;
+    const secureOptions =
+      (secureByDefault || secure) && this.securityWorker ? this.securityWorker(this.securityData) : {};
+    const requestOptions = {
+      ...this.mergeRequestOptions(params, secureOptions),
       method,
       body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
-    }).then(async (response) => {
+    };
+
+    return fetch(requestUrl, requestOptions).then(async (response) => {
       const data = await this.safeParseResponse<T, E>(response);
       if (!response.ok) throw data;
       return data;
     });
+  };
 }
 
 /**

--- a/tests/generated/v3.0/petstore.ts
+++ b/tests/generated/v3.0/petstore.ts
@@ -1,6 +1,5 @@
 /* tslint:disable */
 /* eslint-disable */
-
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/generated/v3.0/petstore.ts
+++ b/tests/generated/v3.0/petstore.ts
@@ -30,11 +30,16 @@ export type RequestParams = Omit<RequestInit, "body" | "method"> & {
 
 export type RequestQueryParamsType = Record<string | number, any>;
 
-type ApiConfig<SecurityDataType> = {
+interface ApiConfig<SecurityDataType> {
   baseUrl?: string;
   baseApiParams?: RequestParams;
   securityWorker?: (securityData: SecurityDataType) => RequestParams;
-};
+}
+
+interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+  data: D | null;
+  error: E | null;
+}
 
 enum BodyType {
   Json,
@@ -101,11 +106,26 @@ class HttpClient<SecurityDataType> {
     };
   }
 
-  private safeParseResponse = <T = any, E = any>(response: Response): Promise<T> =>
-    response
+  private safeParseResponse = <T = any, E = any>(response: Response): Promise<HttpResponse<T, E>> => {
+    const r = response.clone() as HttpResponse<T, E>;
+    r.data = null;
+    r.error = null;
+
+    return response
       .json()
-      .then((data) => data)
-      .catch((e) => response.text);
+      .then((data) => {
+        if (r.ok) {
+          r.data = data;
+        } else {
+          r.error = data;
+        }
+        return r;
+      })
+      .catch((e) => {
+        r.error = e;
+        return r;
+      });
+  };
 
   public request = <T = any, E = any>(
     path: string,
@@ -114,7 +134,7 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<T> =>
+  ): Promise<HttpResponse<T>> =>
     fetch(`${this.baseUrl}${path}`, {
       // @ts-ignore
       ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),

--- a/tests/generated/v3.0/petstore.ts
+++ b/tests/generated/v3.0/petstore.ts
@@ -48,7 +48,7 @@ enum BodyType {
 class HttpClient<SecurityDataType> {
   public baseUrl: string = "http://petstore.swagger.io/v1";
   private securityData: SecurityDataType = null as any;
-  private securityWorker: ApiConfig<SecurityDataType>["securityWorker"] = (() => {}) as any;
+  private securityWorker: null | ApiConfig<SecurityDataType>["securityWorker"] = null;
 
   private baseApiParams: RequestParams = {
     credentials: "same-origin",
@@ -59,10 +59,8 @@ class HttpClient<SecurityDataType> {
     referrerPolicy: "no-referrer",
   };
 
-  constructor({ baseUrl, baseApiParams, securityWorker }: ApiConfig<SecurityDataType> = {}) {
-    this.baseUrl = baseUrl || this.baseUrl;
-    this.baseApiParams = baseApiParams || this.baseApiParams;
-    this.securityWorker = securityWorker || this.securityWorker;
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
   }
 
   public setSecurityData = (data: SecurityDataType) => {
@@ -134,17 +132,22 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<HttpResponse<T>> =>
-    fetch(`${this.baseUrl}${path}`, {
-      // @ts-ignore
-      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+  ): Promise<HttpResponse<T>> => {
+    const requestUrl = `${this.baseUrl}${path}`;
+    const secureOptions =
+      (secureByDefault || secure) && this.securityWorker ? this.securityWorker(this.securityData) : {};
+    const requestOptions = {
+      ...this.mergeRequestOptions(params, secureOptions),
       method,
       body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
-    }).then(async (response) => {
+    };
+
+    return fetch(requestUrl, requestOptions).then(async (response) => {
       const data = await this.safeParseResponse<T, E>(response);
       if (!response.ok) throw data;
       return data;
     });
+  };
 }
 
 /**

--- a/tests/generated/v3.0/responses.ts
+++ b/tests/generated/v3.0/responses.ts
@@ -1,6 +1,5 @@
 /* tslint:disable */
 /* eslint-disable */
-
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/generated/v3.0/responses.ts
+++ b/tests/generated/v3.0/responses.ts
@@ -13,11 +13,16 @@ export type RequestParams = Omit<RequestInit, "body" | "method"> & {
   secure?: boolean;
 };
 
-type ApiConfig<SecurityDataType> = {
+interface ApiConfig<SecurityDataType> {
   baseUrl?: string;
   baseApiParams?: RequestParams;
   securityWorker?: (securityData: SecurityDataType) => RequestParams;
-};
+}
+
+interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+  data: D | null;
+  error: E | null;
+}
 
 enum BodyType {
   Json,
@@ -64,11 +69,26 @@ class HttpClient<SecurityDataType> {
     };
   }
 
-  private safeParseResponse = <T = any, E = any>(response: Response): Promise<T> =>
-    response
+  private safeParseResponse = <T = any, E = any>(response: Response): Promise<HttpResponse<T, E>> => {
+    const r = response.clone() as HttpResponse<T, E>;
+    r.data = null;
+    r.error = null;
+
+    return response
       .json()
-      .then((data) => data)
-      .catch((e) => response.text);
+      .then((data) => {
+        if (r.ok) {
+          r.data = data;
+        } else {
+          r.error = data;
+        }
+        return r;
+      })
+      .catch((e) => {
+        r.error = e;
+        return r;
+      });
+  };
 
   public request = <T = any, E = any>(
     path: string,
@@ -77,7 +97,7 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<T> =>
+  ): Promise<HttpResponse<T>> =>
     fetch(`${this.baseUrl}${path}`, {
       // @ts-ignore
       ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),

--- a/tests/generated/v3.0/responses.ts
+++ b/tests/generated/v3.0/responses.ts
@@ -31,7 +31,7 @@ enum BodyType {
 class HttpClient<SecurityDataType> {
   public baseUrl: string = "";
   private securityData: SecurityDataType = null as any;
-  private securityWorker: ApiConfig<SecurityDataType>["securityWorker"] = (() => {}) as any;
+  private securityWorker: null | ApiConfig<SecurityDataType>["securityWorker"] = null;
 
   private baseApiParams: RequestParams = {
     credentials: "same-origin",
@@ -42,10 +42,8 @@ class HttpClient<SecurityDataType> {
     referrerPolicy: "no-referrer",
   };
 
-  constructor({ baseUrl, baseApiParams, securityWorker }: ApiConfig<SecurityDataType> = {}) {
-    this.baseUrl = baseUrl || this.baseUrl;
-    this.baseApiParams = baseApiParams || this.baseApiParams;
-    this.securityWorker = securityWorker || this.securityWorker;
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
   }
 
   public setSecurityData = (data: SecurityDataType) => {
@@ -97,17 +95,22 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<HttpResponse<T>> =>
-    fetch(`${this.baseUrl}${path}`, {
-      // @ts-ignore
-      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+  ): Promise<HttpResponse<T>> => {
+    const requestUrl = `${this.baseUrl}${path}`;
+    const secureOptions =
+      (secureByDefault || secure) && this.securityWorker ? this.securityWorker(this.securityData) : {};
+    const requestOptions = {
+      ...this.mergeRequestOptions(params, secureOptions),
       method,
       body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
-    }).then(async (response) => {
+    };
+
+    return fetch(requestUrl, requestOptions).then(async (response) => {
       const data = await this.safeParseResponse<T, E>(response);
       if (!response.ok) throw data;
       return data;
     });
+  };
 }
 
 /**

--- a/tests/generated/v3.0/swaggerhub-template.ts
+++ b/tests/generated/v3.0/swaggerhub-template.ts
@@ -1,6 +1,5 @@
 /* tslint:disable */
 /* eslint-disable */
-
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/generated/v3.0/swaggerhub-template.ts
+++ b/tests/generated/v3.0/swaggerhub-template.ts
@@ -31,7 +31,7 @@ enum BodyType {
 class HttpClient<SecurityDataType> {
   public baseUrl: string = "https://virtserver.swaggerhub.com/sdfsdfsffs/sdfff/1.0.0";
   private securityData: SecurityDataType = null as any;
-  private securityWorker: ApiConfig<SecurityDataType>["securityWorker"] = (() => {}) as any;
+  private securityWorker: null | ApiConfig<SecurityDataType>["securityWorker"] = null;
 
   private baseApiParams: RequestParams = {
     credentials: "same-origin",
@@ -42,10 +42,8 @@ class HttpClient<SecurityDataType> {
     referrerPolicy: "no-referrer",
   };
 
-  constructor({ baseUrl, baseApiParams, securityWorker }: ApiConfig<SecurityDataType> = {}) {
-    this.baseUrl = baseUrl || this.baseUrl;
-    this.baseApiParams = baseApiParams || this.baseApiParams;
-    this.securityWorker = securityWorker || this.securityWorker;
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
   }
 
   public setSecurityData = (data: SecurityDataType) => {
@@ -97,17 +95,22 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<HttpResponse<T>> =>
-    fetch(`${this.baseUrl}${path}`, {
-      // @ts-ignore
-      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+  ): Promise<HttpResponse<T>> => {
+    const requestUrl = `${this.baseUrl}${path}`;
+    const secureOptions =
+      (secureByDefault || secure) && this.securityWorker ? this.securityWorker(this.securityData) : {};
+    const requestOptions = {
+      ...this.mergeRequestOptions(params, secureOptions),
       method,
       body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
-    }).then(async (response) => {
+    };
+
+    return fetch(requestUrl, requestOptions).then(async (response) => {
       const data = await this.safeParseResponse<T, E>(response);
       if (!response.ok) throw data;
       return data;
     });
+  };
 }
 
 /**

--- a/tests/generated/v3.0/swaggerhub-template.ts
+++ b/tests/generated/v3.0/swaggerhub-template.ts
@@ -13,11 +13,16 @@ export type RequestParams = Omit<RequestInit, "body" | "method"> & {
   secure?: boolean;
 };
 
-type ApiConfig<SecurityDataType> = {
+interface ApiConfig<SecurityDataType> {
   baseUrl?: string;
   baseApiParams?: RequestParams;
   securityWorker?: (securityData: SecurityDataType) => RequestParams;
-};
+}
+
+interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+  data: D | null;
+  error: E | null;
+}
 
 enum BodyType {
   Json,
@@ -64,11 +69,26 @@ class HttpClient<SecurityDataType> {
     };
   }
 
-  private safeParseResponse = <T = any, E = any>(response: Response): Promise<T> =>
-    response
+  private safeParseResponse = <T = any, E = any>(response: Response): Promise<HttpResponse<T, E>> => {
+    const r = response.clone() as HttpResponse<T, E>;
+    r.data = null;
+    r.error = null;
+
+    return response
       .json()
-      .then((data) => data)
-      .catch((e) => response.text);
+      .then((data) => {
+        if (r.ok) {
+          r.data = data;
+        } else {
+          r.error = data;
+        }
+        return r;
+      })
+      .catch((e) => {
+        r.error = e;
+        return r;
+      });
+  };
 
   public request = <T = any, E = any>(
     path: string,
@@ -77,7 +97,7 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<T> =>
+  ): Promise<HttpResponse<T>> =>
     fetch(`${this.baseUrl}${path}`, {
       // @ts-ignore
       ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),

--- a/tests/generated/v3.0/swaggerhub-template.ts
+++ b/tests/generated/v3.0/swaggerhub-template.ts
@@ -103,17 +103,20 @@ export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
      * @name exampleList
      * @summary Server example operation
      * @request GET:/example
+     * @secure
      * @description This is an example operation to show how security is applied to the call.
      */
-    exampleList: (params?: RequestParams) => this.request<any, any>(`/example`, "GET", params),
+    exampleList: (params?: RequestParams) =>
+      this.request<any, any>(`/example`, "GET", params, null, BodyType.Json, true),
   };
   ping = {
     /**
      * @name pingList
      * @summary Server heartbeat operation
      * @request GET:/ping
+     * @secure
      * @description This operation shows how to override the global security defined above, as we want to open it up for all users.
      */
-    pingList: (params?: RequestParams) => this.request<any, any>(`/ping`, "GET", params),
+    pingList: (params?: RequestParams) => this.request<any, any>(`/ping`, "GET", params, null, BodyType.Json, true),
   };
 }

--- a/tests/generated/v3.0/tsoa-odd-types-3.0.2.ts
+++ b/tests/generated/v3.0/tsoa-odd-types-3.0.2.ts
@@ -1,6 +1,5 @@
 /* tslint:disable */
 /* eslint-disable */
-
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/generated/v3.0/tsoa-odd-types-3.0.2.ts
+++ b/tests/generated/v3.0/tsoa-odd-types-3.0.2.ts
@@ -143,7 +143,7 @@ enum BodyType {
 class HttpClient<SecurityDataType> {
   public baseUrl: string = "http://localhost:8080/api/v1";
   private securityData: SecurityDataType = null as any;
-  private securityWorker: ApiConfig<SecurityDataType>["securityWorker"] = (() => {}) as any;
+  private securityWorker: null | ApiConfig<SecurityDataType>["securityWorker"] = null;
 
   private baseApiParams: RequestParams = {
     credentials: "same-origin",
@@ -154,10 +154,8 @@ class HttpClient<SecurityDataType> {
     referrerPolicy: "no-referrer",
   };
 
-  constructor({ baseUrl, baseApiParams, securityWorker }: ApiConfig<SecurityDataType> = {}) {
-    this.baseUrl = baseUrl || this.baseUrl;
-    this.baseApiParams = baseApiParams || this.baseApiParams;
-    this.securityWorker = securityWorker || this.securityWorker;
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
   }
 
   public setSecurityData = (data: SecurityDataType) => {
@@ -209,17 +207,22 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<HttpResponse<T>> =>
-    fetch(`${this.baseUrl}${path}`, {
-      // @ts-ignore
-      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+  ): Promise<HttpResponse<T>> => {
+    const requestUrl = `${this.baseUrl}${path}`;
+    const secureOptions =
+      (secureByDefault || secure) && this.securityWorker ? this.securityWorker(this.securityData) : {};
+    const requestOptions = {
+      ...this.mergeRequestOptions(params, secureOptions),
       method,
       body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
-    }).then(async (response) => {
+    };
+
+    return fetch(requestUrl, requestOptions).then(async (response) => {
       const data = await this.safeParseResponse<T, E>(response);
       if (!response.ok) throw data;
       return data;
     });
+  };
 }
 
 /**

--- a/tests/generated/v3.0/uspto.ts
+++ b/tests/generated/v3.0/uspto.ts
@@ -1,6 +1,5 @@
 /* tslint:disable */
 /* eslint-disable */
-
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/generated/v3.0/uspto.ts
+++ b/tests/generated/v3.0/uspto.ts
@@ -30,11 +30,16 @@ export type RequestParams = Omit<RequestInit, "body" | "method"> & {
   secure?: boolean;
 };
 
-type ApiConfig<SecurityDataType> = {
+interface ApiConfig<SecurityDataType> {
   baseUrl?: string;
   baseApiParams?: RequestParams;
   securityWorker?: (securityData: SecurityDataType) => RequestParams;
-};
+}
+
+interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+  data: D | null;
+  error: E | null;
+}
 
 enum BodyType {
   Json,
@@ -81,11 +86,26 @@ class HttpClient<SecurityDataType> {
     };
   }
 
-  private safeParseResponse = <T = any, E = any>(response: Response): Promise<T> =>
-    response
+  private safeParseResponse = <T = any, E = any>(response: Response): Promise<HttpResponse<T, E>> => {
+    const r = response.clone() as HttpResponse<T, E>;
+    r.data = null;
+    r.error = null;
+
+    return response
       .json()
-      .then((data) => data)
-      .catch((e) => response.text);
+      .then((data) => {
+        if (r.ok) {
+          r.data = data;
+        } else {
+          r.error = data;
+        }
+        return r;
+      })
+      .catch((e) => {
+        r.error = e;
+        return r;
+      });
+  };
 
   public request = <T = any, E = any>(
     path: string,
@@ -94,7 +114,7 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<T> =>
+  ): Promise<HttpResponse<T>> =>
     fetch(`${this.baseUrl}${path}`, {
       // @ts-ignore
       ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),

--- a/tests/generated/v3.0/uspto.ts
+++ b/tests/generated/v3.0/uspto.ts
@@ -48,7 +48,7 @@ enum BodyType {
 class HttpClient<SecurityDataType> {
   public baseUrl: string = "{scheme}://developer.uspto.gov/ds-api";
   private securityData: SecurityDataType = null as any;
-  private securityWorker: ApiConfig<SecurityDataType>["securityWorker"] = (() => {}) as any;
+  private securityWorker: null | ApiConfig<SecurityDataType>["securityWorker"] = null;
 
   private baseApiParams: RequestParams = {
     credentials: "same-origin",
@@ -59,10 +59,8 @@ class HttpClient<SecurityDataType> {
     referrerPolicy: "no-referrer",
   };
 
-  constructor({ baseUrl, baseApiParams, securityWorker }: ApiConfig<SecurityDataType> = {}) {
-    this.baseUrl = baseUrl || this.baseUrl;
-    this.baseApiParams = baseApiParams || this.baseApiParams;
-    this.securityWorker = securityWorker || this.securityWorker;
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
   }
 
   public setSecurityData = (data: SecurityDataType) => {
@@ -114,17 +112,22 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<HttpResponse<T>> =>
-    fetch(`${this.baseUrl}${path}`, {
-      // @ts-ignore
-      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+  ): Promise<HttpResponse<T>> => {
+    const requestUrl = `${this.baseUrl}${path}`;
+    const secureOptions =
+      (secureByDefault || secure) && this.securityWorker ? this.securityWorker(this.securityData) : {};
+    const requestOptions = {
+      ...this.mergeRequestOptions(params, secureOptions),
       method,
       body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
-    }).then(async (response) => {
+    };
+
+    return fetch(requestUrl, requestOptions).then(async (response) => {
       const data = await this.safeParseResponse<T, E>(response);
       if (!response.ok) throw data;
       return data;
     });
+  };
 }
 
 /**

--- a/tests/generated/v3.0/wrong-enum-subtypes.ts
+++ b/tests/generated/v3.0/wrong-enum-subtypes.ts
@@ -1,6 +1,5 @@
 /* tslint:disable */
 /* eslint-disable */
-
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/generated/v3.0/wrong-enum-subtypes.ts
+++ b/tests/generated/v3.0/wrong-enum-subtypes.ts
@@ -15,11 +15,16 @@ export type RequestParams = Omit<RequestInit, "body" | "method"> & {
   secure?: boolean;
 };
 
-type ApiConfig<SecurityDataType> = {
+interface ApiConfig<SecurityDataType> {
   baseUrl?: string;
   baseApiParams?: RequestParams;
   securityWorker?: (securityData: SecurityDataType) => RequestParams;
-};
+}
+
+interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+  data: D | null;
+  error: E | null;
+}
 
 enum BodyType {
   Json,
@@ -66,11 +71,26 @@ class HttpClient<SecurityDataType> {
     };
   }
 
-  private safeParseResponse = <T = any, E = any>(response: Response): Promise<T> =>
-    response
+  private safeParseResponse = <T = any, E = any>(response: Response): Promise<HttpResponse<T, E>> => {
+    const r = response.clone() as HttpResponse<T, E>;
+    r.data = null;
+    r.error = null;
+
+    return response
       .json()
-      .then((data) => data)
-      .catch((e) => response.text);
+      .then((data) => {
+        if (r.ok) {
+          r.data = data;
+        } else {
+          r.error = data;
+        }
+        return r;
+      })
+      .catch((e) => {
+        r.error = e;
+        return r;
+      });
+  };
 
   public request = <T = any, E = any>(
     path: string,
@@ -79,7 +99,7 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<T> =>
+  ): Promise<HttpResponse<T>> =>
     fetch(`${this.baseUrl}${path}`, {
       // @ts-ignore
       ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),

--- a/tests/generated/v3.0/wrong-enum-subtypes.ts
+++ b/tests/generated/v3.0/wrong-enum-subtypes.ts
@@ -33,7 +33,7 @@ enum BodyType {
 class HttpClient<SecurityDataType> {
   public baseUrl: string = "";
   private securityData: SecurityDataType = null as any;
-  private securityWorker: ApiConfig<SecurityDataType>["securityWorker"] = (() => {}) as any;
+  private securityWorker: null | ApiConfig<SecurityDataType>["securityWorker"] = null;
 
   private baseApiParams: RequestParams = {
     credentials: "same-origin",
@@ -44,10 +44,8 @@ class HttpClient<SecurityDataType> {
     referrerPolicy: "no-referrer",
   };
 
-  constructor({ baseUrl, baseApiParams, securityWorker }: ApiConfig<SecurityDataType> = {}) {
-    this.baseUrl = baseUrl || this.baseUrl;
-    this.baseApiParams = baseApiParams || this.baseApiParams;
-    this.securityWorker = securityWorker || this.securityWorker;
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
   }
 
   public setSecurityData = (data: SecurityDataType) => {
@@ -99,17 +97,22 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<HttpResponse<T>> =>
-    fetch(`${this.baseUrl}${path}`, {
-      // @ts-ignore
-      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+  ): Promise<HttpResponse<T>> => {
+    const requestUrl = `${this.baseUrl}${path}`;
+    const secureOptions =
+      (secureByDefault || secure) && this.securityWorker ? this.securityWorker(this.securityData) : {};
+    const requestOptions = {
+      ...this.mergeRequestOptions(params, secureOptions),
       method,
       body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
-    }).then(async (response) => {
+    };
+
+    return fetch(requestUrl, requestOptions).then(async (response) => {
       const data = await this.safeParseResponse<T, E>(response);
       if (!response.ok) throw data;
       return data;
     });
+  };
 }
 
 /**

--- a/tests/spec/defaultAsSuccess/schema.ts
+++ b/tests/spec/defaultAsSuccess/schema.ts
@@ -1,6 +1,5 @@
 /* tslint:disable */
 /* eslint-disable */
-
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/spec/defaultAsSuccess/schema.ts
+++ b/tests/spec/defaultAsSuccess/schema.ts
@@ -85,7 +85,7 @@ enum BodyType {
 class HttpClient<SecurityDataType> {
   public baseUrl: string = "https://6-dot-authentiqio.appspot.com/";
   private securityData: SecurityDataType = null as any;
-  private securityWorker: ApiConfig<SecurityDataType>["securityWorker"] = (() => {}) as any;
+  private securityWorker: null | ApiConfig<SecurityDataType>["securityWorker"] = null;
 
   private baseApiParams: RequestParams = {
     credentials: "same-origin",
@@ -96,10 +96,8 @@ class HttpClient<SecurityDataType> {
     referrerPolicy: "no-referrer",
   };
 
-  constructor({ baseUrl, baseApiParams, securityWorker }: ApiConfig<SecurityDataType> = {}) {
-    this.baseUrl = baseUrl || this.baseUrl;
-    this.baseApiParams = baseApiParams || this.baseApiParams;
-    this.securityWorker = securityWorker || this.securityWorker;
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
   }
 
   public setSecurityData = (data: SecurityDataType) => {
@@ -171,17 +169,22 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<HttpResponse<T>> =>
-    fetch(`${this.baseUrl}${path}`, {
-      // @ts-ignore
-      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+  ): Promise<HttpResponse<T>> => {
+    const requestUrl = `${this.baseUrl}${path}`;
+    const secureOptions =
+      (secureByDefault || secure) && this.securityWorker ? this.securityWorker(this.securityData) : {};
+    const requestOptions = {
+      ...this.mergeRequestOptions(params, secureOptions),
       method,
       body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
-    }).then(async (response) => {
+    };
+
+    return fetch(requestUrl, requestOptions).then(async (response) => {
       const data = await this.safeParseResponse<T, E>(response);
       if (!response.ok) throw data;
       return data;
     });
+  };
 }
 
 /**

--- a/tests/spec/defaultAsSuccess/schema.ts
+++ b/tests/spec/defaultAsSuccess/schema.ts
@@ -67,11 +67,16 @@ export type RequestParams = Omit<RequestInit, "body" | "method"> & {
 
 export type RequestQueryParamsType = Record<string | number, any>;
 
-type ApiConfig<SecurityDataType> = {
+interface ApiConfig<SecurityDataType> {
   baseUrl?: string;
   baseApiParams?: RequestParams;
   securityWorker?: (securityData: SecurityDataType) => RequestParams;
-};
+}
+
+interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+  data: D | null;
+  error: E | null;
+}
 
 enum BodyType {
   Json,
@@ -138,11 +143,26 @@ class HttpClient<SecurityDataType> {
     };
   }
 
-  private safeParseResponse = <T = any, E = any>(response: Response): Promise<T> =>
-    response
+  private safeParseResponse = <T = any, E = any>(response: Response): Promise<HttpResponse<T, E>> => {
+    const r = response.clone() as HttpResponse<T, E>;
+    r.data = null;
+    r.error = null;
+
+    return response
       .json()
-      .then((data) => data)
-      .catch((e) => response.text);
+      .then((data) => {
+        if (r.ok) {
+          r.data = data;
+        } else {
+          r.error = data;
+        }
+        return r;
+      })
+      .catch((e) => {
+        r.error = e;
+        return r;
+      });
+  };
 
   public request = <T = any, E = any>(
     path: string,
@@ -151,7 +171,7 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<T> =>
+  ): Promise<HttpResponse<T>> =>
     fetch(`${this.baseUrl}${path}`, {
       // @ts-ignore
       ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),

--- a/tests/spec/js/schema.d.ts
+++ b/tests/spec/js/schema.d.ts
@@ -1687,7 +1687,7 @@ declare class HttpClient<SecurityDataType> {
   private securityData;
   private securityWorker;
   private baseApiParams;
-  constructor({ baseUrl, baseApiParams, securityWorker }?: ApiConfig<SecurityDataType>);
+  constructor(apiConfig?: ApiConfig<SecurityDataType>);
   setSecurityData: (data: SecurityDataType) => void;
   private addQueryParam;
   protected addQueryParams(rawQuery?: RequestQueryParamsType): string;

--- a/tests/spec/js/schema.d.ts
+++ b/tests/spec/js/schema.d.ts
@@ -1670,11 +1670,15 @@ export declare type RequestParams = Omit<RequestInit, "body" | "method"> & {
   secure?: boolean;
 };
 export declare type RequestQueryParamsType = Record<string | number, any>;
-declare type ApiConfig<SecurityDataType> = {
+interface ApiConfig<SecurityDataType> {
   baseUrl?: string;
   baseApiParams?: RequestParams;
   securityWorker?: (securityData: SecurityDataType) => RequestParams;
-};
+}
+interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+  data: D | null;
+  error: E | null;
+}
 declare enum BodyType {
   Json = 0,
 }
@@ -1697,7 +1701,7 @@ declare class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ) => Promise<T>;
+  ) => Promise<HttpResponse<T, unknown>>;
 }
 /**
  * @title GitHub
@@ -1712,7 +1716,7 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
      * @request GET:/emojis
      * @description Lists all the emojis available to use on GitHub.
      */
-    emojisList: (params?: RequestParams) => Promise<Record<string, string>>;
+    emojisList: (params?: RequestParams) => Promise<HttpResponse<Record<string, string>, unknown>>;
   };
   events: {
     /**
@@ -1720,7 +1724,7 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
      * @request GET:/events
      * @description List public events.
      */
-    eventsList: (params?: RequestParams) => Promise<Events>;
+    eventsList: (params?: RequestParams) => Promise<HttpResponse<Events, unknown>>;
   };
   feeds: {
     /**
@@ -1728,7 +1732,7 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
      * @request GET:/feeds
      * @description List Feeds. GitHub provides several timeline resources in Atom format. The Feeds API lists all the feeds available to the authenticating user.
      */
-    feedsList: (params?: RequestParams) => Promise<Feeds>;
+    feedsList: (params?: RequestParams) => Promise<HttpResponse<Feeds, unknown>>;
   };
   gists: {
     /**
@@ -1741,13 +1745,13 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
         since?: string;
       },
       params?: RequestParams,
-    ) => Promise<Gists>;
+    ) => Promise<HttpResponse<Gists, unknown>>;
     /**
      * @name gistsCreate
      * @request POST:/gists
      * @description Create a gist.
      */
-    gistsCreate: (body: PostGist, params?: RequestParams) => Promise<Gist>;
+    gistsCreate: (body: PostGist, params?: RequestParams) => Promise<HttpResponse<Gist, unknown>>;
     /**
      * @name publicList
      * @request GET:/gists/public
@@ -1758,7 +1762,7 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
         since?: string;
       },
       params?: RequestParams,
-    ) => Promise<Gists>;
+    ) => Promise<HttpResponse<Gists, unknown>>;
     /**
      * @name starredList
      * @request GET:/gists/starred
@@ -1769,43 +1773,43 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
         since?: string;
       },
       params?: RequestParams,
-    ) => Promise<Gists>;
+    ) => Promise<HttpResponse<Gists, unknown>>;
     /**
      * @name gistsDelete
      * @request DELETE:/gists/{id}
      * @description Delete a gist.
      */
-    gistsDelete: (id: number, params?: RequestParams) => Promise<any>;
+    gistsDelete: (id: number, params?: RequestParams) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name gistsDetail
      * @request GET:/gists/{id}
      * @description Get a single gist.
      */
-    gistsDetail: (id: number, params?: RequestParams) => Promise<Gist>;
+    gistsDetail: (id: number, params?: RequestParams) => Promise<HttpResponse<Gist, unknown>>;
     /**
      * @name gistsPartialUpdate
      * @request PATCH:/gists/{id}
      * @description Edit a gist.
      */
-    gistsPartialUpdate: (id: number, body: PatchGist, params?: RequestParams) => Promise<Gist>;
+    gistsPartialUpdate: (id: number, body: PatchGist, params?: RequestParams) => Promise<HttpResponse<Gist, unknown>>;
     /**
      * @name commentsDetail
      * @request GET:/gists/{id}/comments
      * @description List comments on a gist.
      */
-    commentsDetail: (id: number, params?: RequestParams) => Promise<Comments>;
+    commentsDetail: (id: number, params?: RequestParams) => Promise<HttpResponse<Comments, unknown>>;
     /**
      * @name commentsCreate
      * @request POST:/gists/{id}/comments
      * @description Create a commen
      */
-    commentsCreate: (id: number, body: CommentBody, params?: RequestParams) => Promise<Comment>;
+    commentsCreate: (id: number, body: CommentBody, params?: RequestParams) => Promise<HttpResponse<Comment, unknown>>;
     /**
      * @name commentsDelete
      * @request DELETE:/gists/{id}/comments/{commentId}
      * @description Delete a comment.
      */
-    commentsDelete: (id: number, commentId: number, params?: RequestParams) => Promise<any>;
+    commentsDelete: (id: number, commentId: number, params?: RequestParams) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name commentsDetail
      * @request GET:/gists/{id}/comments/{commentId}
@@ -1813,37 +1817,42 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
      * @originalName commentsDetail
      * @duplicate
      */
-    commentsDetail2: (id: number, commentId: number, params?: RequestParams) => Promise<Comment>;
+    commentsDetail2: (id: number, commentId: number, params?: RequestParams) => Promise<HttpResponse<Comment, unknown>>;
     /**
      * @name commentsPartialUpdate
      * @request PATCH:/gists/{id}/comments/{commentId}
      * @description Edit a comment.
      */
-    commentsPartialUpdate: (id: number, commentId: number, body: Comment, params?: RequestParams) => Promise<Comment>;
+    commentsPartialUpdate: (
+      id: number,
+      commentId: number,
+      body: Comment,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<Comment, unknown>>;
     /**
      * @name forksCreate
      * @request POST:/gists/{id}/forks
      * @description Fork a gist.
      */
-    forksCreate: (id: number, params?: RequestParams) => Promise<any>;
+    forksCreate: (id: number, params?: RequestParams) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name starDelete
      * @request DELETE:/gists/{id}/star
      * @description Unstar a gist.
      */
-    starDelete: (id: number, params?: RequestParams) => Promise<any>;
+    starDelete: (id: number, params?: RequestParams) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name starDetail
      * @request GET:/gists/{id}/star
      * @description Check if a gist is starred.
      */
-    starDetail: (id: number, params?: RequestParams) => Promise<any>;
+    starDetail: (id: number, params?: RequestParams) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name starUpdate
      * @request PUT:/gists/{id}/star
      * @description Star a gist.
      */
-    starUpdate: (id: number, params?: RequestParams) => Promise<any>;
+    starUpdate: (id: number, params?: RequestParams) => Promise<HttpResponse<any, unknown>>;
   };
   gitignore: {
     /**
@@ -1851,13 +1860,13 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
      * @request GET:/gitignore/templates
      * @description Listing available templates. List all templates available to pass as an option when creating a repository.
      */
-    templatesList: (params?: RequestParams) => Promise<Gitignore>;
+    templatesList: (params?: RequestParams) => Promise<HttpResponse<Gitignore, unknown>>;
     /**
      * @name templatesDetail
      * @request GET:/gitignore/templates/{language}
      * @description Get a single template.
      */
-    templatesDetail: (language: string, params?: RequestParams) => Promise<GitignoreLang>;
+    templatesDetail: (language: string, params?: RequestParams) => Promise<HttpResponse<GitignoreLang, unknown>>;
   };
   issues: {
     /**
@@ -1875,7 +1884,7 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
         since?: string;
       },
       params?: RequestParams,
-    ) => Promise<Issues>;
+    ) => Promise<HttpResponse<Issues, unknown>>;
   };
   legacy: {
     /**
@@ -1889,7 +1898,7 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
       owner: string,
       repository: string,
       params?: RequestParams,
-    ) => Promise<SearchIssuesByKeyword>;
+    ) => Promise<HttpResponse<SearchIssuesByKeyword, unknown>>;
     /**
      * @name reposSearchDetail
      * @request GET:/legacy/repos/search/{keyword}
@@ -1904,13 +1913,13 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
         sort?: "updated" | "stars" | "forks";
       },
       params?: RequestParams,
-    ) => Promise<SearchRepositoriesByKeyword>;
+    ) => Promise<HttpResponse<SearchRepositoriesByKeyword, unknown>>;
     /**
      * @name userEmailDetail
      * @request GET:/legacy/user/email/{email}
      * @description This API call is added for compatibility reasons only.
      */
-    userEmailDetail: (email: string, params?: RequestParams) => Promise<SearchUserByEmail>;
+    userEmailDetail: (email: string, params?: RequestParams) => Promise<HttpResponse<SearchUserByEmail, unknown>>;
     /**
      * @name userSearchDetail
      * @request GET:/legacy/user/search/{keyword}
@@ -1924,7 +1933,7 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
         sort?: "updated" | "stars" | "forks";
       },
       params?: RequestParams,
-    ) => Promise<SearchUsersByKeyword>;
+    ) => Promise<HttpResponse<SearchUsersByKeyword, unknown>>;
   };
   markdown: {
     /**
@@ -1932,13 +1941,13 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
      * @request POST:/markdown
      * @description Render an arbitrary Markdown document
      */
-    markdownCreate: (body: Markdown, params?: RequestParams) => Promise<any>;
+    markdownCreate: (body: Markdown, params?: RequestParams) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name postMarkdown
      * @request POST:/markdown/raw
      * @description Render a Markdown document in raw mode
      */
-    postMarkdown: (params?: RequestParams) => Promise<any>;
+    postMarkdown: (params?: RequestParams) => Promise<HttpResponse<any, unknown>>;
   };
   meta: {
     /**
@@ -1946,7 +1955,7 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
      * @request GET:/meta
      * @description This gives some information about GitHub.com, the service.
      */
-    metaList: (params?: RequestParams) => Promise<Meta>;
+    metaList: (params?: RequestParams) => Promise<HttpResponse<Meta, unknown>>;
   };
   networks: {
     /**
@@ -1954,7 +1963,7 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
      * @request GET:/networks/{owner}/{repo}/events
      * @description List public events for a network of repositories.
      */
-    eventsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Events>;
+    eventsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<HttpResponse<Events, unknown>>;
   };
   notifications: {
     /**
@@ -1969,43 +1978,47 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
         since?: string;
       },
       params?: RequestParams,
-    ) => Promise<Notifications>;
+    ) => Promise<HttpResponse<Notifications, unknown>>;
     /**
      * @name notificationsUpdate
      * @request PUT:/notifications
      * @description Mark as read. Marking a notification as "read" removes it from the default view on GitHub.com.
      */
-    notificationsUpdate: (body: NotificationMarkRead, params?: RequestParams) => Promise<any>;
+    notificationsUpdate: (body: NotificationMarkRead, params?: RequestParams) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name threadsDetail
      * @request GET:/notifications/threads/{id}
      * @description View a single thread.
      */
-    threadsDetail: (id: number, params?: RequestParams) => Promise<Notifications>;
+    threadsDetail: (id: number, params?: RequestParams) => Promise<HttpResponse<Notifications, unknown>>;
     /**
      * @name threadsPartialUpdate
      * @request PATCH:/notifications/threads/{id}
      * @description Mark a thread as read
      */
-    threadsPartialUpdate: (id: number, params?: RequestParams) => Promise<any>;
+    threadsPartialUpdate: (id: number, params?: RequestParams) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name threadsSubscriptionDelete
      * @request DELETE:/notifications/threads/{id}/subscription
      * @description Delete a Thread Subscription.
      */
-    threadsSubscriptionDelete: (id: number, params?: RequestParams) => Promise<any>;
+    threadsSubscriptionDelete: (id: number, params?: RequestParams) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name threadsSubscriptionDetail
      * @request GET:/notifications/threads/{id}/subscription
      * @description Get a Thread Subscription.
      */
-    threadsSubscriptionDetail: (id: number, params?: RequestParams) => Promise<Subscription>;
+    threadsSubscriptionDetail: (id: number, params?: RequestParams) => Promise<HttpResponse<Subscription, unknown>>;
     /**
      * @name threadsSubscriptionUpdate
      * @request PUT:/notifications/threads/{id}/subscription
      * @description Set a Thread Subscription. This lets you subscribe to a thread, or ignore it. Subscribing to a thread is unnecessary if the user is already subscribed to the repository. Ignoring a thread will mute all future notifications (until you comment or get @mentioned).
      */
-    threadsSubscriptionUpdate: (id: number, body: PutSubscription, params?: RequestParams) => Promise<Subscription>;
+    threadsSubscriptionUpdate: (
+      id: number,
+      body: PutSubscription,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<Subscription, unknown>>;
   };
   orgs: {
     /**
@@ -2013,19 +2026,19 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
      * @request GET:/orgs/{org}
      * @description Get an Organization.
      */
-    orgsDetail: (org: string, params?: RequestParams) => Promise<any>;
+    orgsDetail: (org: string, params?: RequestParams) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name orgsPartialUpdate
      * @request PATCH:/orgs/{org}
      * @description Edit an Organization.
      */
-    orgsPartialUpdate: (org: string, body: PatchOrg, params?: RequestParams) => Promise<any>;
+    orgsPartialUpdate: (org: string, body: PatchOrg, params?: RequestParams) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name eventsDetail
      * @request GET:/orgs/{org}/events
      * @description List public events for an organization.
      */
-    eventsDetail: (org: string, params?: RequestParams) => Promise<Events>;
+    eventsDetail: (org: string, params?: RequestParams) => Promise<HttpResponse<Events, unknown>>;
     /**
      * @name issuesDetail
      * @request GET:/orgs/{org}/issues
@@ -2042,19 +2055,19 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
         since?: string;
       },
       params?: RequestParams,
-    ) => Promise<Issues>;
+    ) => Promise<HttpResponse<Issues, unknown>>;
     /**
      * @name membersDetail
      * @request GET:/orgs/{org}/members
      * @description Members list. List all users who are members of an organization. A member is a user tha belongs to at least 1 team in the organization. If the authenticated user is also an owner of this organization then both concealed and public members will be returned. If the requester is not an owner of the organization the query will be redirected to the public members list.
      */
-    membersDetail: (org: string, params?: RequestParams) => Promise<Users>;
+    membersDetail: (org: string, params?: RequestParams) => Promise<HttpResponse<Users, unknown>>;
     /**
      * @name membersDelete
      * @request DELETE:/orgs/{org}/members/{username}
      * @description Remove a member. Removing a user from this list will remove them from all teams and they will no longer have any access to the organization's repositories.
      */
-    membersDelete: (org: string, username: string, params?: RequestParams) => Promise<any>;
+    membersDelete: (org: string, username: string, params?: RequestParams) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name membersDetail
      * @request GET:/orgs/{org}/members/{username}
@@ -2062,19 +2075,19 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
      * @originalName membersDetail
      * @duplicate
      */
-    membersDetail2: (org: string, username: string, params?: RequestParams) => Promise<any>;
+    membersDetail2: (org: string, username: string, params?: RequestParams) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name publicMembersDetail
      * @request GET:/orgs/{org}/public_members
      * @description Public members list. Members of an organization can choose to have their membership publicized or not.
      */
-    publicMembersDetail: (org: string, params?: RequestParams) => Promise<Users>;
+    publicMembersDetail: (org: string, params?: RequestParams) => Promise<HttpResponse<Users, unknown>>;
     /**
      * @name publicMembersDelete
      * @request DELETE:/orgs/{org}/public_members/{username}
      * @description Conceal a user's membership.
      */
-    publicMembersDelete: (org: string, username: string, params?: RequestParams) => Promise<any>;
+    publicMembersDelete: (org: string, username: string, params?: RequestParams) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name publicMembersDetail
      * @request GET:/orgs/{org}/public_members/{username}
@@ -2082,13 +2095,17 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
      * @originalName publicMembersDetail
      * @duplicate
      */
-    publicMembersDetail2: (org: string, username: string, params?: RequestParams) => Promise<any>;
+    publicMembersDetail2: (
+      org: string,
+      username: string,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name publicMembersUpdate
      * @request PUT:/orgs/{org}/public_members/{username}
      * @description Publicize a user's membership.
      */
-    publicMembersUpdate: (org: string, username: string, params?: RequestParams) => Promise<any>;
+    publicMembersUpdate: (org: string, username: string, params?: RequestParams) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name reposDetail
      * @request GET:/orgs/{org}/repos
@@ -2100,25 +2117,25 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
         type?: "all" | "public" | "private" | "forks" | "sources" | "member";
       },
       params?: RequestParams,
-    ) => Promise<Repos>;
+    ) => Promise<HttpResponse<Repos, unknown>>;
     /**
      * @name reposCreate
      * @request POST:/orgs/{org}/repos
      * @description Create a new repository for the authenticated user. OAuth users must supply repo scope.
      */
-    reposCreate: (org: string, body: PostRepo, params?: RequestParams) => Promise<Repos>;
+    reposCreate: (org: string, body: PostRepo, params?: RequestParams) => Promise<HttpResponse<Repos, unknown>>;
     /**
      * @name teamsDetail
      * @request GET:/orgs/{org}/teams
      * @description List teams.
      */
-    teamsDetail: (org: string, params?: RequestParams) => Promise<Teams>;
+    teamsDetail: (org: string, params?: RequestParams) => Promise<HttpResponse<Teams, unknown>>;
     /**
      * @name teamsCreate
      * @request POST:/orgs/{org}/teams
      * @description Create team. In order to create a team, the authenticated user must be an owner of organization.
      */
-    teamsCreate: (org: string, body: OrgTeamsPost, params?: RequestParams) => Promise<Team>;
+    teamsCreate: (org: string, body: OrgTeamsPost, params?: RequestParams) => Promise<HttpResponse<Team, unknown>>;
   };
   rateLimit: {
     /**
@@ -2126,7 +2143,7 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
      * @request GET:/rate_limit
      * @description Get your current rate limit status Note: Accessing this endpoint does not count against your rate limit.
      */
-    rateLimitList: (params?: RequestParams) => Promise<RateLimit>;
+    rateLimitList: (params?: RequestParams) => Promise<HttpResponse<RateLimit, unknown>>;
   };
   repos: {
     /**
@@ -2134,25 +2151,30 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
      * @request DELETE:/repos/{owner}/{repo}
      * @description Delete a Repository. Deleting a repository requires admin access. If OAuth is used, the delete_repo scope is required.
      */
-    reposDelete: (owner: string, repo: string, params?: RequestParams) => Promise<any>;
+    reposDelete: (owner: string, repo: string, params?: RequestParams) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name reposDetail
      * @request GET:/repos/{owner}/{repo}
      * @description Get repository.
      */
-    reposDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Repo>;
+    reposDetail: (owner: string, repo: string, params?: RequestParams) => Promise<HttpResponse<Repo, unknown>>;
     /**
      * @name reposPartialUpdate
      * @request PATCH:/repos/{owner}/{repo}
      * @description Edit repository.
      */
-    reposPartialUpdate: (owner: string, repo: string, body: RepoEdit, params?: RequestParams) => Promise<Repo>;
+    reposPartialUpdate: (
+      owner: string,
+      repo: string,
+      body: RepoEdit,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<Repo, unknown>>;
     /**
      * @name assigneesDetail
      * @request GET:/repos/{owner}/{repo}/assignees
      * @description List assignees. This call lists all the available assignees (owner + collaborators) to which issues may be assigned.
      */
-    assigneesDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Assignees>;
+    assigneesDetail: (owner: string, repo: string, params?: RequestParams) => Promise<HttpResponse<Assignees, unknown>>;
     /**
      * @name assigneesDetail
      * @request GET:/repos/{owner}/{repo}/assignees/{assignee}
@@ -2160,13 +2182,18 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
      * @originalName assigneesDetail
      * @duplicate
      */
-    assigneesDetail2: (owner: string, repo: string, assignee: string, params?: RequestParams) => Promise<any>;
+    assigneesDetail2: (
+      owner: string,
+      repo: string,
+      assignee: string,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name branchesDetail
      * @request GET:/repos/{owner}/{repo}/branches
      * @description Get list of branches
      */
-    branchesDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Branches>;
+    branchesDetail: (owner: string, repo: string, params?: RequestParams) => Promise<HttpResponse<Branches, unknown>>;
     /**
      * @name branchesDetail
      * @request GET:/repos/{owner}/{repo}/branches/{branch}
@@ -2174,19 +2201,29 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
      * @originalName branchesDetail
      * @duplicate
      */
-    branchesDetail2: (owner: string, repo: string, branch: string, params?: RequestParams) => Promise<Branch>;
+    branchesDetail2: (
+      owner: string,
+      repo: string,
+      branch: string,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<Branch, unknown>>;
     /**
      * @name collaboratorsDetail
      * @request GET:/repos/{owner}/{repo}/collaborators
      * @description List. When authenticating as an organization owner of an organization-owned repository, all organization owners are included in the list of collaborators. Otherwise, only users with access to the repository are returned in the collaborators list.
      */
-    collaboratorsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Users>;
+    collaboratorsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<HttpResponse<Users, unknown>>;
     /**
      * @name collaboratorsDelete
      * @request DELETE:/repos/{owner}/{repo}/collaborators/{user}
      * @description Remove collaborator.
      */
-    collaboratorsDelete: (owner: string, repo: string, user: string, params?: RequestParams) => Promise<any>;
+    collaboratorsDelete: (
+      owner: string,
+      repo: string,
+      user: string,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name collaboratorsDetail
      * @request GET:/repos/{owner}/{repo}/collaborators/{user}
@@ -2194,25 +2231,44 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
      * @originalName collaboratorsDetail
      * @duplicate
      */
-    collaboratorsDetail2: (owner: string, repo: string, user: string, params?: RequestParams) => Promise<any>;
+    collaboratorsDetail2: (
+      owner: string,
+      repo: string,
+      user: string,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name collaboratorsUpdate
      * @request PUT:/repos/{owner}/{repo}/collaborators/{user}
      * @description Add collaborator.
      */
-    collaboratorsUpdate: (owner: string, repo: string, user: string, params?: RequestParams) => Promise<any>;
+    collaboratorsUpdate: (
+      owner: string,
+      repo: string,
+      user: string,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name commentsDetail
      * @request GET:/repos/{owner}/{repo}/comments
      * @description List commit comments for a repository. Comments are ordered by ascending ID.
      */
-    commentsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<RepoComments>;
+    commentsDetail: (
+      owner: string,
+      repo: string,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<RepoComments, unknown>>;
     /**
      * @name commentsDelete
      * @request DELETE:/repos/{owner}/{repo}/comments/{commentId}
      * @description Delete a commit comment
      */
-    commentsDelete: (owner: string, repo: string, commentId: number, params?: RequestParams) => Promise<any>;
+    commentsDelete: (
+      owner: string,
+      repo: string,
+      commentId: number,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name commentsDetail
      * @request GET:/repos/{owner}/{repo}/comments/{commentId}
@@ -2220,7 +2276,12 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
      * @originalName commentsDetail
      * @duplicate
      */
-    commentsDetail2: (owner: string, repo: string, commentId: number, params?: RequestParams) => Promise<CommitComment>;
+    commentsDetail2: (
+      owner: string,
+      repo: string,
+      commentId: number,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<CommitComment, unknown>>;
     /**
      * @name commentsPartialUpdate
      * @request PATCH:/repos/{owner}/{repo}/comments/{commentId}
@@ -2232,7 +2293,7 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
       commentId: number,
       body: CommentBody,
       params?: RequestParams,
-    ) => Promise<CommitComment>;
+    ) => Promise<HttpResponse<CommitComment, unknown>>;
     /**
      * @name commitsDetail
      * @request GET:/repos/{owner}/{repo}/commits
@@ -2249,13 +2310,18 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
         until?: string;
       },
       params?: RequestParams,
-    ) => Promise<Commits>;
+    ) => Promise<HttpResponse<Commits, unknown>>;
     /**
      * @name commitsStatusDetail
      * @request GET:/repos/{owner}/{repo}/commits/{ref}/status
      * @description Get the combined Status for a specific Ref The Combined status endpoint is currently available for developers to preview. During the preview period, the API may change without advance notice. Please see the blog post for full details. To access this endpoint during the preview period, you must provide a custom media type in the Accept header: application/vnd.github.she-hulk-preview+json
      */
-    commitsStatusDetail: (owner: string, repo: string, ref: string, params?: RequestParams) => Promise<RefStatus>;
+    commitsStatusDetail: (
+      owner: string,
+      repo: string,
+      ref: string,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<RefStatus, unknown>>;
     /**
      * @name commitsDetail
      * @request GET:/repos/{owner}/{repo}/commits/{shaCode}
@@ -2263,7 +2329,12 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
      * @originalName commitsDetail
      * @duplicate
      */
-    commitsDetail2: (owner: string, repo: string, shaCode: string, params?: RequestParams) => Promise<Commit>;
+    commitsDetail2: (
+      owner: string,
+      repo: string,
+      shaCode: string,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<Commit, unknown>>;
     /**
      * @name commitsCommentsDetail
      * @request GET:/repos/{owner}/{repo}/commits/{shaCode}/comments
@@ -2274,7 +2345,7 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
       repo: string,
       shaCode: string,
       params?: RequestParams,
-    ) => Promise<RepoComments>;
+    ) => Promise<HttpResponse<RepoComments, unknown>>;
     /**
      * @name commitsCommentsCreate
      * @request POST:/repos/{owner}/{repo}/commits/{shaCode}/comments
@@ -2286,7 +2357,7 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
       shaCode: string,
       body: CommitCommentBody,
       params?: RequestParams,
-    ) => Promise<CommitComment>;
+    ) => Promise<HttpResponse<CommitComment, unknown>>;
     /**
      * @name compareDetail
      * @request GET:/repos/{owner}/{repo}/compare/{baseId}...{headId}
@@ -2298,7 +2369,7 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
       baseId: string,
       headId: string,
       params?: RequestParams,
-    ) => Promise<CompareCommits>;
+    ) => Promise<HttpResponse<CompareCommits, unknown>>;
     /**
      * @name contentsDelete
      * @request DELETE:/repos/{owner}/{repo}/contents/{path}
@@ -2310,7 +2381,7 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
       path: string,
       body: DeleteFileBody,
       params?: RequestParams,
-    ) => Promise<DeleteFile>;
+    ) => Promise<HttpResponse<DeleteFile, unknown>>;
     /**
      * @name contentsDetail
      * @request GET:/repos/{owner}/{repo}/contents/{path}
@@ -2325,7 +2396,7 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
         ref?: string;
       },
       params?: RequestParams,
-    ) => Promise<ContentsPath>;
+    ) => Promise<HttpResponse<ContentsPath, unknown>>;
     /**
      * @name contentsUpdate
      * @request PUT:/repos/{owner}/{repo}/contents/{path}
@@ -2337,7 +2408,7 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
       path: string,
       body: CreateFileBody,
       params?: RequestParams,
-    ) => Promise<CreateFile>;
+    ) => Promise<HttpResponse<CreateFile, unknown>>;
     /**
      * @name contributorsDetail
      * @request GET:/repos/{owner}/{repo}/contributors
@@ -2350,13 +2421,17 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
         anon: string;
       },
       params?: RequestParams,
-    ) => Promise<Users>;
+    ) => Promise<HttpResponse<Users, unknown>>;
     /**
      * @name deploymentsDetail
      * @request GET:/repos/{owner}/{repo}/deployments
      * @description Users with pull access can view deployments for a repository
      */
-    deploymentsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<RepoDeployments>;
+    deploymentsDetail: (
+      owner: string,
+      repo: string,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<RepoDeployments, unknown>>;
     /**
      * @name deploymentsCreate
      * @request POST:/repos/{owner}/{repo}/deployments
@@ -2367,7 +2442,7 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
       repo: string,
       body: Deployment,
       params?: RequestParams,
-    ) => Promise<DeploymentResp>;
+    ) => Promise<HttpResponse<DeploymentResp, unknown>>;
     /**
      * @name deploymentsStatusesDetail
      * @request GET:/repos/{owner}/{repo}/deployments/{id}/statuses
@@ -2378,7 +2453,7 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
       repo: string,
       id: number,
       params?: RequestParams,
-    ) => Promise<DeploymentStatuses>;
+    ) => Promise<HttpResponse<DeploymentStatuses, unknown>>;
     /**
      * @name deploymentsStatusesCreate
      * @request POST:/repos/{owner}/{repo}/deployments/{id}/statuses
@@ -2390,19 +2465,24 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
       id: number,
       body: DeploymentStatusesCreate,
       params?: RequestParams,
-    ) => Promise<any>;
+    ) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name downloadsDetail
      * @request GET:/repos/{owner}/{repo}/downloads
      * @description Deprecated. List downloads for a repository.
      */
-    downloadsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Downloads>;
+    downloadsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<HttpResponse<Downloads, unknown>>;
     /**
      * @name downloadsDelete
      * @request DELETE:/repos/{owner}/{repo}/downloads/{downloadId}
      * @description Deprecated. Delete a download.
      */
-    downloadsDelete: (owner: string, repo: string, downloadId: number, params?: RequestParams) => Promise<any>;
+    downloadsDelete: (
+      owner: string,
+      repo: string,
+      downloadId: number,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name downloadsDetail
      * @request GET:/repos/{owner}/{repo}/downloads/{downloadId}
@@ -2410,13 +2490,18 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
      * @originalName downloadsDetail
      * @duplicate
      */
-    downloadsDetail2: (owner: string, repo: string, downloadId: number, params?: RequestParams) => Promise<Download>;
+    downloadsDetail2: (
+      owner: string,
+      repo: string,
+      downloadId: number,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<Download, unknown>>;
     /**
      * @name eventsDetail
      * @request GET:/repos/{owner}/{repo}/events
      * @description Get list of repository events.
      */
-    eventsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Events>;
+    eventsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<HttpResponse<Events, unknown>>;
     /**
      * @name forksDetail
      * @request GET:/repos/{owner}/{repo}/forks
@@ -2429,55 +2514,90 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
         sort?: "newes" | "oldes" | "watchers";
       },
       params?: RequestParams,
-    ) => Promise<Repos>;
+    ) => Promise<HttpResponse<Repos, unknown>>;
     /**
      * @name forksCreate
      * @request POST:/repos/{owner}/{repo}/forks
      * @description Create a fork. Forking a Repository happens asynchronously. Therefore, you may have to wai a short period before accessing the git objects. If this takes longer than 5 minutes, be sure to contact Support.
      */
-    forksCreate: (owner: string, repo: string, body: ForkBody, params?: RequestParams) => Promise<Repo>;
+    forksCreate: (
+      owner: string,
+      repo: string,
+      body: ForkBody,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<Repo, unknown>>;
     /**
      * @name gitBlobsCreate
      * @request POST:/repos/{owner}/{repo}/git/blobs
      * @description Create a Blob.
      */
-    gitBlobsCreate: (owner: string, repo: string, body: Blob, params?: RequestParams) => Promise<Blobs>;
+    gitBlobsCreate: (
+      owner: string,
+      repo: string,
+      body: Blob,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<Blobs, unknown>>;
     /**
      * @name gitBlobsDetail
      * @request GET:/repos/{owner}/{repo}/git/blobs/{shaCode}
      * @description Get a Blob. Since blobs can be any arbitrary binary data, the input and responses for the blob API takes an encoding parameter that can be either utf-8 or base64. If your data cannot be losslessly sent as a UTF-8 string, you can base64 encode it.
      */
-    gitBlobsDetail: (owner: string, repo: string, shaCode: string, params?: RequestParams) => Promise<Blob>;
+    gitBlobsDetail: (
+      owner: string,
+      repo: string,
+      shaCode: string,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<Blob, unknown>>;
     /**
      * @name gitCommitsCreate
      * @request POST:/repos/{owner}/{repo}/git/commits
      * @description Create a Commit.
      */
-    gitCommitsCreate: (owner: string, repo: string, body: RepoCommitBody, params?: RequestParams) => Promise<GitCommit>;
+    gitCommitsCreate: (
+      owner: string,
+      repo: string,
+      body: RepoCommitBody,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<GitCommit, unknown>>;
     /**
      * @name gitCommitsDetail
      * @request GET:/repos/{owner}/{repo}/git/commits/{shaCode}
      * @description Get a Commit.
      */
-    gitCommitsDetail: (owner: string, repo: string, shaCode: string, params?: RequestParams) => Promise<RepoCommit>;
+    gitCommitsDetail: (
+      owner: string,
+      repo: string,
+      shaCode: string,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<RepoCommit, unknown>>;
     /**
      * @name gitRefsDetail
      * @request GET:/repos/{owner}/{repo}/git/refs
      * @description Get all References
      */
-    gitRefsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Refs>;
+    gitRefsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<HttpResponse<Refs, unknown>>;
     /**
      * @name gitRefsCreate
      * @request POST:/repos/{owner}/{repo}/git/refs
      * @description Create a Reference
      */
-    gitRefsCreate: (owner: string, repo: string, body: RefsBody, params?: RequestParams) => Promise<HeadBranch>;
+    gitRefsCreate: (
+      owner: string,
+      repo: string,
+      body: RefsBody,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<HeadBranch, unknown>>;
     /**
      * @name gitRefsDelete
      * @request DELETE:/repos/{owner}/{repo}/git/refs/{ref}
      * @description Delete a Reference Example: Deleting a branch: DELETE /repos/octocat/Hello-World/git/refs/heads/feature-a Example: Deleting a tag:        DELETE /repos/octocat/Hello-World/git/refs/tags/v1.0
      */
-    gitRefsDelete: (owner: string, repo: string, ref: string, params?: RequestParams) => Promise<any>;
+    gitRefsDelete: (
+      owner: string,
+      repo: string,
+      ref: string,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name gitRefsDetail
      * @request GET:/repos/{owner}/{repo}/git/refs/{ref}
@@ -2485,7 +2605,12 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
      * @originalName gitRefsDetail
      * @duplicate
      */
-    gitRefsDetail2: (owner: string, repo: string, ref: string, params?: RequestParams) => Promise<HeadBranch>;
+    gitRefsDetail2: (
+      owner: string,
+      repo: string,
+      ref: string,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<HeadBranch, unknown>>;
     /**
      * @name gitRefsPartialUpdate
      * @request PATCH:/repos/{owner}/{repo}/git/refs/{ref}
@@ -2497,25 +2622,40 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
       ref: string,
       body: GitRefPatch,
       params?: RequestParams,
-    ) => Promise<HeadBranch>;
+    ) => Promise<HttpResponse<HeadBranch, unknown>>;
     /**
      * @name gitTagsCreate
      * @request POST:/repos/{owner}/{repo}/git/tags
      * @description Create a Tag Object. Note that creating a tag object does not create the reference that makes a tag in Git. If you want to create an annotated tag in Git, you have to do this call to create the tag object, and then create the refs/tags/[tag] reference. If you want to create a lightweight tag, you only have to create the tag reference - this call would be unnecessary.
      */
-    gitTagsCreate: (owner: string, repo: string, body: TagBody, params?: RequestParams) => Promise<Tag>;
+    gitTagsCreate: (
+      owner: string,
+      repo: string,
+      body: TagBody,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<Tag, unknown>>;
     /**
      * @name gitTagsDetail
      * @request GET:/repos/{owner}/{repo}/git/tags/{shaCode}
      * @description Get a Tag.
      */
-    gitTagsDetail: (owner: string, repo: string, shaCode: string, params?: RequestParams) => Promise<Tag>;
+    gitTagsDetail: (
+      owner: string,
+      repo: string,
+      shaCode: string,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<Tag, unknown>>;
     /**
      * @name gitTreesCreate
      * @request POST:/repos/{owner}/{repo}/git/trees
      * @description Create a Tree. The tree creation API will take nested entries as well. If both a tree and a nested path modifying that tree are specified, it will overwrite the contents of that tree with the new path contents and write a new tree out.
      */
-    gitTreesCreate: (owner: string, repo: string, body: Tree, params?: RequestParams) => Promise<Trees>;
+    gitTreesCreate: (
+      owner: string,
+      repo: string,
+      body: Tree,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<Trees, unknown>>;
     /**
      * @name gitTreesDetail
      * @request GET:/repos/{owner}/{repo}/git/trees/{shaCode}
@@ -2529,25 +2669,35 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
         recursive?: number;
       },
       params?: RequestParams,
-    ) => Promise<Tree>;
+    ) => Promise<HttpResponse<Tree, unknown>>;
     /**
      * @name hooksDetail
      * @request GET:/repos/{owner}/{repo}/hooks
      * @description Get list of hooks.
      */
-    hooksDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Hook>;
+    hooksDetail: (owner: string, repo: string, params?: RequestParams) => Promise<HttpResponse<Hook, unknown>>;
     /**
      * @name hooksCreate
      * @request POST:/repos/{owner}/{repo}/hooks
      * @description Create a hook.
      */
-    hooksCreate: (owner: string, repo: string, body: HookBody, params?: RequestParams) => Promise<Hook>;
+    hooksCreate: (
+      owner: string,
+      repo: string,
+      body: HookBody,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<Hook, unknown>>;
     /**
      * @name hooksDelete
      * @request DELETE:/repos/{owner}/{repo}/hooks/{hookId}
      * @description Delete a hook.
      */
-    hooksDelete: (owner: string, repo: string, hookId: number, params?: RequestParams) => Promise<any>;
+    hooksDelete: (
+      owner: string,
+      repo: string,
+      hookId: number,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name hooksDetail
      * @request GET:/repos/{owner}/{repo}/hooks/{hookId}
@@ -2555,7 +2705,12 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
      * @originalName hooksDetail
      * @duplicate
      */
-    hooksDetail2: (owner: string, repo: string, hookId: number, params?: RequestParams) => Promise<Hook>;
+    hooksDetail2: (
+      owner: string,
+      repo: string,
+      hookId: number,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<Hook, unknown>>;
     /**
      * @name hooksPartialUpdate
      * @request PATCH:/repos/{owner}/{repo}/hooks/{hookId}
@@ -2567,13 +2722,18 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
       hookId: number,
       body: HookBody,
       params?: RequestParams,
-    ) => Promise<Hook>;
+    ) => Promise<HttpResponse<Hook, unknown>>;
     /**
      * @name hooksTestsCreate
      * @request POST:/repos/{owner}/{repo}/hooks/{hookId}/tests
      * @description Test a push hook. This will trigger the hook with the latest push to the current repository if the hook is subscribed to push events. If the hook is not subscribed to push events, the server will respond with 204 but no test POST will be generated. Note: Previously /repos/:owner/:repo/hooks/:id/tes
      */
-    hooksTestsCreate: (owner: string, repo: string, hookId: number, params?: RequestParams) => Promise<any>;
+    hooksTestsCreate: (
+      owner: string,
+      repo: string,
+      hookId: number,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name issuesDetail
      * @request GET:/repos/{owner}/{repo}/issues
@@ -2591,13 +2751,18 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
         since?: string;
       },
       params?: RequestParams,
-    ) => Promise<Issues>;
+    ) => Promise<HttpResponse<Issues, unknown>>;
     /**
      * @name issuesCreate
      * @request POST:/repos/{owner}/{repo}/issues
      * @description Create an issue. Any user with pull access to a repository can create an issue.
      */
-    issuesCreate: (owner: string, repo: string, body: Issue, params?: RequestParams) => Promise<Issue>;
+    issuesCreate: (
+      owner: string,
+      repo: string,
+      body: Issue,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<Issue, unknown>>;
     /**
      * @name issuesCommentsDetail
      * @request GET:/repos/{owner}/{repo}/issues/comments
@@ -2612,13 +2777,18 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
         since?: string;
       },
       params?: RequestParams,
-    ) => Promise<IssuesComments>;
+    ) => Promise<HttpResponse<IssuesComments, unknown>>;
     /**
      * @name issuesCommentsDelete
      * @request DELETE:/repos/{owner}/{repo}/issues/comments/{commentId}
      * @description Delete a comment.
      */
-    issuesCommentsDelete: (owner: string, repo: string, commentId: number, params?: RequestParams) => Promise<any>;
+    issuesCommentsDelete: (
+      owner: string,
+      repo: string,
+      commentId: number,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name issuesCommentsDetail
      * @request GET:/repos/{owner}/{repo}/issues/comments/{commentId}
@@ -2631,7 +2801,7 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
       repo: string,
       commentId: number,
       params?: RequestParams,
-    ) => Promise<IssuesComment>;
+    ) => Promise<HttpResponse<IssuesComment, unknown>>;
     /**
      * @name issuesCommentsPartialUpdate
      * @request PATCH:/repos/{owner}/{repo}/issues/comments/{commentId}
@@ -2643,13 +2813,17 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
       commentId: number,
       body: CommentBody,
       params?: RequestParams,
-    ) => Promise<IssuesComment>;
+    ) => Promise<HttpResponse<IssuesComment, unknown>>;
     /**
      * @name issuesEventsDetail
      * @request GET:/repos/{owner}/{repo}/issues/events
      * @description List issue events for a repository.
      */
-    issuesEventsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<IssueEvents>;
+    issuesEventsDetail: (
+      owner: string,
+      repo: string,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<IssueEvents, unknown>>;
     /**
      * @name issuesEventsDetail
      * @request GET:/repos/{owner}/{repo}/issues/events/{eventId}
@@ -2657,7 +2831,12 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
      * @originalName issuesEventsDetail
      * @duplicate
      */
-    issuesEventsDetail2: (owner: string, repo: string, eventId: number, params?: RequestParams) => Promise<IssueEvent>;
+    issuesEventsDetail2: (
+      owner: string,
+      repo: string,
+      eventId: number,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<IssueEvent, unknown>>;
     /**
      * @name issuesDetail
      * @request GET:/repos/{owner}/{repo}/issues/{number}
@@ -2665,7 +2844,12 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
      * @originalName issuesDetail
      * @duplicate
      */
-    issuesDetail2: (owner: string, repo: string, number: number, params?: RequestParams) => Promise<Issue>;
+    issuesDetail2: (
+      owner: string,
+      repo: string,
+      number: number,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<Issue, unknown>>;
     /**
      * @name issuesPartialUpdate
      * @request PATCH:/repos/{owner}/{repo}/issues/{number}
@@ -2677,7 +2861,7 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
       number: number,
       body: Issue,
       params?: RequestParams,
-    ) => Promise<Issue>;
+    ) => Promise<HttpResponse<Issue, unknown>>;
     /**
      * @name issuesCommentsDetail
      * @request GET:/repos/{owner}/{repo}/issues/{number}/comments
@@ -2690,7 +2874,7 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
       repo: string,
       number: number,
       params?: RequestParams,
-    ) => Promise<IssuesComments>;
+    ) => Promise<HttpResponse<IssuesComments, unknown>>;
     /**
      * @name issuesCommentsCreate
      * @request POST:/repos/{owner}/{repo}/issues/{number}/comments
@@ -2702,7 +2886,7 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
       number: number,
       body: CommentBody,
       params?: RequestParams,
-    ) => Promise<IssuesComment>;
+    ) => Promise<HttpResponse<IssuesComment, unknown>>;
     /**
      * @name issuesEventsDetail
      * @request GET:/repos/{owner}/{repo}/issues/{number}/events
@@ -2710,19 +2894,34 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
      * @originalName issuesEventsDetail
      * @duplicate
      */
-    issuesEventsDetail3: (owner: string, repo: string, number: number, params?: RequestParams) => Promise<IssueEvents>;
+    issuesEventsDetail3: (
+      owner: string,
+      repo: string,
+      number: number,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<IssueEvents, unknown>>;
     /**
      * @name issuesLabelsDelete
      * @request DELETE:/repos/{owner}/{repo}/issues/{number}/labels
      * @description Remove all labels from an issue.
      */
-    issuesLabelsDelete: (owner: string, repo: string, number: number, params?: RequestParams) => Promise<any>;
+    issuesLabelsDelete: (
+      owner: string,
+      repo: string,
+      number: number,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name issuesLabelsDetail
      * @request GET:/repos/{owner}/{repo}/issues/{number}/labels
      * @description List labels on an issue.
      */
-    issuesLabelsDetail: (owner: string, repo: string, number: number, params?: RequestParams) => Promise<Labels>;
+    issuesLabelsDetail: (
+      owner: string,
+      repo: string,
+      number: number,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<Labels, unknown>>;
     /**
      * @name issuesLabelsCreate
      * @request POST:/repos/{owner}/{repo}/issues/{number}/labels
@@ -2734,7 +2933,7 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
       number: number,
       body: EmailsPost,
       params?: RequestParams,
-    ) => Promise<Label>;
+    ) => Promise<HttpResponse<Label, unknown>>;
     /**
      * @name issuesLabelsUpdate
      * @request PUT:/repos/{owner}/{repo}/issues/{number}/labels
@@ -2746,7 +2945,7 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
       number: number,
       body: EmailsPost,
       params?: RequestParams,
-    ) => Promise<Label>;
+    ) => Promise<HttpResponse<Label, unknown>>;
     /**
      * @name issuesLabelsDelete
      * @request DELETE:/repos/{owner}/{repo}/issues/{number}/labels/{name}
@@ -2760,25 +2959,35 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
       number: number,
       name: string,
       params?: RequestParams,
-    ) => Promise<any>;
+    ) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name keysDetail
      * @request GET:/repos/{owner}/{repo}/keys
      * @description Get list of keys.
      */
-    keysDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Keys>;
+    keysDetail: (owner: string, repo: string, params?: RequestParams) => Promise<HttpResponse<Keys, unknown>>;
     /**
      * @name keysCreate
      * @request POST:/repos/{owner}/{repo}/keys
      * @description Create a key.
      */
-    keysCreate: (owner: string, repo: string, body: UserKeysPost, params?: RequestParams) => Promise<UserKeysKeyId>;
+    keysCreate: (
+      owner: string,
+      repo: string,
+      body: UserKeysPost,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<UserKeysKeyId, unknown>>;
     /**
      * @name keysDelete
      * @request DELETE:/repos/{owner}/{repo}/keys/{keyId}
      * @description Delete a key.
      */
-    keysDelete: (owner: string, repo: string, keyId: number, params?: RequestParams) => Promise<any>;
+    keysDelete: (
+      owner: string,
+      repo: string,
+      keyId: number,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name keysDetail
      * @request GET:/repos/{owner}/{repo}/keys/{keyId}
@@ -2786,25 +2995,40 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
      * @originalName keysDetail
      * @duplicate
      */
-    keysDetail2: (owner: string, repo: string, keyId: number, params?: RequestParams) => Promise<UserKeysKeyId>;
+    keysDetail2: (
+      owner: string,
+      repo: string,
+      keyId: number,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<UserKeysKeyId, unknown>>;
     /**
      * @name labelsDetail
      * @request GET:/repos/{owner}/{repo}/labels
      * @description List all labels for this repository.
      */
-    labelsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Labels>;
+    labelsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<HttpResponse<Labels, unknown>>;
     /**
      * @name labelsCreate
      * @request POST:/repos/{owner}/{repo}/labels
      * @description Create a label.
      */
-    labelsCreate: (owner: string, repo: string, body: EmailsPost, params?: RequestParams) => Promise<Label>;
+    labelsCreate: (
+      owner: string,
+      repo: string,
+      body: EmailsPost,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<Label, unknown>>;
     /**
      * @name labelsDelete
      * @request DELETE:/repos/{owner}/{repo}/labels/{name}
      * @description Delete a label.
      */
-    labelsDelete: (owner: string, repo: string, name: string, params?: RequestParams) => Promise<any>;
+    labelsDelete: (
+      owner: string,
+      repo: string,
+      name: string,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name labelsDetail
      * @request GET:/repos/{owner}/{repo}/labels/{name}
@@ -2812,7 +3036,12 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
      * @originalName labelsDetail
      * @duplicate
      */
-    labelsDetail2: (owner: string, repo: string, name: string, params?: RequestParams) => Promise<Label>;
+    labelsDetail2: (
+      owner: string,
+      repo: string,
+      name: string,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<Label, unknown>>;
     /**
      * @name labelsPartialUpdate
      * @request PATCH:/repos/{owner}/{repo}/labels/{name}
@@ -2824,19 +3053,28 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
       name: string,
       body: EmailsPost,
       params?: RequestParams,
-    ) => Promise<Label>;
+    ) => Promise<HttpResponse<Label, unknown>>;
     /**
      * @name languagesDetail
      * @request GET:/repos/{owner}/{repo}/languages
      * @description List languages. List languages for the specified repository. The value on the right of a language is the number of bytes of code written in that language.
      */
-    languagesDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Record<string, number>>;
+    languagesDetail: (
+      owner: string,
+      repo: string,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<Record<string, number>, unknown>>;
     /**
      * @name mergesCreate
      * @request POST:/repos/{owner}/{repo}/merges
      * @description Perform a merge.
      */
-    mergesCreate: (owner: string, repo: string, body: MergesBody, params?: RequestParams) => Promise<MergesSuccessful>;
+    mergesCreate: (
+      owner: string,
+      repo: string,
+      body: MergesBody,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<MergesSuccessful, unknown>>;
     /**
      * @name milestonesDetail
      * @request GET:/repos/{owner}/{repo}/milestones
@@ -2851,7 +3089,7 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
         sort?: "due_date" | "completeness";
       },
       params?: RequestParams,
-    ) => Promise<Milestone>;
+    ) => Promise<HttpResponse<Milestone, unknown>>;
     /**
      * @name milestonesCreate
      * @request POST:/repos/{owner}/{repo}/milestones
@@ -2862,13 +3100,18 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
       repo: string,
       body: MilestoneUpdate,
       params?: RequestParams,
-    ) => Promise<Milestone>;
+    ) => Promise<HttpResponse<Milestone, unknown>>;
     /**
      * @name milestonesDelete
      * @request DELETE:/repos/{owner}/{repo}/milestones/{number}
      * @description Delete a milestone.
      */
-    milestonesDelete: (owner: string, repo: string, number: number, params?: RequestParams) => Promise<any>;
+    milestonesDelete: (
+      owner: string,
+      repo: string,
+      number: number,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name milestonesDetail
      * @request GET:/repos/{owner}/{repo}/milestones/{number}
@@ -2876,7 +3119,12 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
      * @originalName milestonesDetail
      * @duplicate
      */
-    milestonesDetail2: (owner: string, repo: string, number: number, params?: RequestParams) => Promise<Milestone>;
+    milestonesDetail2: (
+      owner: string,
+      repo: string,
+      number: number,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<Milestone, unknown>>;
     /**
      * @name milestonesPartialUpdate
      * @request PATCH:/repos/{owner}/{repo}/milestones/{number}
@@ -2888,13 +3136,18 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
       number: number,
       body: MilestoneUpdate,
       params?: RequestParams,
-    ) => Promise<Milestone>;
+    ) => Promise<HttpResponse<Milestone, unknown>>;
     /**
      * @name milestonesLabelsDetail
      * @request GET:/repos/{owner}/{repo}/milestones/{number}/labels
      * @description Get labels for every issue in a milestone.
      */
-    milestonesLabelsDetail: (owner: string, repo: string, number: number, params?: RequestParams) => Promise<Labels>;
+    milestonesLabelsDetail: (
+      owner: string,
+      repo: string,
+      number: number,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<Labels, unknown>>;
     /**
      * @name notificationsDetail
      * @request GET:/repos/{owner}/{repo}/notifications
@@ -2909,7 +3162,7 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
         since?: string;
       },
       params?: RequestParams,
-    ) => Promise<Notifications>;
+    ) => Promise<HttpResponse<Notifications, unknown>>;
     /**
      * @name notificationsUpdate
      * @request PUT:/repos/{owner}/{repo}/notifications
@@ -2920,7 +3173,7 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
       repo: string,
       body: NotificationMarkRead,
       params?: RequestParams,
-    ) => Promise<any>;
+    ) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name pullsDetail
      * @request GET:/repos/{owner}/{repo}/pulls
@@ -2935,13 +3188,18 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
         base?: string;
       },
       params?: RequestParams,
-    ) => Promise<Pulls>;
+    ) => Promise<HttpResponse<Pulls, unknown>>;
     /**
      * @name pullsCreate
      * @request POST:/repos/{owner}/{repo}/pulls
      * @description Create a pull request.
      */
-    pullsCreate: (owner: string, repo: string, body: PullsPost, params?: RequestParams) => Promise<Pulls>;
+    pullsCreate: (
+      owner: string,
+      repo: string,
+      body: PullsPost,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<Pulls, unknown>>;
     /**
      * @name pullsCommentsDetail
      * @request GET:/repos/{owner}/{repo}/pulls/comments
@@ -2956,13 +3214,18 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
         since?: string;
       },
       params?: RequestParams,
-    ) => Promise<IssuesComments>;
+    ) => Promise<HttpResponse<IssuesComments, unknown>>;
     /**
      * @name pullsCommentsDelete
      * @request DELETE:/repos/{owner}/{repo}/pulls/comments/{commentId}
      * @description Delete a comment.
      */
-    pullsCommentsDelete: (owner: string, repo: string, commentId: number, params?: RequestParams) => Promise<any>;
+    pullsCommentsDelete: (
+      owner: string,
+      repo: string,
+      commentId: number,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name pullsCommentsDetail
      * @request GET:/repos/{owner}/{repo}/pulls/comments/{commentId}
@@ -2975,7 +3238,7 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
       repo: string,
       commentId: number,
       params?: RequestParams,
-    ) => Promise<PullsComment>;
+    ) => Promise<HttpResponse<PullsComment, unknown>>;
     /**
      * @name pullsCommentsPartialUpdate
      * @request PATCH:/repos/{owner}/{repo}/pulls/comments/{commentId}
@@ -2987,7 +3250,7 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
       commentId: number,
       body: CommentBody,
       params?: RequestParams,
-    ) => Promise<PullsComment>;
+    ) => Promise<HttpResponse<PullsComment, unknown>>;
     /**
      * @name pullsDetail
      * @request GET:/repos/{owner}/{repo}/pulls/{number}
@@ -2995,7 +3258,12 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
      * @originalName pullsDetail
      * @duplicate
      */
-    pullsDetail2: (owner: string, repo: string, number: number, params?: RequestParams) => Promise<PullRequest>;
+    pullsDetail2: (
+      owner: string,
+      repo: string,
+      number: number,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<PullRequest, unknown>>;
     /**
      * @name pullsPartialUpdate
      * @request PATCH:/repos/{owner}/{repo}/pulls/{number}
@@ -3007,7 +3275,7 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
       number: number,
       body: PullUpdate,
       params?: RequestParams,
-    ) => Promise<Repo>;
+    ) => Promise<HttpResponse<Repo, unknown>>;
     /**
      * @name pullsCommentsDetail
      * @request GET:/repos/{owner}/{repo}/pulls/{number}/comments
@@ -3020,7 +3288,7 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
       repo: string,
       number: number,
       params?: RequestParams,
-    ) => Promise<PullsComment>;
+    ) => Promise<HttpResponse<PullsComment, unknown>>;
     /**
      * @name pullsCommentsCreate
      * @request POST:/repos/{owner}/{repo}/pulls/{number}/comments
@@ -3032,25 +3300,40 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
       number: number,
       body: PullsCommentPost,
       params?: RequestParams,
-    ) => Promise<PullsComment>;
+    ) => Promise<HttpResponse<PullsComment, unknown>>;
     /**
      * @name pullsCommitsDetail
      * @request GET:/repos/{owner}/{repo}/pulls/{number}/commits
      * @description List commits on a pull request.
      */
-    pullsCommitsDetail: (owner: string, repo: string, number: number, params?: RequestParams) => Promise<Commits>;
+    pullsCommitsDetail: (
+      owner: string,
+      repo: string,
+      number: number,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<Commits, unknown>>;
     /**
      * @name pullsFilesDetail
      * @request GET:/repos/{owner}/{repo}/pulls/{number}/files
      * @description List pull requests files.
      */
-    pullsFilesDetail: (owner: string, repo: string, number: number, params?: RequestParams) => Promise<Pulls>;
+    pullsFilesDetail: (
+      owner: string,
+      repo: string,
+      number: number,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<Pulls, unknown>>;
     /**
      * @name pullsMergeDetail
      * @request GET:/repos/{owner}/{repo}/pulls/{number}/merge
      * @description Get if a pull request has been merged.
      */
-    pullsMergeDetail: (owner: string, repo: string, number: number, params?: RequestParams) => Promise<any>;
+    pullsMergeDetail: (
+      owner: string,
+      repo: string,
+      number: number,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name pullsMergeUpdate
      * @request PUT:/repos/{owner}/{repo}/pulls/{number}/merge
@@ -3062,7 +3345,7 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
       number: number,
       body: MergePullBody,
       params?: RequestParams,
-    ) => Promise<Merge>;
+    ) => Promise<HttpResponse<Merge, unknown>>;
     /**
      * @name readmeDetail
      * @request GET:/repos/{owner}/{repo}/readme
@@ -3075,31 +3358,46 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
         ref?: string;
       },
       params?: RequestParams,
-    ) => Promise<ContentsPath>;
+    ) => Promise<HttpResponse<ContentsPath, unknown>>;
     /**
      * @name releasesDetail
      * @request GET:/repos/{owner}/{repo}/releases
      * @description Users with push access to the repository will receive all releases (i.e., published releases and draft releases). Users with pull access will receive published releases only
      */
-    releasesDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Releases>;
+    releasesDetail: (owner: string, repo: string, params?: RequestParams) => Promise<HttpResponse<Releases, unknown>>;
     /**
      * @name releasesCreate
      * @request POST:/repos/{owner}/{repo}/releases
      * @description Create a release Users with push access to the repository can create a release.
      */
-    releasesCreate: (owner: string, repo: string, body: ReleaseCreate, params?: RequestParams) => Promise<Release>;
+    releasesCreate: (
+      owner: string,
+      repo: string,
+      body: ReleaseCreate,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<Release, unknown>>;
     /**
      * @name releasesAssetsDelete
      * @request DELETE:/repos/{owner}/{repo}/releases/assets/{id}
      * @description Delete a release asset
      */
-    releasesAssetsDelete: (owner: string, repo: string, id: string, params?: RequestParams) => Promise<any>;
+    releasesAssetsDelete: (
+      owner: string,
+      repo: string,
+      id: string,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name releasesAssetsDetail
      * @request GET:/repos/{owner}/{repo}/releases/assets/{id}
      * @description Get a single release asset
      */
-    releasesAssetsDetail: (owner: string, repo: string, id: string, params?: RequestParams) => Promise<Asset>;
+    releasesAssetsDetail: (
+      owner: string,
+      repo: string,
+      id: string,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<Asset, unknown>>;
     /**
      * @name releasesAssetsPartialUpdate
      * @request PATCH:/repos/{owner}/{repo}/releases/assets/{id}
@@ -3111,13 +3409,18 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
       id: string,
       body: AssetPatch,
       params?: RequestParams,
-    ) => Promise<Asset>;
+    ) => Promise<HttpResponse<Asset, unknown>>;
     /**
      * @name releasesDelete
      * @request DELETE:/repos/{owner}/{repo}/releases/{id}
      * @description Users with push access to the repository can delete a release.
      */
-    releasesDelete: (owner: string, repo: string, id: string, params?: RequestParams) => Promise<any>;
+    releasesDelete: (
+      owner: string,
+      repo: string,
+      id: string,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name releasesDetail
      * @request GET:/repos/{owner}/{repo}/releases/{id}
@@ -3125,7 +3428,12 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
      * @originalName releasesDetail
      * @duplicate
      */
-    releasesDetail2: (owner: string, repo: string, id: string, params?: RequestParams) => Promise<Release>;
+    releasesDetail2: (
+      owner: string,
+      repo: string,
+      id: string,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<Release, unknown>>;
     /**
      * @name releasesPartialUpdate
      * @request PATCH:/repos/{owner}/{repo}/releases/{id}
@@ -3137,7 +3445,7 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
       id: string,
       body: ReleaseCreate,
       params?: RequestParams,
-    ) => Promise<Release>;
+    ) => Promise<HttpResponse<Release, unknown>>;
     /**
      * @name releasesAssetsDetail
      * @request GET:/repos/{owner}/{repo}/releases/{id}/assets
@@ -3145,49 +3453,79 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
      * @originalName releasesAssetsDetail
      * @duplicate
      */
-    releasesAssetsDetail2: (owner: string, repo: string, id: string, params?: RequestParams) => Promise<Assets>;
+    releasesAssetsDetail2: (
+      owner: string,
+      repo: string,
+      id: string,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<Assets, unknown>>;
     /**
      * @name stargazersDetail
      * @request GET:/repos/{owner}/{repo}/stargazers
      * @description List Stargazers.
      */
-    stargazersDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Users>;
+    stargazersDetail: (owner: string, repo: string, params?: RequestParams) => Promise<HttpResponse<Users, unknown>>;
     /**
      * @name statsCodeFrequencyDetail
      * @request GET:/repos/{owner}/{repo}/stats/code_frequency
      * @description Get the number of additions and deletions per week. Returns a weekly aggregate of the number of additions and deletions pushed to a repository.
      */
-    statsCodeFrequencyDetail: (owner: string, repo: string, params?: RequestParams) => Promise<CodeFrequencyStats>;
+    statsCodeFrequencyDetail: (
+      owner: string,
+      repo: string,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<CodeFrequencyStats, unknown>>;
     /**
      * @name statsCommitActivityDetail
      * @request GET:/repos/{owner}/{repo}/stats/commit_activity
      * @description Get the last year of commit activity data. Returns the last year of commit activity grouped by week. The days array is a group of commits per day, starting on Sunday.
      */
-    statsCommitActivityDetail: (owner: string, repo: string, params?: RequestParams) => Promise<CommitActivityStats>;
+    statsCommitActivityDetail: (
+      owner: string,
+      repo: string,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<CommitActivityStats, unknown>>;
     /**
      * @name statsContributorsDetail
      * @request GET:/repos/{owner}/{repo}/stats/contributors
      * @description Get contributors list with additions, deletions, and commit counts.
      */
-    statsContributorsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<ContributorsStats>;
+    statsContributorsDetail: (
+      owner: string,
+      repo: string,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<ContributorsStats, unknown>>;
     /**
      * @name statsParticipationDetail
      * @request GET:/repos/{owner}/{repo}/stats/participation
      * @description Get the weekly commit count for the repo owner and everyone else.
      */
-    statsParticipationDetail: (owner: string, repo: string, params?: RequestParams) => Promise<ParticipationStats>;
+    statsParticipationDetail: (
+      owner: string,
+      repo: string,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<ParticipationStats, unknown>>;
     /**
      * @name statsPunchCardDetail
      * @request GET:/repos/{owner}/{repo}/stats/punch_card
      * @description Get the number of commits per hour in each day. Each array contains the day number, hour number, and number of commits 0-6 Sunday - Saturday 0-23 Hour of day Number of commits For example, [2, 14, 25] indicates that there were 25 total commits, during the 2.00pm hour on Tuesdays. All times are based on the time zone of individual commits.
      */
-    statsPunchCardDetail: (owner: string, repo: string, params?: RequestParams) => Promise<CodeFrequencyStats>;
+    statsPunchCardDetail: (
+      owner: string,
+      repo: string,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<CodeFrequencyStats, unknown>>;
     /**
      * @name statusesDetail
      * @request GET:/repos/{owner}/{repo}/statuses/{ref}
      * @description List Statuses for a specific Ref.
      */
-    statusesDetail: (owner: string, repo: string, ref: string, params?: RequestParams) => Promise<Ref>;
+    statusesDetail: (
+      owner: string,
+      repo: string,
+      ref: string,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<Ref, unknown>>;
     /**
      * @name statusesCreate
      * @request POST:/repos/{owner}/{repo}/statuses/{ref}
@@ -3199,25 +3537,29 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
       ref: string,
       body: HeadBranch,
       params?: RequestParams,
-    ) => Promise<Ref>;
+    ) => Promise<HttpResponse<Ref, unknown>>;
     /**
      * @name subscribersDetail
      * @request GET:/repos/{owner}/{repo}/subscribers
      * @description List watchers.
      */
-    subscribersDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Users>;
+    subscribersDetail: (owner: string, repo: string, params?: RequestParams) => Promise<HttpResponse<Users, unknown>>;
     /**
      * @name subscriptionDelete
      * @request DELETE:/repos/{owner}/{repo}/subscription
      * @description Delete a Repository Subscription.
      */
-    subscriptionDelete: (owner: string, repo: string, params?: RequestParams) => Promise<any>;
+    subscriptionDelete: (owner: string, repo: string, params?: RequestParams) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name subscriptionDetail
      * @request GET:/repos/{owner}/{repo}/subscription
      * @description Get a Repository Subscription.
      */
-    subscriptionDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Subscription>;
+    subscriptionDetail: (
+      owner: string,
+      repo: string,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<Subscription, unknown>>;
     /**
      * @name subscriptionUpdate
      * @request PUT:/repos/{owner}/{repo}/subscription
@@ -3228,25 +3570,25 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
       repo: string,
       body: SubscriptionBody,
       params?: RequestParams,
-    ) => Promise<Subscription>;
+    ) => Promise<HttpResponse<Subscription, unknown>>;
     /**
      * @name tagsDetail
      * @request GET:/repos/{owner}/{repo}/tags
      * @description Get list of tags.
      */
-    tagsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Tags>;
+    tagsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<HttpResponse<Tags, unknown>>;
     /**
      * @name teamsDetail
      * @request GET:/repos/{owner}/{repo}/teams
      * @description Get list of teams
      */
-    teamsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Teams>;
+    teamsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<HttpResponse<Teams, unknown>>;
     /**
      * @name watchersDetail
      * @request GET:/repos/{owner}/{repo}/watchers
      * @description List Stargazers. New implementation.
      */
-    watchersDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Users>;
+    watchersDetail: (owner: string, repo: string, params?: RequestParams) => Promise<HttpResponse<Users, unknown>>;
     /**
      * @name reposDetail
      * @request GET:/repos/{owner}/{repo}/{archive_format}/{path}
@@ -3260,7 +3602,7 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
       archive_format: "tarball" | "zipball",
       path: string,
       params?: RequestParams,
-    ) => Promise<any>;
+    ) => Promise<HttpResponse<any, unknown>>;
   };
   repositories: {
     /**
@@ -3273,7 +3615,7 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
         since?: string;
       },
       params?: RequestParams,
-    ) => Promise<Repos>;
+    ) => Promise<HttpResponse<Repos, unknown>>;
   };
   search: {
     /**
@@ -3288,7 +3630,7 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
         sort?: "indexed";
       },
       params?: RequestParams,
-    ) => Promise<SearchCode>;
+    ) => Promise<HttpResponse<SearchCode, unknown>>;
     /**
      * @name issuesList
      * @request GET:/search/issues
@@ -3301,7 +3643,7 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
         sort?: "updated" | "created" | "comments";
       },
       params?: RequestParams,
-    ) => Promise<SearchIssues>;
+    ) => Promise<HttpResponse<SearchIssues, unknown>>;
     /**
      * @name repositoriesList
      * @request GET:/search/repositories
@@ -3314,7 +3656,7 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
         sort?: "stars" | "forks" | "updated";
       },
       params?: RequestParams,
-    ) => Promise<SearchRepositories>;
+    ) => Promise<HttpResponse<SearchRepositories, unknown>>;
     /**
      * @name usersList
      * @request GET:/search/users
@@ -3327,7 +3669,7 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
         sort?: "followers" | "repositories" | "joined";
       },
       params?: RequestParams,
-    ) => Promise<SearchUsers>;
+    ) => Promise<HttpResponse<SearchUsers, unknown>>;
   };
   teams: {
     /**
@@ -3335,31 +3677,35 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
      * @request DELETE:/teams/{teamId}
      * @description Delete team. In order to delete a team, the authenticated user must be an owner of the org that the team is associated with.
      */
-    teamsDelete: (teamId: number, params?: RequestParams) => Promise<any>;
+    teamsDelete: (teamId: number, params?: RequestParams) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name teamsDetail
      * @request GET:/teams/{teamId}
      * @description Get team.
      */
-    teamsDetail: (teamId: number, params?: RequestParams) => Promise<Team>;
+    teamsDetail: (teamId: number, params?: RequestParams) => Promise<HttpResponse<Team, unknown>>;
     /**
      * @name teamsPartialUpdate
      * @request PATCH:/teams/{teamId}
      * @description Edit team. In order to edit a team, the authenticated user must be an owner of the org that the team is associated with.
      */
-    teamsPartialUpdate: (teamId: number, body: EditTeam, params?: RequestParams) => Promise<Team>;
+    teamsPartialUpdate: (
+      teamId: number,
+      body: EditTeam,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<Team, unknown>>;
     /**
      * @name membersDetail
      * @request GET:/teams/{teamId}/members
      * @description List team members. In order to list members in a team, the authenticated user must be a member of the team.
      */
-    membersDetail: (teamId: number, params?: RequestParams) => Promise<Users>;
+    membersDetail: (teamId: number, params?: RequestParams) => Promise<HttpResponse<Users, unknown>>;
     /**
      * @name membersDelete
      * @request DELETE:/teams/{teamId}/members/{username}
      * @description The "Remove team member" API is deprecated and is scheduled for removal in the next major version of the API. We recommend using the Remove team membership API instead. It allows you to remove both active and pending memberships. Remove team member. In order to remove a user from a team, the authenticated user must have 'admin' permissions to the team or be an owner of the org that the team is associated with. NOTE This does not delete the user, it just remove them from the team.
      */
-    membersDelete: (teamId: number, username: string, params?: RequestParams) => Promise<any>;
+    membersDelete: (teamId: number, username: string, params?: RequestParams) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name membersDetail
      * @request GET:/teams/{teamId}/members/{username}
@@ -3367,43 +3713,60 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
      * @originalName membersDetail
      * @duplicate
      */
-    membersDetail2: (teamId: number, username: string, params?: RequestParams) => Promise<any>;
+    membersDetail2: (teamId: number, username: string, params?: RequestParams) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name membersUpdate
      * @request PUT:/teams/{teamId}/members/{username}
      * @description The API (described below) is deprecated and is scheduled for removal in the next major version of the API. We recommend using the Add team membership API instead. It allows you to invite new organization members to your teams. Add team member. In order to add a user to a team, the authenticated user must have 'admin' permissions to the team or be an owner of the org that the team is associated with.
      */
-    membersUpdate: (teamId: number, username: string, params?: RequestParams) => Promise<any>;
+    membersUpdate: (teamId: number, username: string, params?: RequestParams) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name membershipsDelete
      * @request DELETE:/teams/{teamId}/memberships/{username}
      * @description Remove team membership. In order to remove a membership between a user and a team, the authenticated user must have 'admin' permissions to the team or be an owner of the organization that the team is associated with. NOTE: This does not delete the user, it just removes their membership from the team.
      */
-    membershipsDelete: (teamId: number, username: string, params?: RequestParams) => Promise<any>;
+    membershipsDelete: (
+      teamId: number,
+      username: string,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name membershipsDetail
      * @request GET:/teams/{teamId}/memberships/{username}
      * @description Get team membership. In order to get a user's membership with a team, the authenticated user must be a member of the team or an owner of the team's organization.
      */
-    membershipsDetail: (teamId: number, username: string, params?: RequestParams) => Promise<TeamMembership>;
+    membershipsDetail: (
+      teamId: number,
+      username: string,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<TeamMembership, unknown>>;
     /**
      * @name membershipsUpdate
      * @request PUT:/teams/{teamId}/memberships/{username}
      * @description Add team membership. In order to add a membership between a user and a team, the authenticated user must have 'admin' permissions to the team or be an owner of the organization that the team is associated with. If the user is already a part of the team's organization (meaning they're on at least one other team in the organization), this endpoint will add the user to the team. If the user is completely unaffiliated with the team's organization (meaning they're on none of the organization's teams), this endpoint will send an invitation to the user via email. This newly-created membership will be in the 'pending' state until the user accepts the invitation, at which point the membership will transition to the 'active' state and the user will be added as a member of the team.
      */
-    membershipsUpdate: (teamId: number, username: string, params?: RequestParams) => Promise<TeamMembership>;
+    membershipsUpdate: (
+      teamId: number,
+      username: string,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<TeamMembership, unknown>>;
     /**
      * @name reposDetail
      * @request GET:/teams/{teamId}/repos
      * @description List team repos
      */
-    reposDetail: (teamId: number, params?: RequestParams) => Promise<Repos>;
+    reposDetail: (teamId: number, params?: RequestParams) => Promise<HttpResponse<Repos, unknown>>;
     /**
      * @name reposDelete
      * @request DELETE:/teams/{teamId}/repos/{owner}/{repo}
      * @description In order to remove a repository from a team, the authenticated user must be an owner of the org that the team is associated with. NOTE: This does not delete the repository, it just removes it from the team.
      */
-    reposDelete: (teamId: number, owner: string, repo: string, params?: RequestParams) => Promise<any>;
+    reposDelete: (
+      teamId: number,
+      owner: string,
+      repo: string,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name reposDetail
      * @request GET:/teams/{teamId}/repos/{owner}/{repo}
@@ -3411,13 +3774,23 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
      * @originalName reposDetail
      * @duplicate
      */
-    reposDetail2: (teamId: number, owner: string, repo: string, params?: RequestParams) => Promise<any>;
+    reposDetail2: (
+      teamId: number,
+      owner: string,
+      repo: string,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name reposUpdate
      * @request PUT:/teams/{teamId}/repos/{owner}/{repo}
      * @description In order to add a repository to a team, the authenticated user must be an owner of the org that the team is associated with. Also, the repository must be owned by the organization, or a direct fork of a repository owned by the organization.
      */
-    reposUpdate: (teamId: number, owner: string, repo: string, params?: RequestParams) => Promise<any>;
+    reposUpdate: (
+      teamId: number,
+      owner: string,
+      repo: string,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<any, unknown>>;
   };
   user: {
     /**
@@ -3425,61 +3798,61 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
      * @request GET:/user
      * @description Get the authenticated user.
      */
-    userList: (params?: RequestParams) => Promise<any>;
+    userList: (params?: RequestParams) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name userPartialUpdate
      * @request PATCH:/user
      * @description Update the authenticated user.
      */
-    userPartialUpdate: (body: UserUpdate, params?: RequestParams) => Promise<any>;
+    userPartialUpdate: (body: UserUpdate, params?: RequestParams) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name emailsDelete
      * @request DELETE:/user/emails
      * @description Delete email address(es). You can include a single email address or an array of addresses.
      */
-    emailsDelete: (body: UserEmails, params?: RequestParams) => Promise<any>;
+    emailsDelete: (body: UserEmails, params?: RequestParams) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name emailsList
      * @request GET:/user/emails
      * @description List email addresses for a user. In the final version of the API, this method will return an array of hashes with extended information for each email address indicating if the address has been verified and if it's primary email address for GitHub. Until API v3 is finalized, use the application/vnd.github.v3 media type to get other response format.
      */
-    emailsList: (params?: RequestParams) => Promise<UserEmails>;
+    emailsList: (params?: RequestParams) => Promise<HttpResponse<UserEmails, unknown>>;
     /**
      * @name emailsCreate
      * @request POST:/user/emails
      * @description Add email address(es). You can post a single email address or an array of addresses.
      */
-    emailsCreate: (body: EmailsPost, params?: RequestParams) => Promise<any>;
+    emailsCreate: (body: EmailsPost, params?: RequestParams) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name followersList
      * @request GET:/user/followers
      * @description List the authenticated user's followers
      */
-    followersList: (params?: RequestParams) => Promise<Users>;
+    followersList: (params?: RequestParams) => Promise<HttpResponse<Users, unknown>>;
     /**
      * @name followingList
      * @request GET:/user/following
      * @description List who the authenticated user is following.
      */
-    followingList: (params?: RequestParams) => Promise<Users>;
+    followingList: (params?: RequestParams) => Promise<HttpResponse<Users, unknown>>;
     /**
      * @name followingDelete
      * @request DELETE:/user/following/{username}
      * @description Unfollow a user. Unfollowing a user requires the user to be logged in and authenticated with basic auth or OAuth with the user:follow scope.
      */
-    followingDelete: (username: string, params?: RequestParams) => Promise<any>;
+    followingDelete: (username: string, params?: RequestParams) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name followingDetail
      * @request GET:/user/following/{username}
      * @description Check if you are following a user.
      */
-    followingDetail: (username: string, params?: RequestParams) => Promise<any>;
+    followingDetail: (username: string, params?: RequestParams) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name followingUpdate
      * @request PUT:/user/following/{username}
      * @description Follow a user. Following a user requires the user to be logged in and authenticated with basic auth or OAuth with the user:follow scope.
      */
-    followingUpdate: (username: string, params?: RequestParams) => Promise<any>;
+    followingUpdate: (username: string, params?: RequestParams) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name issuesList
      * @request GET:/user/issues
@@ -3495,37 +3868,37 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
         since?: string;
       },
       params?: RequestParams,
-    ) => Promise<Issues>;
+    ) => Promise<HttpResponse<Issues, unknown>>;
     /**
      * @name keysList
      * @request GET:/user/keys
      * @description List your public keys. Lists the current user's keys. Management of public keys via the API requires that you are authenticated through basic auth, or OAuth with the 'user', 'write:public_key' scopes.
      */
-    keysList: (params?: RequestParams) => Promise<Gitignore>;
+    keysList: (params?: RequestParams) => Promise<HttpResponse<Gitignore, unknown>>;
     /**
      * @name keysCreate
      * @request POST:/user/keys
      * @description Create a public key.
      */
-    keysCreate: (body: UserKeysPost, params?: RequestParams) => Promise<UserKeysKeyId>;
+    keysCreate: (body: UserKeysPost, params?: RequestParams) => Promise<HttpResponse<UserKeysKeyId, unknown>>;
     /**
      * @name keysDelete
      * @request DELETE:/user/keys/{keyId}
      * @description Delete a public key. Removes a public key. Requires that you are authenticated via Basic Auth or via OAuth with at least admin:public_key scope.
      */
-    keysDelete: (keyId: number, params?: RequestParams) => Promise<any>;
+    keysDelete: (keyId: number, params?: RequestParams) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name keysDetail
      * @request GET:/user/keys/{keyId}
      * @description Get a single public key.
      */
-    keysDetail: (keyId: number, params?: RequestParams) => Promise<UserKeysKeyId>;
+    keysDetail: (keyId: number, params?: RequestParams) => Promise<HttpResponse<UserKeysKeyId, unknown>>;
     /**
      * @name orgsList
      * @request GET:/user/orgs
      * @description List public and private organizations for the authenticated user.
      */
-    orgsList: (params?: RequestParams) => Promise<Gitignore>;
+    orgsList: (params?: RequestParams) => Promise<HttpResponse<Gitignore, unknown>>;
     /**
      * @name reposList
      * @request GET:/user/repos
@@ -3536,13 +3909,13 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
         type?: "all" | "public" | "private" | "forks" | "sources" | "member";
       },
       params?: RequestParams,
-    ) => Promise<Repos>;
+    ) => Promise<HttpResponse<Repos, unknown>>;
     /**
      * @name reposCreate
      * @request POST:/user/repos
      * @description Create a new repository for the authenticated user. OAuth users must supply repo scope.
      */
-    reposCreate: (body: PostRepo, params?: RequestParams) => Promise<Repos>;
+    reposCreate: (body: PostRepo, params?: RequestParams) => Promise<HttpResponse<Repos, unknown>>;
     /**
      * @name starredList
      * @request GET:/user/starred
@@ -3554,55 +3927,55 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
         sort?: "created" | "updated";
       },
       params?: RequestParams,
-    ) => Promise<Gitignore>;
+    ) => Promise<HttpResponse<Gitignore, unknown>>;
     /**
      * @name starredDelete
      * @request DELETE:/user/starred/{owner}/{repo}
      * @description Unstar a repository
      */
-    starredDelete: (owner: string, repo: string, params?: RequestParams) => Promise<any>;
+    starredDelete: (owner: string, repo: string, params?: RequestParams) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name starredDetail
      * @request GET:/user/starred/{owner}/{repo}
      * @description Check if you are starring a repository.
      */
-    starredDetail: (owner: string, repo: string, params?: RequestParams) => Promise<any>;
+    starredDetail: (owner: string, repo: string, params?: RequestParams) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name starredUpdate
      * @request PUT:/user/starred/{owner}/{repo}
      * @description Star a repository.
      */
-    starredUpdate: (owner: string, repo: string, params?: RequestParams) => Promise<any>;
+    starredUpdate: (owner: string, repo: string, params?: RequestParams) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name subscriptionsList
      * @request GET:/user/subscriptions
      * @description List repositories being watched by the authenticated user.
      */
-    subscriptionsList: (params?: RequestParams) => Promise<Repos>;
+    subscriptionsList: (params?: RequestParams) => Promise<HttpResponse<Repos, unknown>>;
     /**
      * @name subscriptionsDelete
      * @request DELETE:/user/subscriptions/{owner}/{repo}
      * @description Stop watching a repository
      */
-    subscriptionsDelete: (owner: string, repo: string, params?: RequestParams) => Promise<any>;
+    subscriptionsDelete: (owner: string, repo: string, params?: RequestParams) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name subscriptionsDetail
      * @request GET:/user/subscriptions/{owner}/{repo}
      * @description Check if you are watching a repository.
      */
-    subscriptionsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<any>;
+    subscriptionsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name subscriptionsUpdate
      * @request PUT:/user/subscriptions/{owner}/{repo}
      * @description Watch a repository.
      */
-    subscriptionsUpdate: (owner: string, repo: string, params?: RequestParams) => Promise<any>;
+    subscriptionsUpdate: (owner: string, repo: string, params?: RequestParams) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name teamsList
      * @request GET:/user/teams
      * @description List all of the teams across all of the organizations to which the authenticated user belongs. This method requires user or repo scope when authenticating via OAuth.
      */
-    teamsList: (params?: RequestParams) => Promise<TeamsList>;
+    teamsList: (params?: RequestParams) => Promise<HttpResponse<TeamsList, unknown>>;
   };
   users: {
     /**
@@ -3615,37 +3988,41 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
         since?: number;
       },
       params?: RequestParams,
-    ) => Promise<Users>;
+    ) => Promise<HttpResponse<Users, unknown>>;
     /**
      * @name usersDetail
      * @request GET:/users/{username}
      * @description Get a single user.
      */
-    usersDetail: (username: string, params?: RequestParams) => Promise<any>;
+    usersDetail: (username: string, params?: RequestParams) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name eventsDetail
      * @request GET:/users/{username}/events
      * @description If you are authenticated as the given user, you will see your private events. Otherwise, you'll only see public events.
      */
-    eventsDetail: (username: string, params?: RequestParams) => Promise<any>;
+    eventsDetail: (username: string, params?: RequestParams) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name eventsOrgsDetail
      * @request GET:/users/{username}/events/orgs/{org}
      * @description This is the user's organization dashboard. You must be authenticated as the user to view this.
      */
-    eventsOrgsDetail: (username: string, org: string, params?: RequestParams) => Promise<any>;
+    eventsOrgsDetail: (username: string, org: string, params?: RequestParams) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name followersDetail
      * @request GET:/users/{username}/followers
      * @description List a user's followers
      */
-    followersDetail: (username: string, params?: RequestParams) => Promise<Users>;
+    followersDetail: (username: string, params?: RequestParams) => Promise<HttpResponse<Users, unknown>>;
     /**
      * @name followingDetail
      * @request GET:/users/{username}/following/{targetUser}
      * @description Check if one user follows another.
      */
-    followingDetail: (username: string, targetUser: string, params?: RequestParams) => Promise<any>;
+    followingDetail: (
+      username: string,
+      targetUser: string,
+      params?: RequestParams,
+    ) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name gistsDetail
      * @request GET:/users/{username}/gists
@@ -3657,31 +4034,31 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
         since?: string;
       },
       params?: RequestParams,
-    ) => Promise<Gists>;
+    ) => Promise<HttpResponse<Gists, unknown>>;
     /**
      * @name keysDetail
      * @request GET:/users/{username}/keys
      * @description List public keys for a user. Lists the verified public keys for a user. This is accessible by anyone.
      */
-    keysDetail: (username: string, params?: RequestParams) => Promise<Gitignore>;
+    keysDetail: (username: string, params?: RequestParams) => Promise<HttpResponse<Gitignore, unknown>>;
     /**
      * @name orgsDetail
      * @request GET:/users/{username}/orgs
      * @description List all public organizations for a user.
      */
-    orgsDetail: (username: string, params?: RequestParams) => Promise<Gitignore>;
+    orgsDetail: (username: string, params?: RequestParams) => Promise<HttpResponse<Gitignore, unknown>>;
     /**
      * @name receivedEventsDetail
      * @request GET:/users/{username}/received_events
      * @description These are events that you'll only see public events.
      */
-    receivedEventsDetail: (username: string, params?: RequestParams) => Promise<any>;
+    receivedEventsDetail: (username: string, params?: RequestParams) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name receivedEventsPublicDetail
      * @request GET:/users/{username}/received_events/public
      * @description List public events that a user has received
      */
-    receivedEventsPublicDetail: (username: string, params?: RequestParams) => Promise<any>;
+    receivedEventsPublicDetail: (username: string, params?: RequestParams) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name reposDetail
      * @request GET:/users/{username}/repos
@@ -3693,19 +4070,19 @@ export declare class Api<SecurityDataType = any> extends HttpClient<SecurityData
         type?: "all" | "public" | "private" | "forks" | "sources" | "member";
       },
       params?: RequestParams,
-    ) => Promise<Repos>;
+    ) => Promise<HttpResponse<Repos, unknown>>;
     /**
      * @name starredDetail
      * @request GET:/users/{username}/starred
      * @description List repositories being starred by a user.
      */
-    starredDetail: (username: string, params?: RequestParams) => Promise<any>;
+    starredDetail: (username: string, params?: RequestParams) => Promise<HttpResponse<any, unknown>>;
     /**
      * @name subscriptionsDetail
      * @request GET:/users/{username}/subscriptions
      * @description List repositories being watched by a user.
      */
-    subscriptionsDetail: (username: string, params?: RequestParams) => Promise<any>;
+    subscriptionsDetail: (username: string, params?: RequestParams) => Promise<HttpResponse<any, unknown>>;
   };
 }
 export {};

--- a/tests/spec/js/schema.d.ts
+++ b/tests/spec/js/schema.d.ts
@@ -1,0 +1,3360 @@
+/**
+ * A user or organization
+ */
+export interface Actor {
+    avatar_url?: string;
+    bio?: string;
+    /** The website URL from the profile page */
+    blog?: string;
+    collaborators?: number;
+    company?: string;
+    /** ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ */
+    created_at?: string;
+    disk_usage?: number;
+    /** Note: The returned email is the user’s publicly visible email address (or null if the user has not specified a public email address in their profile). */
+    email?: string;
+    followers?: number;
+    followers_url?: string;
+    following?: number;
+    following_url?: string;
+    gists_url?: string;
+    gravatar_id?: string;
+    hireable?: boolean;
+    html_url?: string;
+    id?: number;
+    location?: string;
+    /** The account username */
+    login?: string;
+    /** The full account name */
+    name?: string;
+    organizations_url?: string;
+    owned_private_repos?: number;
+    plan?: {
+        collaborators?: number;
+        name?: string;
+        private_repos?: number;
+        space?: number;
+    };
+    private_gists?: number;
+    public_gists?: number;
+    public_repos?: number;
+    starred_url?: string;
+    subscriptions_url?: string;
+    total_private_repos?: number;
+    type?: "User" | "Organization";
+    /** ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ */
+    updated_at?: string;
+    url?: string;
+}
+export interface Asset {
+    content_type?: string;
+    created_at?: string;
+    download_count?: number;
+    id?: number;
+    label?: string;
+    name?: string;
+    size?: number;
+    state?: string;
+    updated_at?: string;
+    uploader?: User;
+    url?: string;
+}
+export interface AssetPatch {
+    label?: string;
+    name: string;
+}
+export declare type Assets = Asset[];
+export declare type Assignees = User[];
+export interface Blob {
+    content?: string;
+    encoding?: "utf-8" | "base64";
+    sha?: string;
+    size?: number;
+}
+export interface Blobs {
+    sha?: string;
+}
+export interface Branch {
+    _links?: {
+        html?: string;
+        self?: string;
+    };
+    commit?: {
+        author?: User;
+        commit?: {
+            author?: {
+                date?: string;
+                email?: string;
+                name?: string;
+            };
+            committer?: {
+                date?: string;
+                email?: string;
+                name?: string;
+            };
+            message?: string;
+            tree?: {
+                sha?: string;
+                url?: string;
+            };
+            url?: string;
+        };
+        committer?: User;
+        parents?: {
+            sha?: string;
+            url?: string;
+        }[];
+        sha?: string;
+        url?: string;
+    };
+    name?: string;
+}
+export declare type Branches = {
+    commit?: {
+        sha?: string;
+        url?: string;
+    };
+    name?: string;
+}[];
+export declare type CodeFrequencyStats = number[];
+export interface Comment {
+    body?: string;
+}
+export interface CommentBody {
+    body: string;
+}
+export declare type Comments = {
+    body?: string;
+    created_at?: string;
+    id?: number;
+    url?: string;
+    user?: User;
+}[];
+export interface Commit {
+    author?: User;
+    commit?: {
+        author?: {
+            date?: string;
+            email?: string;
+            name?: string;
+        };
+        committer?: {
+            date?: string;
+            email?: string;
+            name?: string;
+        };
+        message?: string;
+        tree?: {
+            sha?: string;
+            url?: string;
+        };
+        url?: string;
+    };
+    committer?: User;
+    files?: {
+        additions?: number;
+        blob_url?: string;
+        changes?: number;
+        deletions?: number;
+        filename?: string;
+        patch?: string;
+        raw_url?: string;
+        status?: string;
+    }[];
+    parents?: {
+        sha?: string;
+        url?: string;
+    }[];
+    sha?: string;
+    stats?: {
+        additions?: number;
+        deletions?: number;
+        total?: number;
+    };
+    url?: string;
+}
+export declare type CommitActivityStats = {
+    days?: number[];
+    total?: number;
+    week?: number;
+}[];
+export interface CommitComment {
+    body?: string;
+    commit_id?: string;
+    /** ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ */
+    created_at?: string;
+    html_url?: string;
+    id?: number;
+    line?: number;
+    path?: string;
+    position?: number;
+    /** ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ */
+    updated_at?: string;
+    url?: string;
+    user?: User;
+}
+export interface CommitCommentBody {
+    body: string;
+    /** Deprecated - Use position parameter instead. */
+    line?: string;
+    /** Line number in the file to comment on. Defaults to null. */
+    number?: string;
+    /** Relative path of the file to comment on. */
+    path?: string;
+    /** Line index in the diff to comment on. */
+    position?: number;
+    /** SHA of the commit to comment on. */
+    sha: string;
+}
+export declare type Commits = {
+    author?: User;
+    commit?: {
+        author?: {
+            date?: string;
+            email?: string;
+            name?: string;
+        };
+        committer?: {
+            date?: string;
+            email?: string;
+            name?: string;
+        };
+        message?: string;
+        tree?: {
+            sha?: string;
+            url?: string;
+        };
+        url?: string;
+    };
+    committer?: User;
+    parents?: {
+        sha?: string;
+        url?: string;
+    }[];
+    sha?: string;
+    url?: string;
+}[];
+export interface CompareCommits {
+    ahead_by?: number;
+    base_commit?: {
+        author?: User;
+        commit?: {
+            author?: {
+                date?: string;
+                email?: string;
+                name?: string;
+            };
+            committer?: {
+                date?: string;
+                email?: string;
+                name?: string;
+            };
+            message?: string;
+            tree?: {
+                sha?: string;
+                url?: string;
+            };
+            url?: string;
+        };
+        committer?: User;
+        parents?: {
+            sha?: string;
+            url?: string;
+        }[];
+        sha?: string;
+        url?: string;
+    };
+    behind_by?: number;
+    commits?: {
+        author?: User;
+        commit?: {
+            author?: {
+                date?: string;
+                email?: string;
+                name?: string;
+            };
+            committer?: {
+                date?: string;
+                email?: string;
+                name?: string;
+            };
+            message?: string;
+            tree?: {
+                sha?: string;
+                url?: string;
+            };
+            url?: string;
+        };
+        committer?: User;
+        parents?: {
+            sha?: string;
+            url?: string;
+        }[];
+        sha?: string;
+        url?: string;
+    }[];
+    diff_url?: string;
+    files?: {
+        additions?: number;
+        blob_url?: string;
+        changes?: number;
+        contents_url?: string;
+        deletions?: number;
+        filename?: string;
+        patch?: string;
+        raw_url?: string;
+        sha?: string;
+        status?: string;
+    }[];
+    html_url?: string;
+    patch_url?: string;
+    permalink_url?: string;
+    status?: string;
+    total_commits?: number;
+    url?: string;
+}
+export interface ContentsPath {
+    _links?: {
+        git?: string;
+        html?: string;
+        self?: string;
+    };
+    content?: string;
+    encoding?: string;
+    git_url?: string;
+    html_url?: string;
+    name?: string;
+    path?: string;
+    sha?: string;
+    size?: number;
+    type?: string;
+    url?: string;
+}
+export declare type ContributorsStats = {
+    author?: {
+        avatar_url?: string;
+        gravatar_id?: string;
+        id?: number;
+        login?: string;
+        url?: string;
+    };
+    total?: number;
+    weeks?: {
+        a?: number;
+        c?: number;
+        d?: number;
+        w?: string;
+    }[];
+}[];
+export interface CreateFile {
+    commit?: {
+        author?: {
+            date?: string;
+            email?: string;
+            name?: string;
+        };
+        committer?: {
+            date?: string;
+            email?: string;
+            name?: string;
+        };
+        html_url?: string;
+        message?: string;
+        parents?: {
+            html_url?: string;
+            sha?: string;
+            url?: string;
+        }[];
+        sha?: string;
+        tree?: {
+            sha?: string;
+            url?: string;
+        };
+        url?: string;
+    };
+    content?: {
+        _links?: {
+            git?: string;
+            html?: string;
+            self?: string;
+        };
+        git_url?: string;
+        html_url?: string;
+        name?: string;
+        path?: string;
+        sha?: string;
+        size?: number;
+        type?: string;
+        url?: string;
+    };
+}
+export interface CreateFileBody {
+    committer?: {
+        email?: string;
+        name?: string;
+    };
+    content?: string;
+    message?: string;
+}
+export interface DeleteFile {
+    commit?: {
+        author?: {
+            date?: string;
+            email?: string;
+            name?: string;
+        };
+        committer?: {
+            date?: string;
+            email?: string;
+            name?: string;
+        };
+        html_url?: string;
+        message?: string;
+        parents?: {
+            html_url?: string;
+            sha?: string;
+            url?: string;
+        };
+        sha?: string;
+        tree?: {
+            sha?: string;
+            url?: string;
+        };
+        url?: string;
+    };
+    content?: string;
+}
+export interface DeleteFileBody {
+    committer?: {
+        email?: string;
+        name?: string;
+    };
+    message?: string;
+    sha?: string;
+}
+export interface Deployment {
+    description?: string;
+    payload?: {
+        deploy_user?: string;
+        environment?: string;
+        room_id?: number;
+    };
+    ref?: string;
+}
+export interface DeploymentResp {
+    created_at?: string;
+    creator?: User;
+    description?: string;
+    id?: number;
+    payload?: string;
+    sha?: string;
+    statuses_url?: string;
+    updated_at?: string;
+    url?: string;
+}
+export declare type DeploymentStatuses = {
+    created_at?: string;
+    creator?: User;
+    description?: string;
+    id?: number;
+    payload?: string;
+    state?: string;
+    target_url?: string;
+    updated_at?: string;
+    url?: string;
+}[];
+export interface DeploymentStatusesCreate {
+    description?: string;
+    state?: string;
+    target_url?: string;
+}
+export interface Download {
+    content_type?: string;
+    description?: string;
+    download_count?: number;
+    html_url?: string;
+    id?: number;
+    name?: string;
+    size?: number;
+    url?: string;
+}
+export declare type Downloads = Download[];
+export interface EditTeam {
+    name: string;
+    permission?: "pull" | "push" | "admin";
+}
+export declare type EmailsPost = string[];
+export declare type Emojis = Record<string, string>;
+export interface Event {
+    actor?: Actor;
+    created_at?: object;
+    id?: number;
+    org?: Organization;
+    payload?: object;
+    public?: boolean;
+    repo?: {
+        id?: number;
+        name?: string;
+        url?: string;
+    };
+    type?: string;
+}
+export declare type Events = Event[];
+export interface Feeds {
+    _links?: {
+        current_user?: {
+            href?: string;
+            type?: string;
+        };
+        current_user_actor?: {
+            href?: string;
+            type?: string;
+        };
+        current_user_organization?: {
+            href?: string;
+            type?: string;
+        };
+        current_user_public?: {
+            href?: string;
+            type?: string;
+        };
+        timeline?: {
+            href?: string;
+            type?: string;
+        };
+        user?: {
+            href?: string;
+            type?: string;
+        };
+    };
+    current_user_actor_url?: string;
+    current_user_organization_url?: string;
+    current_user_public?: string;
+    current_user_url?: string;
+    timeline_url?: string;
+    user_url?: string;
+}
+export interface ForkBody {
+    organization?: string;
+}
+export declare type Forks = Repos;
+export interface Gist {
+    comments?: number;
+    comments_url?: string;
+    /** Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ. */
+    created_at?: string;
+    description?: string;
+    files?: {
+        "ring.erl"?: {
+            filename?: string;
+            raw_url?: string;
+            size?: number;
+        };
+    };
+    forks?: {
+        created_at?: string;
+        url?: string;
+        user?: User;
+    }[];
+    git_pull_url?: string;
+    git_push_url?: string;
+    history?: {
+        change_status?: {
+            additions?: number;
+            deletions?: number;
+            total?: number;
+        };
+        committed_at?: string;
+        url?: string;
+        user?: User;
+        version?: string;
+    }[];
+    html_url?: string;
+    id?: string;
+    public?: boolean;
+    url?: string;
+    user?: User;
+}
+export declare type Gists = {
+    comments?: number;
+    comments_url?: string;
+    created_at?: string;
+    description?: string;
+    files?: {
+        "ring.erl"?: {
+            filename?: string;
+            raw_url?: string;
+            size?: number;
+        };
+    };
+    git_pull_url?: string;
+    git_push_url?: string;
+    html_url?: string;
+    id?: string;
+    public?: boolean;
+    url?: string;
+    user?: User;
+}[];
+export interface GitCommit {
+    author?: {
+        date?: string;
+        email?: string;
+        name?: string;
+    };
+    message?: string;
+    parents?: string;
+    tree?: string;
+}
+export interface GitRefPatch {
+    force?: boolean;
+    sha?: string;
+}
+export declare type Gitignore = any[];
+export interface GitignoreLang {
+    name?: string;
+    source?: string;
+}
+export interface HeadBranch {
+    object?: {
+        sha?: string;
+        type?: string;
+        url?: string;
+    };
+    ref?: string;
+    url?: string;
+}
+export declare type Hook = {
+    active?: boolean;
+    config?: {
+        content_type?: string;
+        url?: string;
+    };
+    created_at?: string;
+    events?: ("push" | "issues" | "issue_comment" | "commit_comment" | "pull_request" | "pull_request_review_comment" | "gollum" | "watch" | "download" | "fork" | "fork_apply" | "member" | "public" | "team_add" | "status")[];
+    id?: number;
+    name?: string;
+    updated_at?: string;
+    url?: string;
+}[];
+export interface HookBody {
+    active?: boolean;
+    add_events?: string[];
+}
+export interface Issue {
+    assignee?: string;
+    body?: string;
+    labels?: string[];
+    milestone?: number;
+    title?: string;
+}
+export interface IssueEvent {
+    actor?: Actor;
+    commit_id?: string;
+    /** ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ */
+    created_at?: string;
+    event?: string;
+    issue?: {
+        assignee?: User;
+        body?: string;
+        closed_at?: string;
+        comments?: number;
+        created_at?: string;
+        html_url?: string;
+        labels?: {
+            color?: string;
+            name?: string;
+            url?: string;
+        }[];
+        milestone?: {
+            closed_issues?: number;
+            created_at?: string;
+            creator?: User;
+            description?: string;
+            due_on?: string;
+            number?: number;
+            open_issues?: number;
+            state?: "open" | "closed";
+            title?: string;
+            url?: string;
+        };
+        number?: number;
+        pull_request?: {
+            diff_url?: string;
+            html_url?: string;
+            patch_url?: string;
+        };
+        state?: "open" | "closed";
+        title?: string;
+        updated_at?: string;
+        url?: string;
+        user?: User;
+    };
+    url?: string;
+}
+export declare type IssueEvents = IssueEvent[];
+export declare type Issues = {
+    assignee?: User;
+    body?: string;
+    closed_at?: string;
+    comments?: number;
+    created_at?: string;
+    html_url?: string;
+    labels?: {
+        color?: string;
+        name?: string;
+        url?: string;
+    }[];
+    milestone?: {
+        closed_issues?: number;
+        created_at?: string;
+        creator?: User;
+        description?: string;
+        due_on?: string;
+        number?: number;
+        open_issues?: number;
+        state?: "open" | "closed";
+        title?: string;
+        url?: string;
+    };
+    number?: number;
+    pull_request?: {
+        diff_url?: string;
+        html_url?: string;
+        patch_url?: string;
+    };
+    state?: "open" | "closed";
+    title?: string;
+    updated_at?: string;
+    url?: string;
+    user?: User;
+}[];
+export interface IssuesComment {
+    body?: string;
+    /** ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ */
+    created_at?: string;
+    html_url?: string;
+    id?: number;
+    /** ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ */
+    updated_at?: string;
+    url?: string;
+    user?: User;
+}
+export declare type IssuesComments = {
+    _links?: {
+        html?: {
+            href?: string;
+        };
+        pull_request?: {
+            href?: string;
+        };
+        self?: {
+            href?: string;
+        };
+    };
+    body?: string;
+    commit_id?: string;
+    created_at?: string;
+    id?: number;
+    path?: string;
+    position?: number;
+    updated_at?: string;
+    url?: string;
+    user?: User;
+}[];
+export declare type Keys = {
+    id?: number;
+    key?: string;
+    title?: string;
+    url?: string;
+}[];
+export interface Label {
+    color?: string;
+    name?: string;
+    url?: string;
+}
+export declare type Labels = {
+    color?: string;
+    name?: string;
+    url?: string;
+}[];
+export declare type Languages = Record<string, number>;
+export interface Markdown {
+    context?: string;
+    mode?: string;
+    text?: string;
+}
+export interface Merge {
+    merged?: boolean;
+    message?: string;
+    sha?: string;
+}
+export interface MergePullBody {
+    commit_message?: string;
+}
+export interface MergesBody {
+    base?: string;
+    commit_message?: string;
+    head?: string;
+}
+export interface MergesConflict {
+    /** Error message */
+    message?: string;
+}
+export interface MergesSuccessful {
+    author?: User;
+    comments_url?: string;
+    commit?: {
+        author?: {
+            date?: string;
+            email?: string;
+            name?: string;
+        };
+        comment_count?: number;
+        committer?: {
+            date?: string;
+            email?: string;
+            name?: string;
+        };
+        message?: string;
+        tree?: {
+            sha?: string;
+            url?: string;
+        };
+        url?: string;
+    };
+    committer?: User;
+    merged?: boolean;
+    message?: string;
+    parents?: {
+        sha?: string;
+        url?: string;
+    }[];
+    sha?: string;
+    url?: string;
+}
+export interface Meta {
+    git?: string[];
+    hooks?: string[];
+}
+export interface Milestone {
+    closed_issues?: number;
+    /** ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ */
+    created_at?: string;
+    creator?: User;
+    description?: string;
+    /** ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ */
+    due_on?: string;
+    number?: number;
+    open_issues?: number;
+    state?: "open" | "closed";
+    title?: string;
+    url?: string;
+}
+export interface MilestoneUpdate {
+    description?: string;
+    due_on?: string;
+    state?: string;
+    title?: string;
+}
+export interface NotificationMarkRead {
+    last_read_at?: string;
+}
+export interface Notifications {
+    id?: number;
+    last_read_at?: string;
+    reason?: string;
+    repository?: {
+        description?: string;
+        fork?: boolean;
+        full_name?: string;
+        html_url?: string;
+        id?: number;
+        name?: string;
+        owner?: Actor;
+        private?: boolean;
+        url?: string;
+    };
+    subject?: {
+        latest_comment_url?: string;
+        title?: string;
+        type?: string;
+        url?: string;
+    };
+    unread?: boolean;
+    updated_at?: string;
+    url?: string;
+}
+export interface OrgTeamsPost {
+    name: string;
+    permission?: "pull" | "push" | "admin";
+    repo_names?: string[];
+}
+export declare type Organization = Actor & any;
+export interface OrganizationAsTeamMember {
+    errors?: {
+        code?: string;
+        field?: string;
+        resource?: string;
+    }[];
+    message?: string;
+}
+export interface ParticipationStats {
+    all?: number[];
+    owner?: number[];
+}
+export interface PatchGist {
+    description?: string;
+    files?: {
+        "delete_this_file.txt"?: string;
+        "file1.txt"?: {
+            content?: string;
+        };
+        "new_file.txt"?: {
+            content?: string;
+        };
+        "old_name.txt"?: {
+            content?: string;
+            filename?: string;
+        };
+    };
+}
+export interface PatchOrg {
+    /** Billing email address. This address is not publicized. */
+    billing_email?: string;
+    company?: string;
+    /** Publicly visible email address. */
+    email?: string;
+    location?: string;
+    name?: string;
+}
+export interface PostGist {
+    description?: string;
+    files?: {
+        "file1.txt"?: {
+            content?: string;
+        };
+    };
+    public?: boolean;
+}
+export interface PostRepo {
+    /** True to create an initial commit with empty README. Default is false. */
+    auto_init?: boolean;
+    description?: string;
+    /** Desired language or platform .gitignore template to apply. Use the name of the template without the extension. For example, "Haskell" Ignored if auto_init parameter is not provided.  */
+    gitignore_template?: string;
+    /** True to enable downloads for this repository, false to disable them. Default is true. */
+    has_downloads?: boolean;
+    /** True to enable issues for this repository, false to disable them. Default is true. */
+    has_issues?: boolean;
+    /** True to enable the wiki for this repository, false to disable it. Default is true. */
+    has_wiki?: boolean;
+    homepage?: string;
+    name: string;
+    /** True to create a private repository, false to create a public one. Creating private repositories requires a paid GitHub account. */
+    private?: boolean;
+    /** The id of the team that will be granted access to this repository. This is only valid when creating a repo in an organization. */
+    team_id?: number;
+}
+export interface PullRequest {
+    _links?: {
+        comments?: {
+            href?: string;
+        };
+        html?: {
+            href?: string;
+        };
+        review_comments?: {
+            href?: string;
+        };
+        self?: {
+            href?: string;
+        };
+    };
+    additions?: number;
+    base?: {
+        label?: string;
+        ref?: string;
+        repo?: Repo;
+        sha?: string;
+        user?: {
+            avatar_url?: string;
+            gravatar_id?: string;
+            id?: number;
+            login?: string;
+            url?: string;
+        };
+    };
+    body?: string;
+    changed_files?: number;
+    closed_at?: string;
+    comments?: number;
+    commits?: number;
+    created_at?: string;
+    deletions?: number;
+    diff_url?: string;
+    head?: {
+        label?: string;
+        ref?: string;
+        repo?: Repo;
+        sha?: string;
+        user?: {
+            avatar_url?: string;
+            gravatar_id?: string;
+            id?: number;
+            login?: string;
+            url?: string;
+        };
+    };
+    html_url?: string;
+    issue_url?: string;
+    merge_commit_sha?: string;
+    mergeable?: boolean;
+    merged?: boolean;
+    merged_at?: string;
+    merged_by?: {
+        avatar_url?: string;
+        gravatar_id?: string;
+        id?: number;
+        login?: string;
+        url?: string;
+    };
+    number?: number;
+    patch_url?: string;
+    state?: string;
+    title?: string;
+    updated_at?: string;
+    url?: string;
+    user?: {
+        avatar_url?: string;
+        gravatar_id?: string;
+        id?: number;
+        login?: string;
+        url?: string;
+    };
+}
+export interface PullUpdate {
+    body?: string;
+    state?: string;
+    title?: string;
+}
+export declare type Pulls = {
+    _links?: {
+        comments?: {
+            href?: string;
+        };
+        html?: {
+            href?: string;
+        };
+        review_comments?: {
+            href?: string;
+        };
+        self?: {
+            href?: string;
+        };
+    };
+    base?: {
+        label?: string;
+        ref?: string;
+        repo?: Repo;
+        sha?: string;
+        user?: {
+            avatar_url?: string;
+            gravatar_id?: string;
+            id?: number;
+            login?: string;
+            url?: string;
+        };
+    };
+    body?: string;
+    closed_at?: string;
+    created_at?: string;
+    diff_url?: string;
+    head?: {
+        label?: string;
+        ref?: string;
+        repo?: Repo;
+        sha?: string;
+        user?: {
+            avatar_url?: string;
+            gravatar_id?: string;
+            id?: number;
+            login?: string;
+            url?: string;
+        };
+    };
+    html_url?: string;
+    issue_url?: string;
+    merged_at?: string;
+    number?: number;
+    patch_url?: string;
+    state?: "open" | "closed";
+    title?: string;
+    updated_at?: string;
+    url?: string;
+    user?: {
+        avatar_url?: string;
+        gravatar_id?: string;
+        id?: number;
+        login?: string;
+        url?: string;
+    };
+}[];
+export interface PullsComment {
+    _links?: {
+        html?: {
+            href?: string;
+        };
+        pull_request?: {
+            href?: string;
+        };
+        self?: {
+            href?: string;
+        };
+    };
+    body?: string;
+    commit_id?: string;
+    /** ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ */
+    created_at?: string;
+    id?: number;
+    path?: string;
+    position?: number;
+    /** ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ */
+    updated_at?: string;
+    url?: string;
+    user?: {
+        avatar_url?: string;
+        gravatar_id?: string;
+        id?: number;
+        login?: string;
+        url?: string;
+    };
+}
+export interface PullsCommentPost {
+    body?: string;
+    commit_id?: string;
+    path?: string;
+    position?: number;
+}
+export declare type PullsComments = {
+    _links?: {
+        html?: {
+            href?: string;
+        };
+        pull_request?: {
+            href?: string;
+        };
+        self?: {
+            href?: string;
+        };
+    };
+    body?: string;
+    commit_id?: string;
+    created_at?: string;
+    id?: number;
+    path?: string;
+    position?: number;
+    updated_at?: string;
+    url?: string;
+    user?: {
+        avatar_url?: string;
+        gravatar_id?: string;
+        id?: number;
+        login?: string;
+        url?: string;
+    };
+}[];
+export interface PullsPost {
+    base?: string;
+    body?: string;
+    head?: string;
+    title?: string;
+}
+export interface PutSubscription {
+    created_at?: string;
+    ignored?: boolean;
+    reason?: object;
+    subscribed?: boolean;
+    thread_url?: string;
+    url?: string;
+}
+export interface RateLimit {
+    rate?: {
+        limit?: number;
+        remaining?: number;
+        reset?: number;
+    };
+}
+export declare type Ref = {
+    created_at?: string;
+    creator?: {
+        avatar_url?: string;
+        gravatar_id?: string;
+        id?: number;
+        login?: string;
+        url?: string;
+    };
+    description?: string;
+    id?: number;
+    state?: string;
+    target_url?: string;
+    updated_at?: string;
+    url?: string;
+}[];
+export declare type RefStatus = {
+    commit_url?: string;
+    name?: string;
+    repository_url?: string;
+    sha?: string;
+    state?: string;
+    statuses?: {
+        context?: string;
+        created_at?: string;
+        description?: string;
+        id?: number;
+        state?: string;
+        target_url?: string;
+        updated_at?: string;
+        url?: string;
+    }[];
+}[];
+export declare type Refs = {
+    object?: {
+        sha?: string;
+        type?: string;
+        url?: string;
+    };
+    ref?: string;
+    url?: string;
+}[];
+export interface RefsBody {
+    ref?: string;
+    sha?: string;
+}
+export interface Release {
+    assets?: {
+        content_type?: string;
+        created_at?: string;
+        download_count?: number;
+        id?: number;
+        label?: string;
+        name?: string;
+        size?: number;
+        state?: string;
+        updated_at?: string;
+        uploader?: User;
+        url?: string;
+    }[];
+    assets_url?: string;
+    author?: User;
+    body?: string;
+    created_at?: string;
+    draft?: boolean;
+    html_url?: string;
+    id?: number;
+    name?: string;
+    prerelease?: boolean;
+    published_at?: string;
+    tag_name?: string;
+    tarball_url?: string;
+    target_commitish?: string;
+    upload_url?: string;
+    url?: string;
+    zipball_url?: string;
+}
+export interface ReleaseCreate {
+    body?: string;
+    draft?: boolean;
+    name?: string;
+    prerelease?: boolean;
+    tag_name?: string;
+    target_commitish?: string;
+}
+export declare type Releases = {
+    assets?: {
+        content_type?: string;
+        created_at?: string;
+        download_count?: number;
+        id?: number;
+        label?: string;
+        name?: string;
+        size?: number;
+        state?: string;
+        updated_at?: string;
+        uploader?: User;
+        url?: string;
+    }[];
+    assets_url?: string;
+    author?: User;
+    body?: string;
+    created_at?: string;
+    draft?: boolean;
+    html_url?: string;
+    id?: number;
+    name?: string;
+    prerelease?: boolean;
+    published_at?: string;
+    tag_name?: string;
+    tarball_url?: string;
+    target_commitish?: string;
+    upload_url?: string;
+    url?: string;
+    zipball_url?: string;
+}[];
+export interface Repo {
+    clone_url?: string;
+    /** ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ */
+    created_at?: string;
+    description?: string;
+    fork?: boolean;
+    forks?: number;
+    forks_count?: number;
+    full_name?: string;
+    git_url?: string;
+    has_downloads?: boolean;
+    has_issues?: boolean;
+    has_wiki?: boolean;
+    homepage?: string;
+    html_url?: string;
+    id?: number;
+    language?: string;
+    master_branch?: string;
+    mirror_url?: string;
+    name?: string;
+    open_issues?: number;
+    open_issues_count?: number;
+    organization?: Organization;
+    owner?: Actor;
+    parent?: Repo & any;
+    private?: boolean;
+    /** ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ */
+    pushed_at?: string;
+    size?: number;
+    source?: Repo & any;
+    ssh_url?: string;
+    svn_url?: string;
+    /** ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ */
+    updated_at?: string;
+    url?: string;
+    watchers?: number;
+    watchers_count?: number;
+}
+export declare type RepoDeployments = {
+    created_at?: string;
+    creator?: User;
+    description?: string;
+    id?: number;
+    payload?: string;
+    sha?: string;
+    statuses_url?: string;
+    updated_at?: string;
+    url?: string;
+}[];
+export declare type RepoComments = {
+    body?: string;
+    commit_id?: string;
+    created_at?: string;
+    html_url?: string;
+    id?: number;
+    line?: number;
+    path?: string;
+    position?: number;
+    updated_at?: string;
+    url?: string;
+    user?: User;
+}[];
+export interface RepoCommit {
+    author?: {
+        date?: string;
+        email?: string;
+        name?: string;
+    };
+    committer?: {
+        date?: string;
+        email?: string;
+        name?: string;
+    };
+    message?: string;
+    parents?: {
+        sha?: string;
+        url?: string;
+    }[];
+    sha?: string;
+    tree?: {
+        sha?: string;
+        url?: string;
+    };
+    url?: string;
+}
+export interface RepoCommitBody {
+    author?: {
+        date?: string;
+        email?: string;
+        name?: string;
+    };
+    message: string;
+    parents: string[];
+    tree: string;
+}
+export interface RepoEdit {
+    description?: string;
+    has_downloads?: boolean;
+    has_issues?: boolean;
+    has_wiki?: boolean;
+    homepage?: string;
+    name?: string;
+    private?: boolean;
+}
+export declare type Repos = Repo[];
+export interface SearchCode {
+    items?: {
+        git_url?: string;
+        html_url?: string;
+        name?: string;
+        path?: string;
+        repository?: {
+            archive_url?: string;
+            assignees_url?: string;
+            blobs_url?: string;
+            branches_url?: string;
+            collaborators_url?: string;
+            comments_url?: string;
+            commits_url?: string;
+            compare_url?: string;
+            contents_url?: string;
+            contributors_url?: string;
+            description?: string;
+            downloads_url?: string;
+            events_url?: string;
+            fork?: boolean;
+            forks_url?: string;
+            full_name?: string;
+            git_commits_url?: string;
+            git_refs_url?: string;
+            git_tags_url?: string;
+            hooks_url?: string;
+            html_url?: string;
+            id?: number;
+            issue_comment_url?: string;
+            issue_events_url?: string;
+            issues_url?: string;
+            keys_url?: string;
+            labels_url?: string;
+            languages_url?: string;
+            merges_url?: string;
+            milestones_url?: string;
+            name?: string;
+            notifications_url?: string;
+            owner?: Actor;
+            private?: boolean;
+            pulls_url?: string;
+            stargazers_url?: string;
+            statuses_url?: string;
+            subscribers_url?: string;
+            subscription_url?: string;
+            tags_url?: string;
+            teams_url?: string;
+            trees_url?: string;
+            url?: string;
+        };
+        score?: number;
+        sha?: string;
+        url?: string;
+    }[];
+    total_count?: number;
+}
+export interface SearchIssues {
+    items?: {
+        assignee?: any;
+        body?: string;
+        closed_at?: any;
+        comments?: number;
+        comments_url?: string;
+        created_at?: string;
+        events_url?: string;
+        html_url?: string;
+        id?: number;
+        labels?: {
+            color?: string;
+            name?: string;
+            url?: string;
+        }[];
+        labels_url?: string;
+        milestone?: any;
+        number?: number;
+        pull_request?: {
+            diff_url?: any;
+            html_url?: any;
+            patch_url?: any;
+        };
+        score?: number;
+        state?: string;
+        title?: string;
+        updated_at?: string;
+        url?: string;
+        user?: User;
+    }[];
+    total_count?: number;
+}
+export interface SearchIssuesByKeyword {
+    issues?: {
+        body?: string;
+        comments?: number;
+        created_at?: string;
+        gravatar_id?: string;
+        html_url?: string;
+        labels?: string[];
+        number?: number;
+        position?: number;
+        state?: string;
+        title?: string;
+        updated_at?: string;
+        user?: string;
+        votes?: number;
+    }[];
+}
+export interface SearchRepositories {
+    items?: Repo[];
+    total_count?: number;
+}
+export interface SearchRepositoriesByKeyword {
+    repositories?: Repo[];
+}
+export interface SearchUserByEmail {
+    user?: User;
+}
+export interface SearchUsers {
+    items?: Users;
+    total_count?: number;
+}
+export interface SearchUsersByKeyword {
+    users?: Users;
+}
+export interface Subscription {
+    /** ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ */
+    created_at?: string;
+    ignored?: boolean;
+    reason?: string;
+    repository_url?: string;
+    subscribed?: boolean;
+    thread_url?: string;
+    url?: string;
+}
+export interface SubscriptionBody {
+    ignored?: boolean;
+    subscribed?: boolean;
+}
+export interface Tag {
+    /** String of the tag message. */
+    message?: string;
+    object?: {
+        sha?: string;
+        type?: "commit" | "tree" | "blob";
+        url?: string;
+    };
+    sha?: string;
+    /** The tag's name. This is typically a version (e.g., "v0.0.1"). */
+    tag?: string;
+    tagger?: {
+        date?: string;
+        email?: string;
+        name?: string;
+    };
+    url?: string;
+}
+export interface TagBody {
+    /** String of the tag message. */
+    message: string;
+    /** String of the SHA of the git object this is tagging. */
+    object: string;
+    /** The tag's name. This is typically a version (e.g., "v0.0.1"). */
+    tag: string;
+    tagger: {
+        date?: string;
+        email?: string;
+        name?: string;
+    };
+    /** String of the type of the object we’re tagging. Normally this is a commit but it can also be a tree or a blob. */
+    type: "commit" | "tree" | "blob";
+}
+export declare type Tags = Tag[];
+export interface Team {
+    id?: number;
+    members_count?: number;
+    name?: string;
+    permission?: string;
+    repos_count?: number;
+    url?: string;
+}
+export interface TeamMembership {
+    state?: string;
+    url?: string;
+}
+export declare type TeamRepos = Repos;
+export declare type Teams = {
+    id?: number;
+    name?: string;
+    url?: string;
+}[];
+export declare type TeamsList = {
+    id?: number;
+    members_count?: number;
+    name?: string;
+    organization?: {
+        avatar_url?: string;
+        id?: number;
+        login?: string;
+        url?: string;
+    };
+    permission?: string;
+    repos_count?: number;
+    url?: string;
+}[];
+export interface Tree {
+    sha?: string;
+    tree?: {
+        mode?: "100644" | "100755" | "040000" | "160000" | "120000";
+        path?: string;
+        sha?: string;
+        size?: number;
+        type?: "blob" | "tree" | "commit";
+        url?: string;
+    }[];
+    url?: string;
+}
+export interface Trees {
+    base_tree?: string;
+    /** SHA1 checksum ID of the object in the tree. */
+    sha?: string;
+    tree?: Tree[];
+    url?: string;
+}
+export declare type User = Actor & any;
+export declare type UserEmails = string[];
+export interface UserKeysKeyId {
+    id?: number;
+    key?: string;
+    title?: string;
+    url?: string;
+}
+export interface UserKeysPost {
+    key?: string;
+    title?: string;
+}
+export interface UserUpdate {
+    bio?: string;
+    blog?: string;
+    company?: string;
+    email?: string;
+    hireable?: boolean;
+    location?: string;
+    name?: string;
+}
+export declare type Users = User[];
+export declare type RequestParams = Omit<RequestInit, "body" | "method"> & {
+    secure?: boolean;
+};
+export declare type RequestQueryParamsType = Record<string | number, any>;
+declare type ApiConfig<SecurityDataType> = {
+    baseUrl?: string;
+    baseApiParams?: RequestParams;
+    securityWorker?: (securityData: SecurityDataType) => RequestParams;
+};
+declare enum BodyType {
+    Json = 0
+}
+declare class HttpClient<SecurityDataType> {
+    baseUrl: string;
+    private securityData;
+    private securityWorker;
+    private baseApiParams;
+    constructor({ baseUrl, baseApiParams, securityWorker }?: ApiConfig<SecurityDataType>);
+    setSecurityData: (data: SecurityDataType) => void;
+    private addQueryParam;
+    protected addQueryParams(rawQuery?: RequestQueryParamsType): string;
+    private bodyFormatters;
+    private mergeRequestOptions;
+    private safeParseResponse;
+    request: <T = any, E = any>(path: string, method: string, { secure, ...params }?: RequestParams, body?: any, bodyType?: BodyType, secureByDefault?: boolean) => Promise<T>;
+}
+/**
+ * @title GitHub
+ * @version v3
+ * @baseUrl https://api.github.com/
+ * Powerful collaboration, code review, and code management for open source and private projects.
+ */
+export declare class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
+    emojis: {
+        /**
+         * @name emojisList
+         * @request GET:/emojis
+         * @description Lists all the emojis available to use on GitHub.
+         */
+        emojisList: (params?: RequestParams) => Promise<Record<string, string>>;
+    };
+    events: {
+        /**
+         * @name eventsList
+         * @request GET:/events
+         * @description List public events.
+         */
+        eventsList: (params?: RequestParams) => Promise<Events>;
+    };
+    feeds: {
+        /**
+         * @name feedsList
+         * @request GET:/feeds
+         * @description List Feeds. GitHub provides several timeline resources in Atom format. The Feeds API lists all the feeds available to the authenticating user.
+         */
+        feedsList: (params?: RequestParams) => Promise<Feeds>;
+    };
+    gists: {
+        /**
+         * @name gistsList
+         * @request GET:/gists
+         * @description List the authenticated user's gists or if called anonymously, this will return all public gists.
+         */
+        gistsList: (query?: {
+            since?: string;
+        }, params?: RequestParams) => Promise<Gists>;
+        /**
+         * @name gistsCreate
+         * @request POST:/gists
+         * @description Create a gist.
+         */
+        gistsCreate: (body: PostGist, params?: RequestParams) => Promise<Gist>;
+        /**
+         * @name publicList
+         * @request GET:/gists/public
+         * @description List all public gists.
+         */
+        publicList: (query?: {
+            since?: string;
+        }, params?: RequestParams) => Promise<Gists>;
+        /**
+         * @name starredList
+         * @request GET:/gists/starred
+         * @description List the authenticated user's starred gists.
+         */
+        starredList: (query?: {
+            since?: string;
+        }, params?: RequestParams) => Promise<Gists>;
+        /**
+         * @name gistsDelete
+         * @request DELETE:/gists/{id}
+         * @description Delete a gist.
+         */
+        gistsDelete: (id: number, params?: RequestParams) => Promise<any>;
+        /**
+         * @name gistsDetail
+         * @request GET:/gists/{id}
+         * @description Get a single gist.
+         */
+        gistsDetail: (id: number, params?: RequestParams) => Promise<Gist>;
+        /**
+         * @name gistsPartialUpdate
+         * @request PATCH:/gists/{id}
+         * @description Edit a gist.
+         */
+        gistsPartialUpdate: (id: number, body: PatchGist, params?: RequestParams) => Promise<Gist>;
+        /**
+         * @name commentsDetail
+         * @request GET:/gists/{id}/comments
+         * @description List comments on a gist.
+         */
+        commentsDetail: (id: number, params?: RequestParams) => Promise<Comments>;
+        /**
+         * @name commentsCreate
+         * @request POST:/gists/{id}/comments
+         * @description Create a commen
+         */
+        commentsCreate: (id: number, body: CommentBody, params?: RequestParams) => Promise<Comment>;
+        /**
+         * @name commentsDelete
+         * @request DELETE:/gists/{id}/comments/{commentId}
+         * @description Delete a comment.
+         */
+        commentsDelete: (id: number, commentId: number, params?: RequestParams) => Promise<any>;
+        /**
+         * @name commentsDetail
+         * @request GET:/gists/{id}/comments/{commentId}
+         * @description Get a single comment.
+         * @originalName commentsDetail
+         * @duplicate
+         */
+        commentsDetail2: (id: number, commentId: number, params?: RequestParams) => Promise<Comment>;
+        /**
+         * @name commentsPartialUpdate
+         * @request PATCH:/gists/{id}/comments/{commentId}
+         * @description Edit a comment.
+         */
+        commentsPartialUpdate: (id: number, commentId: number, body: Comment, params?: RequestParams) => Promise<Comment>;
+        /**
+         * @name forksCreate
+         * @request POST:/gists/{id}/forks
+         * @description Fork a gist.
+         */
+        forksCreate: (id: number, params?: RequestParams) => Promise<any>;
+        /**
+         * @name starDelete
+         * @request DELETE:/gists/{id}/star
+         * @description Unstar a gist.
+         */
+        starDelete: (id: number, params?: RequestParams) => Promise<any>;
+        /**
+         * @name starDetail
+         * @request GET:/gists/{id}/star
+         * @description Check if a gist is starred.
+         */
+        starDetail: (id: number, params?: RequestParams) => Promise<any>;
+        /**
+         * @name starUpdate
+         * @request PUT:/gists/{id}/star
+         * @description Star a gist.
+         */
+        starUpdate: (id: number, params?: RequestParams) => Promise<any>;
+    };
+    gitignore: {
+        /**
+         * @name templatesList
+         * @request GET:/gitignore/templates
+         * @description Listing available templates. List all templates available to pass as an option when creating a repository.
+         */
+        templatesList: (params?: RequestParams) => Promise<Gitignore>;
+        /**
+         * @name templatesDetail
+         * @request GET:/gitignore/templates/{language}
+         * @description Get a single template.
+         */
+        templatesDetail: (language: string, params?: RequestParams) => Promise<GitignoreLang>;
+    };
+    issues: {
+        /**
+         * @name issuesList
+         * @request GET:/issues
+         * @description List issues. List all issues across all the authenticated user's visible repositories.
+         */
+        issuesList: (query: {
+            filter: "assigned" | "created" | "mentioned" | "subscribed" | "all";
+            state: "open" | "closed";
+            labels: string;
+            sort: "created" | "updated" | "comments";
+            direction: "asc" | "desc";
+            since?: string;
+        }, params?: RequestParams) => Promise<Issues>;
+    };
+    legacy: {
+        /**
+         * @name issuesSearchDetail
+         * @request GET:/legacy/issues/search/{owner}/{repository}/{state}/{keyword}
+         * @description Find issues by state and keyword.
+         */
+        issuesSearchDetail: (keyword: string, state: "open" | "closed", owner: string, repository: string, params?: RequestParams) => Promise<SearchIssuesByKeyword>;
+        /**
+         * @name reposSearchDetail
+         * @request GET:/legacy/repos/search/{keyword}
+         * @description Find repositories by keyword. Note, this legacy method does not follow the v3 pagination pattern. This method returns up to 100 results per page and pages can be fetched using the start_page parameter.
+         */
+        reposSearchDetail: (keyword: string, query?: {
+            order?: "desc" | "asc";
+            language?: string;
+            start_page?: string;
+            sort?: "updated" | "stars" | "forks";
+        }, params?: RequestParams) => Promise<SearchRepositoriesByKeyword>;
+        /**
+         * @name userEmailDetail
+         * @request GET:/legacy/user/email/{email}
+         * @description This API call is added for compatibility reasons only.
+         */
+        userEmailDetail: (email: string, params?: RequestParams) => Promise<SearchUserByEmail>;
+        /**
+         * @name userSearchDetail
+         * @request GET:/legacy/user/search/{keyword}
+         * @description Find users by keyword.
+         */
+        userSearchDetail: (keyword: string, query?: {
+            order?: "desc" | "asc";
+            start_page?: string;
+            sort?: "updated" | "stars" | "forks";
+        }, params?: RequestParams) => Promise<SearchUsersByKeyword>;
+    };
+    markdown: {
+        /**
+         * @name markdownCreate
+         * @request POST:/markdown
+         * @description Render an arbitrary Markdown document
+         */
+        markdownCreate: (body: Markdown, params?: RequestParams) => Promise<any>;
+        /**
+         * @name postMarkdown
+         * @request POST:/markdown/raw
+         * @description Render a Markdown document in raw mode
+         */
+        postMarkdown: (params?: RequestParams) => Promise<any>;
+    };
+    meta: {
+        /**
+         * @name metaList
+         * @request GET:/meta
+         * @description This gives some information about GitHub.com, the service.
+         */
+        metaList: (params?: RequestParams) => Promise<Meta>;
+    };
+    networks: {
+        /**
+         * @name eventsDetail
+         * @request GET:/networks/{owner}/{repo}/events
+         * @description List public events for a network of repositories.
+         */
+        eventsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Events>;
+    };
+    notifications: {
+        /**
+         * @name notificationsList
+         * @request GET:/notifications
+         * @description List your notifications. List all notifications for the current user, grouped by repository.
+         */
+        notificationsList: (query?: {
+            all?: boolean;
+            participating?: boolean;
+            since?: string;
+        }, params?: RequestParams) => Promise<Notifications>;
+        /**
+         * @name notificationsUpdate
+         * @request PUT:/notifications
+         * @description Mark as read. Marking a notification as "read" removes it from the default view on GitHub.com.
+         */
+        notificationsUpdate: (body: NotificationMarkRead, params?: RequestParams) => Promise<any>;
+        /**
+         * @name threadsDetail
+         * @request GET:/notifications/threads/{id}
+         * @description View a single thread.
+         */
+        threadsDetail: (id: number, params?: RequestParams) => Promise<Notifications>;
+        /**
+         * @name threadsPartialUpdate
+         * @request PATCH:/notifications/threads/{id}
+         * @description Mark a thread as read
+         */
+        threadsPartialUpdate: (id: number, params?: RequestParams) => Promise<any>;
+        /**
+         * @name threadsSubscriptionDelete
+         * @request DELETE:/notifications/threads/{id}/subscription
+         * @description Delete a Thread Subscription.
+         */
+        threadsSubscriptionDelete: (id: number, params?: RequestParams) => Promise<any>;
+        /**
+         * @name threadsSubscriptionDetail
+         * @request GET:/notifications/threads/{id}/subscription
+         * @description Get a Thread Subscription.
+         */
+        threadsSubscriptionDetail: (id: number, params?: RequestParams) => Promise<Subscription>;
+        /**
+         * @name threadsSubscriptionUpdate
+         * @request PUT:/notifications/threads/{id}/subscription
+         * @description Set a Thread Subscription. This lets you subscribe to a thread, or ignore it. Subscribing to a thread is unnecessary if the user is already subscribed to the repository. Ignoring a thread will mute all future notifications (until you comment or get @mentioned).
+         */
+        threadsSubscriptionUpdate: (id: number, body: PutSubscription, params?: RequestParams) => Promise<Subscription>;
+    };
+    orgs: {
+        /**
+         * @name orgsDetail
+         * @request GET:/orgs/{org}
+         * @description Get an Organization.
+         */
+        orgsDetail: (org: string, params?: RequestParams) => Promise<any>;
+        /**
+         * @name orgsPartialUpdate
+         * @request PATCH:/orgs/{org}
+         * @description Edit an Organization.
+         */
+        orgsPartialUpdate: (org: string, body: PatchOrg, params?: RequestParams) => Promise<any>;
+        /**
+         * @name eventsDetail
+         * @request GET:/orgs/{org}/events
+         * @description List public events for an organization.
+         */
+        eventsDetail: (org: string, params?: RequestParams) => Promise<Events>;
+        /**
+         * @name issuesDetail
+         * @request GET:/orgs/{org}/issues
+         * @description List issues. List all issues for a given organization for the authenticated user.
+         */
+        issuesDetail: (org: string, query: {
+            filter: "assigned" | "created" | "mentioned" | "subscribed" | "all";
+            state: "open" | "closed";
+            labels: string;
+            sort: "created" | "updated" | "comments";
+            direction: "asc" | "desc";
+            since?: string;
+        }, params?: RequestParams) => Promise<Issues>;
+        /**
+         * @name membersDetail
+         * @request GET:/orgs/{org}/members
+         * @description Members list. List all users who are members of an organization. A member is a user tha belongs to at least 1 team in the organization. If the authenticated user is also an owner of this organization then both concealed and public members will be returned. If the requester is not an owner of the organization the query will be redirected to the public members list.
+         */
+        membersDetail: (org: string, params?: RequestParams) => Promise<Users>;
+        /**
+         * @name membersDelete
+         * @request DELETE:/orgs/{org}/members/{username}
+         * @description Remove a member. Removing a user from this list will remove them from all teams and they will no longer have any access to the organization's repositories.
+         */
+        membersDelete: (org: string, username: string, params?: RequestParams) => Promise<any>;
+        /**
+         * @name membersDetail
+         * @request GET:/orgs/{org}/members/{username}
+         * @description Check if a user is, publicly or privately, a member of the organization.
+         * @originalName membersDetail
+         * @duplicate
+         */
+        membersDetail2: (org: string, username: string, params?: RequestParams) => Promise<any>;
+        /**
+         * @name publicMembersDetail
+         * @request GET:/orgs/{org}/public_members
+         * @description Public members list. Members of an organization can choose to have their membership publicized or not.
+         */
+        publicMembersDetail: (org: string, params?: RequestParams) => Promise<Users>;
+        /**
+         * @name publicMembersDelete
+         * @request DELETE:/orgs/{org}/public_members/{username}
+         * @description Conceal a user's membership.
+         */
+        publicMembersDelete: (org: string, username: string, params?: RequestParams) => Promise<any>;
+        /**
+         * @name publicMembersDetail
+         * @request GET:/orgs/{org}/public_members/{username}
+         * @description Check public membership.
+         * @originalName publicMembersDetail
+         * @duplicate
+         */
+        publicMembersDetail2: (org: string, username: string, params?: RequestParams) => Promise<any>;
+        /**
+         * @name publicMembersUpdate
+         * @request PUT:/orgs/{org}/public_members/{username}
+         * @description Publicize a user's membership.
+         */
+        publicMembersUpdate: (org: string, username: string, params?: RequestParams) => Promise<any>;
+        /**
+         * @name reposDetail
+         * @request GET:/orgs/{org}/repos
+         * @description List repositories for the specified org.
+         */
+        reposDetail: (org: string, query?: {
+            type?: "all" | "public" | "private" | "forks" | "sources" | "member";
+        }, params?: RequestParams) => Promise<Repos>;
+        /**
+         * @name reposCreate
+         * @request POST:/orgs/{org}/repos
+         * @description Create a new repository for the authenticated user. OAuth users must supply repo scope.
+         */
+        reposCreate: (org: string, body: PostRepo, params?: RequestParams) => Promise<Repos>;
+        /**
+         * @name teamsDetail
+         * @request GET:/orgs/{org}/teams
+         * @description List teams.
+         */
+        teamsDetail: (org: string, params?: RequestParams) => Promise<Teams>;
+        /**
+         * @name teamsCreate
+         * @request POST:/orgs/{org}/teams
+         * @description Create team. In order to create a team, the authenticated user must be an owner of organization.
+         */
+        teamsCreate: (org: string, body: OrgTeamsPost, params?: RequestParams) => Promise<Team>;
+    };
+    rateLimit: {
+        /**
+         * @name rateLimitList
+         * @request GET:/rate_limit
+         * @description Get your current rate limit status Note: Accessing this endpoint does not count against your rate limit.
+         */
+        rateLimitList: (params?: RequestParams) => Promise<RateLimit>;
+    };
+    repos: {
+        /**
+         * @name reposDelete
+         * @request DELETE:/repos/{owner}/{repo}
+         * @description Delete a Repository. Deleting a repository requires admin access. If OAuth is used, the delete_repo scope is required.
+         */
+        reposDelete: (owner: string, repo: string, params?: RequestParams) => Promise<any>;
+        /**
+         * @name reposDetail
+         * @request GET:/repos/{owner}/{repo}
+         * @description Get repository.
+         */
+        reposDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Repo>;
+        /**
+         * @name reposPartialUpdate
+         * @request PATCH:/repos/{owner}/{repo}
+         * @description Edit repository.
+         */
+        reposPartialUpdate: (owner: string, repo: string, body: RepoEdit, params?: RequestParams) => Promise<Repo>;
+        /**
+         * @name assigneesDetail
+         * @request GET:/repos/{owner}/{repo}/assignees
+         * @description List assignees. This call lists all the available assignees (owner + collaborators) to which issues may be assigned.
+         */
+        assigneesDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Assignees>;
+        /**
+         * @name assigneesDetail
+         * @request GET:/repos/{owner}/{repo}/assignees/{assignee}
+         * @description Check assignee. You may also check to see if a particular user is an assignee for a repository.
+         * @originalName assigneesDetail
+         * @duplicate
+         */
+        assigneesDetail2: (owner: string, repo: string, assignee: string, params?: RequestParams) => Promise<any>;
+        /**
+         * @name branchesDetail
+         * @request GET:/repos/{owner}/{repo}/branches
+         * @description Get list of branches
+         */
+        branchesDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Branches>;
+        /**
+         * @name branchesDetail
+         * @request GET:/repos/{owner}/{repo}/branches/{branch}
+         * @description Get Branch
+         * @originalName branchesDetail
+         * @duplicate
+         */
+        branchesDetail2: (owner: string, repo: string, branch: string, params?: RequestParams) => Promise<Branch>;
+        /**
+         * @name collaboratorsDetail
+         * @request GET:/repos/{owner}/{repo}/collaborators
+         * @description List. When authenticating as an organization owner of an organization-owned repository, all organization owners are included in the list of collaborators. Otherwise, only users with access to the repository are returned in the collaborators list.
+         */
+        collaboratorsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Users>;
+        /**
+         * @name collaboratorsDelete
+         * @request DELETE:/repos/{owner}/{repo}/collaborators/{user}
+         * @description Remove collaborator.
+         */
+        collaboratorsDelete: (owner: string, repo: string, user: string, params?: RequestParams) => Promise<any>;
+        /**
+         * @name collaboratorsDetail
+         * @request GET:/repos/{owner}/{repo}/collaborators/{user}
+         * @description Check if user is a collaborator
+         * @originalName collaboratorsDetail
+         * @duplicate
+         */
+        collaboratorsDetail2: (owner: string, repo: string, user: string, params?: RequestParams) => Promise<any>;
+        /**
+         * @name collaboratorsUpdate
+         * @request PUT:/repos/{owner}/{repo}/collaborators/{user}
+         * @description Add collaborator.
+         */
+        collaboratorsUpdate: (owner: string, repo: string, user: string, params?: RequestParams) => Promise<any>;
+        /**
+         * @name commentsDetail
+         * @request GET:/repos/{owner}/{repo}/comments
+         * @description List commit comments for a repository. Comments are ordered by ascending ID.
+         */
+        commentsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<RepoComments>;
+        /**
+         * @name commentsDelete
+         * @request DELETE:/repos/{owner}/{repo}/comments/{commentId}
+         * @description Delete a commit comment
+         */
+        commentsDelete: (owner: string, repo: string, commentId: number, params?: RequestParams) => Promise<any>;
+        /**
+         * @name commentsDetail
+         * @request GET:/repos/{owner}/{repo}/comments/{commentId}
+         * @description Get a single commit comment.
+         * @originalName commentsDetail
+         * @duplicate
+         */
+        commentsDetail2: (owner: string, repo: string, commentId: number, params?: RequestParams) => Promise<CommitComment>;
+        /**
+         * @name commentsPartialUpdate
+         * @request PATCH:/repos/{owner}/{repo}/comments/{commentId}
+         * @description Update a commit comment.
+         */
+        commentsPartialUpdate: (owner: string, repo: string, commentId: number, body: CommentBody, params?: RequestParams) => Promise<CommitComment>;
+        /**
+         * @name commitsDetail
+         * @request GET:/repos/{owner}/{repo}/commits
+         * @description List commits on a repository.
+         */
+        commitsDetail: (owner: string, repo: string, query?: {
+            since?: string;
+            sha?: string;
+            path?: string;
+            author?: string;
+            until?: string;
+        }, params?: RequestParams) => Promise<Commits>;
+        /**
+         * @name commitsStatusDetail
+         * @request GET:/repos/{owner}/{repo}/commits/{ref}/status
+         * @description Get the combined Status for a specific Ref The Combined status endpoint is currently available for developers to preview. During the preview period, the API may change without advance notice. Please see the blog post for full details. To access this endpoint during the preview period, you must provide a custom media type in the Accept header: application/vnd.github.she-hulk-preview+json
+         */
+        commitsStatusDetail: (owner: string, repo: string, ref: string, params?: RequestParams) => Promise<RefStatus>;
+        /**
+         * @name commitsDetail
+         * @request GET:/repos/{owner}/{repo}/commits/{shaCode}
+         * @description Get a single commit.
+         * @originalName commitsDetail
+         * @duplicate
+         */
+        commitsDetail2: (owner: string, repo: string, shaCode: string, params?: RequestParams) => Promise<Commit>;
+        /**
+         * @name commitsCommentsDetail
+         * @request GET:/repos/{owner}/{repo}/commits/{shaCode}/comments
+         * @description List comments for a single commitList comments for a single commit.
+         */
+        commitsCommentsDetail: (owner: string, repo: string, shaCode: string, params?: RequestParams) => Promise<RepoComments>;
+        /**
+         * @name commitsCommentsCreate
+         * @request POST:/repos/{owner}/{repo}/commits/{shaCode}/comments
+         * @description Create a commit comment.
+         */
+        commitsCommentsCreate: (owner: string, repo: string, shaCode: string, body: CommitCommentBody, params?: RequestParams) => Promise<CommitComment>;
+        /**
+         * @name compareDetail
+         * @request GET:/repos/{owner}/{repo}/compare/{baseId}...{headId}
+         * @description Compare two commits
+         */
+        compareDetail: (owner: string, repo: string, baseId: string, headId: string, params?: RequestParams) => Promise<CompareCommits>;
+        /**
+         * @name contentsDelete
+         * @request DELETE:/repos/{owner}/{repo}/contents/{path}
+         * @description Delete a file. This method deletes a file in a repository.
+         */
+        contentsDelete: (owner: string, repo: string, path: string, body: DeleteFileBody, params?: RequestParams) => Promise<DeleteFile>;
+        /**
+         * @name contentsDetail
+         * @request GET:/repos/{owner}/{repo}/contents/{path}
+         * @description Get contents. This method returns the contents of a file or directory in a repository. Files and symlinks support a custom media type for getting the raw content. Directories and submodules do not support custom media types. Note: This API supports files up to 1 megabyte in size. Here can be many outcomes. For details see "http://developer.github.com/v3/repos/contents/"
+         */
+        contentsDetail: (owner: string, repo: string, path: string, query?: {
+            path?: string;
+            ref?: string;
+        }, params?: RequestParams) => Promise<ContentsPath>;
+        /**
+         * @name contentsUpdate
+         * @request PUT:/repos/{owner}/{repo}/contents/{path}
+         * @description Create a file.
+         */
+        contentsUpdate: (owner: string, repo: string, path: string, body: CreateFileBody, params?: RequestParams) => Promise<CreateFile>;
+        /**
+         * @name contributorsDetail
+         * @request GET:/repos/{owner}/{repo}/contributors
+         * @description Get list of contributors.
+         */
+        contributorsDetail: (owner: string, repo: string, query: {
+            anon: string;
+        }, params?: RequestParams) => Promise<Users>;
+        /**
+         * @name deploymentsDetail
+         * @request GET:/repos/{owner}/{repo}/deployments
+         * @description Users with pull access can view deployments for a repository
+         */
+        deploymentsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<RepoDeployments>;
+        /**
+         * @name deploymentsCreate
+         * @request POST:/repos/{owner}/{repo}/deployments
+         * @description Users with push access can create a deployment for a given ref
+         */
+        deploymentsCreate: (owner: string, repo: string, body: Deployment, params?: RequestParams) => Promise<DeploymentResp>;
+        /**
+         * @name deploymentsStatusesDetail
+         * @request GET:/repos/{owner}/{repo}/deployments/{id}/statuses
+         * @description Users with pull access can view deployment statuses for a deployment
+         */
+        deploymentsStatusesDetail: (owner: string, repo: string, id: number, params?: RequestParams) => Promise<DeploymentStatuses>;
+        /**
+         * @name deploymentsStatusesCreate
+         * @request POST:/repos/{owner}/{repo}/deployments/{id}/statuses
+         * @description Create a Deployment Status Users with push access can create deployment statuses for a given deployment:
+         */
+        deploymentsStatusesCreate: (owner: string, repo: string, id: number, body: DeploymentStatusesCreate, params?: RequestParams) => Promise<any>;
+        /**
+         * @name downloadsDetail
+         * @request GET:/repos/{owner}/{repo}/downloads
+         * @description Deprecated. List downloads for a repository.
+         */
+        downloadsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Downloads>;
+        /**
+         * @name downloadsDelete
+         * @request DELETE:/repos/{owner}/{repo}/downloads/{downloadId}
+         * @description Deprecated. Delete a download.
+         */
+        downloadsDelete: (owner: string, repo: string, downloadId: number, params?: RequestParams) => Promise<any>;
+        /**
+         * @name downloadsDetail
+         * @request GET:/repos/{owner}/{repo}/downloads/{downloadId}
+         * @description Deprecated. Get a single download.
+         * @originalName downloadsDetail
+         * @duplicate
+         */
+        downloadsDetail2: (owner: string, repo: string, downloadId: number, params?: RequestParams) => Promise<Download>;
+        /**
+         * @name eventsDetail
+         * @request GET:/repos/{owner}/{repo}/events
+         * @description Get list of repository events.
+         */
+        eventsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Events>;
+        /**
+         * @name forksDetail
+         * @request GET:/repos/{owner}/{repo}/forks
+         * @description List forks.
+         */
+        forksDetail: (owner: string, repo: string, query?: {
+            sort?: "newes" | "oldes" | "watchers";
+        }, params?: RequestParams) => Promise<Repos>;
+        /**
+         * @name forksCreate
+         * @request POST:/repos/{owner}/{repo}/forks
+         * @description Create a fork. Forking a Repository happens asynchronously. Therefore, you may have to wai a short period before accessing the git objects. If this takes longer than 5 minutes, be sure to contact Support.
+         */
+        forksCreate: (owner: string, repo: string, body: ForkBody, params?: RequestParams) => Promise<Repo>;
+        /**
+         * @name gitBlobsCreate
+         * @request POST:/repos/{owner}/{repo}/git/blobs
+         * @description Create a Blob.
+         */
+        gitBlobsCreate: (owner: string, repo: string, body: Blob, params?: RequestParams) => Promise<Blobs>;
+        /**
+         * @name gitBlobsDetail
+         * @request GET:/repos/{owner}/{repo}/git/blobs/{shaCode}
+         * @description Get a Blob. Since blobs can be any arbitrary binary data, the input and responses for the blob API takes an encoding parameter that can be either utf-8 or base64. If your data cannot be losslessly sent as a UTF-8 string, you can base64 encode it.
+         */
+        gitBlobsDetail: (owner: string, repo: string, shaCode: string, params?: RequestParams) => Promise<Blob>;
+        /**
+         * @name gitCommitsCreate
+         * @request POST:/repos/{owner}/{repo}/git/commits
+         * @description Create a Commit.
+         */
+        gitCommitsCreate: (owner: string, repo: string, body: RepoCommitBody, params?: RequestParams) => Promise<GitCommit>;
+        /**
+         * @name gitCommitsDetail
+         * @request GET:/repos/{owner}/{repo}/git/commits/{shaCode}
+         * @description Get a Commit.
+         */
+        gitCommitsDetail: (owner: string, repo: string, shaCode: string, params?: RequestParams) => Promise<RepoCommit>;
+        /**
+         * @name gitRefsDetail
+         * @request GET:/repos/{owner}/{repo}/git/refs
+         * @description Get all References
+         */
+        gitRefsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Refs>;
+        /**
+         * @name gitRefsCreate
+         * @request POST:/repos/{owner}/{repo}/git/refs
+         * @description Create a Reference
+         */
+        gitRefsCreate: (owner: string, repo: string, body: RefsBody, params?: RequestParams) => Promise<HeadBranch>;
+        /**
+         * @name gitRefsDelete
+         * @request DELETE:/repos/{owner}/{repo}/git/refs/{ref}
+         * @description Delete a Reference Example: Deleting a branch: DELETE /repos/octocat/Hello-World/git/refs/heads/feature-a Example: Deleting a tag:        DELETE /repos/octocat/Hello-World/git/refs/tags/v1.0
+         */
+        gitRefsDelete: (owner: string, repo: string, ref: string, params?: RequestParams) => Promise<any>;
+        /**
+         * @name gitRefsDetail
+         * @request GET:/repos/{owner}/{repo}/git/refs/{ref}
+         * @description Get a Reference
+         * @originalName gitRefsDetail
+         * @duplicate
+         */
+        gitRefsDetail2: (owner: string, repo: string, ref: string, params?: RequestParams) => Promise<HeadBranch>;
+        /**
+         * @name gitRefsPartialUpdate
+         * @request PATCH:/repos/{owner}/{repo}/git/refs/{ref}
+         * @description Update a Reference
+         */
+        gitRefsPartialUpdate: (owner: string, repo: string, ref: string, body: GitRefPatch, params?: RequestParams) => Promise<HeadBranch>;
+        /**
+         * @name gitTagsCreate
+         * @request POST:/repos/{owner}/{repo}/git/tags
+         * @description Create a Tag Object. Note that creating a tag object does not create the reference that makes a tag in Git. If you want to create an annotated tag in Git, you have to do this call to create the tag object, and then create the refs/tags/[tag] reference. If you want to create a lightweight tag, you only have to create the tag reference - this call would be unnecessary.
+         */
+        gitTagsCreate: (owner: string, repo: string, body: TagBody, params?: RequestParams) => Promise<Tag>;
+        /**
+         * @name gitTagsDetail
+         * @request GET:/repos/{owner}/{repo}/git/tags/{shaCode}
+         * @description Get a Tag.
+         */
+        gitTagsDetail: (owner: string, repo: string, shaCode: string, params?: RequestParams) => Promise<Tag>;
+        /**
+         * @name gitTreesCreate
+         * @request POST:/repos/{owner}/{repo}/git/trees
+         * @description Create a Tree. The tree creation API will take nested entries as well. If both a tree and a nested path modifying that tree are specified, it will overwrite the contents of that tree with the new path contents and write a new tree out.
+         */
+        gitTreesCreate: (owner: string, repo: string, body: Tree, params?: RequestParams) => Promise<Trees>;
+        /**
+         * @name gitTreesDetail
+         * @request GET:/repos/{owner}/{repo}/git/trees/{shaCode}
+         * @description Get a Tree.
+         */
+        gitTreesDetail: (owner: string, repo: string, shaCode: string, query?: {
+            recursive?: number;
+        }, params?: RequestParams) => Promise<Tree>;
+        /**
+         * @name hooksDetail
+         * @request GET:/repos/{owner}/{repo}/hooks
+         * @description Get list of hooks.
+         */
+        hooksDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Hook>;
+        /**
+         * @name hooksCreate
+         * @request POST:/repos/{owner}/{repo}/hooks
+         * @description Create a hook.
+         */
+        hooksCreate: (owner: string, repo: string, body: HookBody, params?: RequestParams) => Promise<Hook>;
+        /**
+         * @name hooksDelete
+         * @request DELETE:/repos/{owner}/{repo}/hooks/{hookId}
+         * @description Delete a hook.
+         */
+        hooksDelete: (owner: string, repo: string, hookId: number, params?: RequestParams) => Promise<any>;
+        /**
+         * @name hooksDetail
+         * @request GET:/repos/{owner}/{repo}/hooks/{hookId}
+         * @description Get single hook.
+         * @originalName hooksDetail
+         * @duplicate
+         */
+        hooksDetail2: (owner: string, repo: string, hookId: number, params?: RequestParams) => Promise<Hook>;
+        /**
+         * @name hooksPartialUpdate
+         * @request PATCH:/repos/{owner}/{repo}/hooks/{hookId}
+         * @description Edit a hook.
+         */
+        hooksPartialUpdate: (owner: string, repo: string, hookId: number, body: HookBody, params?: RequestParams) => Promise<Hook>;
+        /**
+         * @name hooksTestsCreate
+         * @request POST:/repos/{owner}/{repo}/hooks/{hookId}/tests
+         * @description Test a push hook. This will trigger the hook with the latest push to the current repository if the hook is subscribed to push events. If the hook is not subscribed to push events, the server will respond with 204 but no test POST will be generated. Note: Previously /repos/:owner/:repo/hooks/:id/tes
+         */
+        hooksTestsCreate: (owner: string, repo: string, hookId: number, params?: RequestParams) => Promise<any>;
+        /**
+         * @name issuesDetail
+         * @request GET:/repos/{owner}/{repo}/issues
+         * @description List issues for a repository.
+         */
+        issuesDetail: (owner: string, repo: string, query: {
+            filter: "assigned" | "created" | "mentioned" | "subscribed" | "all";
+            state: "open" | "closed";
+            labels: string;
+            sort: "created" | "updated" | "comments";
+            direction: "asc" | "desc";
+            since?: string;
+        }, params?: RequestParams) => Promise<Issues>;
+        /**
+         * @name issuesCreate
+         * @request POST:/repos/{owner}/{repo}/issues
+         * @description Create an issue. Any user with pull access to a repository can create an issue.
+         */
+        issuesCreate: (owner: string, repo: string, body: Issue, params?: RequestParams) => Promise<Issue>;
+        /**
+         * @name issuesCommentsDetail
+         * @request GET:/repos/{owner}/{repo}/issues/comments
+         * @description List comments in a repository.
+         */
+        issuesCommentsDetail: (owner: string, repo: string, query?: {
+            direction?: string;
+            sort?: "created" | "updated";
+            since?: string;
+        }, params?: RequestParams) => Promise<IssuesComments>;
+        /**
+         * @name issuesCommentsDelete
+         * @request DELETE:/repos/{owner}/{repo}/issues/comments/{commentId}
+         * @description Delete a comment.
+         */
+        issuesCommentsDelete: (owner: string, repo: string, commentId: number, params?: RequestParams) => Promise<any>;
+        /**
+         * @name issuesCommentsDetail
+         * @request GET:/repos/{owner}/{repo}/issues/comments/{commentId}
+         * @description Get a single comment.
+         * @originalName issuesCommentsDetail
+         * @duplicate
+         */
+        issuesCommentsDetail2: (owner: string, repo: string, commentId: number, params?: RequestParams) => Promise<IssuesComment>;
+        /**
+         * @name issuesCommentsPartialUpdate
+         * @request PATCH:/repos/{owner}/{repo}/issues/comments/{commentId}
+         * @description Edit a comment.
+         */
+        issuesCommentsPartialUpdate: (owner: string, repo: string, commentId: number, body: CommentBody, params?: RequestParams) => Promise<IssuesComment>;
+        /**
+         * @name issuesEventsDetail
+         * @request GET:/repos/{owner}/{repo}/issues/events
+         * @description List issue events for a repository.
+         */
+        issuesEventsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<IssueEvents>;
+        /**
+         * @name issuesEventsDetail
+         * @request GET:/repos/{owner}/{repo}/issues/events/{eventId}
+         * @description Get a single event.
+         * @originalName issuesEventsDetail
+         * @duplicate
+         */
+        issuesEventsDetail2: (owner: string, repo: string, eventId: number, params?: RequestParams) => Promise<IssueEvent>;
+        /**
+         * @name issuesDetail
+         * @request GET:/repos/{owner}/{repo}/issues/{number}
+         * @description Get a single issue
+         * @originalName issuesDetail
+         * @duplicate
+         */
+        issuesDetail2: (owner: string, repo: string, number: number, params?: RequestParams) => Promise<Issue>;
+        /**
+         * @name issuesPartialUpdate
+         * @request PATCH:/repos/{owner}/{repo}/issues/{number}
+         * @description Edit an issue. Issue owners and users with push access can edit an issue.
+         */
+        issuesPartialUpdate: (owner: string, repo: string, number: number, body: Issue, params?: RequestParams) => Promise<Issue>;
+        /**
+         * @name issuesCommentsDetail
+         * @request GET:/repos/{owner}/{repo}/issues/{number}/comments
+         * @description List comments on an issue.
+         * @originalName issuesCommentsDetail
+         * @duplicate
+         */
+        issuesCommentsDetail3: (owner: string, repo: string, number: number, params?: RequestParams) => Promise<IssuesComments>;
+        /**
+         * @name issuesCommentsCreate
+         * @request POST:/repos/{owner}/{repo}/issues/{number}/comments
+         * @description Create a comment.
+         */
+        issuesCommentsCreate: (owner: string, repo: string, number: number, body: CommentBody, params?: RequestParams) => Promise<IssuesComment>;
+        /**
+         * @name issuesEventsDetail
+         * @request GET:/repos/{owner}/{repo}/issues/{number}/events
+         * @description List events for an issue.
+         * @originalName issuesEventsDetail
+         * @duplicate
+         */
+        issuesEventsDetail3: (owner: string, repo: string, number: number, params?: RequestParams) => Promise<IssueEvents>;
+        /**
+         * @name issuesLabelsDelete
+         * @request DELETE:/repos/{owner}/{repo}/issues/{number}/labels
+         * @description Remove all labels from an issue.
+         */
+        issuesLabelsDelete: (owner: string, repo: string, number: number, params?: RequestParams) => Promise<any>;
+        /**
+         * @name issuesLabelsDetail
+         * @request GET:/repos/{owner}/{repo}/issues/{number}/labels
+         * @description List labels on an issue.
+         */
+        issuesLabelsDetail: (owner: string, repo: string, number: number, params?: RequestParams) => Promise<Labels>;
+        /**
+         * @name issuesLabelsCreate
+         * @request POST:/repos/{owner}/{repo}/issues/{number}/labels
+         * @description Add labels to an issue.
+         */
+        issuesLabelsCreate: (owner: string, repo: string, number: number, body: EmailsPost, params?: RequestParams) => Promise<Label>;
+        /**
+         * @name issuesLabelsUpdate
+         * @request PUT:/repos/{owner}/{repo}/issues/{number}/labels
+         * @description Replace all labels for an issue. Sending an empty array ([]) will remove all Labels from the Issue.
+         */
+        issuesLabelsUpdate: (owner: string, repo: string, number: number, body: EmailsPost, params?: RequestParams) => Promise<Label>;
+        /**
+         * @name issuesLabelsDelete
+         * @request DELETE:/repos/{owner}/{repo}/issues/{number}/labels/{name}
+         * @description Remove a label from an issue.
+         * @originalName issuesLabelsDelete
+         * @duplicate
+         */
+        issuesLabelsDelete2: (owner: string, repo: string, number: number, name: string, params?: RequestParams) => Promise<any>;
+        /**
+         * @name keysDetail
+         * @request GET:/repos/{owner}/{repo}/keys
+         * @description Get list of keys.
+         */
+        keysDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Keys>;
+        /**
+         * @name keysCreate
+         * @request POST:/repos/{owner}/{repo}/keys
+         * @description Create a key.
+         */
+        keysCreate: (owner: string, repo: string, body: UserKeysPost, params?: RequestParams) => Promise<UserKeysKeyId>;
+        /**
+         * @name keysDelete
+         * @request DELETE:/repos/{owner}/{repo}/keys/{keyId}
+         * @description Delete a key.
+         */
+        keysDelete: (owner: string, repo: string, keyId: number, params?: RequestParams) => Promise<any>;
+        /**
+         * @name keysDetail
+         * @request GET:/repos/{owner}/{repo}/keys/{keyId}
+         * @description Get a key
+         * @originalName keysDetail
+         * @duplicate
+         */
+        keysDetail2: (owner: string, repo: string, keyId: number, params?: RequestParams) => Promise<UserKeysKeyId>;
+        /**
+         * @name labelsDetail
+         * @request GET:/repos/{owner}/{repo}/labels
+         * @description List all labels for this repository.
+         */
+        labelsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Labels>;
+        /**
+         * @name labelsCreate
+         * @request POST:/repos/{owner}/{repo}/labels
+         * @description Create a label.
+         */
+        labelsCreate: (owner: string, repo: string, body: EmailsPost, params?: RequestParams) => Promise<Label>;
+        /**
+         * @name labelsDelete
+         * @request DELETE:/repos/{owner}/{repo}/labels/{name}
+         * @description Delete a label.
+         */
+        labelsDelete: (owner: string, repo: string, name: string, params?: RequestParams) => Promise<any>;
+        /**
+         * @name labelsDetail
+         * @request GET:/repos/{owner}/{repo}/labels/{name}
+         * @description Get a single label.
+         * @originalName labelsDetail
+         * @duplicate
+         */
+        labelsDetail2: (owner: string, repo: string, name: string, params?: RequestParams) => Promise<Label>;
+        /**
+         * @name labelsPartialUpdate
+         * @request PATCH:/repos/{owner}/{repo}/labels/{name}
+         * @description Update a label.
+         */
+        labelsPartialUpdate: (owner: string, repo: string, name: string, body: EmailsPost, params?: RequestParams) => Promise<Label>;
+        /**
+         * @name languagesDetail
+         * @request GET:/repos/{owner}/{repo}/languages
+         * @description List languages. List languages for the specified repository. The value on the right of a language is the number of bytes of code written in that language.
+         */
+        languagesDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Record<string, number>>;
+        /**
+         * @name mergesCreate
+         * @request POST:/repos/{owner}/{repo}/merges
+         * @description Perform a merge.
+         */
+        mergesCreate: (owner: string, repo: string, body: MergesBody, params?: RequestParams) => Promise<MergesSuccessful>;
+        /**
+         * @name milestonesDetail
+         * @request GET:/repos/{owner}/{repo}/milestones
+         * @description List milestones for a repository.
+         */
+        milestonesDetail: (owner: string, repo: string, query?: {
+            state?: "open" | "closed";
+            direction?: string;
+            sort?: "due_date" | "completeness";
+        }, params?: RequestParams) => Promise<Milestone>;
+        /**
+         * @name milestonesCreate
+         * @request POST:/repos/{owner}/{repo}/milestones
+         * @description Create a milestone.
+         */
+        milestonesCreate: (owner: string, repo: string, body: MilestoneUpdate, params?: RequestParams) => Promise<Milestone>;
+        /**
+         * @name milestonesDelete
+         * @request DELETE:/repos/{owner}/{repo}/milestones/{number}
+         * @description Delete a milestone.
+         */
+        milestonesDelete: (owner: string, repo: string, number: number, params?: RequestParams) => Promise<any>;
+        /**
+         * @name milestonesDetail
+         * @request GET:/repos/{owner}/{repo}/milestones/{number}
+         * @description Get a single milestone.
+         * @originalName milestonesDetail
+         * @duplicate
+         */
+        milestonesDetail2: (owner: string, repo: string, number: number, params?: RequestParams) => Promise<Milestone>;
+        /**
+         * @name milestonesPartialUpdate
+         * @request PATCH:/repos/{owner}/{repo}/milestones/{number}
+         * @description Update a milestone.
+         */
+        milestonesPartialUpdate: (owner: string, repo: string, number: number, body: MilestoneUpdate, params?: RequestParams) => Promise<Milestone>;
+        /**
+         * @name milestonesLabelsDetail
+         * @request GET:/repos/{owner}/{repo}/milestones/{number}/labels
+         * @description Get labels for every issue in a milestone.
+         */
+        milestonesLabelsDetail: (owner: string, repo: string, number: number, params?: RequestParams) => Promise<Labels>;
+        /**
+         * @name notificationsDetail
+         * @request GET:/repos/{owner}/{repo}/notifications
+         * @description List your notifications in a repository List all notifications for the current user.
+         */
+        notificationsDetail: (owner: string, repo: string, query?: {
+            all?: boolean;
+            participating?: boolean;
+            since?: string;
+        }, params?: RequestParams) => Promise<Notifications>;
+        /**
+         * @name notificationsUpdate
+         * @request PUT:/repos/{owner}/{repo}/notifications
+         * @description Mark notifications as read in a repository. Marking all notifications in a repository as "read" removes them from the default view on GitHub.com.
+         */
+        notificationsUpdate: (owner: string, repo: string, body: NotificationMarkRead, params?: RequestParams) => Promise<any>;
+        /**
+         * @name pullsDetail
+         * @request GET:/repos/{owner}/{repo}/pulls
+         * @description List pull requests.
+         */
+        pullsDetail: (owner: string, repo: string, query?: {
+            state?: "open" | "closed";
+            head?: string;
+            base?: string;
+        }, params?: RequestParams) => Promise<Pulls>;
+        /**
+         * @name pullsCreate
+         * @request POST:/repos/{owner}/{repo}/pulls
+         * @description Create a pull request.
+         */
+        pullsCreate: (owner: string, repo: string, body: PullsPost, params?: RequestParams) => Promise<Pulls>;
+        /**
+         * @name pullsCommentsDetail
+         * @request GET:/repos/{owner}/{repo}/pulls/comments
+         * @description List comments in a repository. By default, Review Comments are ordered by ascending ID.
+         */
+        pullsCommentsDetail: (owner: string, repo: string, query?: {
+            direction?: string;
+            sort?: "created" | "updated";
+            since?: string;
+        }, params?: RequestParams) => Promise<IssuesComments>;
+        /**
+         * @name pullsCommentsDelete
+         * @request DELETE:/repos/{owner}/{repo}/pulls/comments/{commentId}
+         * @description Delete a comment.
+         */
+        pullsCommentsDelete: (owner: string, repo: string, commentId: number, params?: RequestParams) => Promise<any>;
+        /**
+         * @name pullsCommentsDetail
+         * @request GET:/repos/{owner}/{repo}/pulls/comments/{commentId}
+         * @description Get a single comment.
+         * @originalName pullsCommentsDetail
+         * @duplicate
+         */
+        pullsCommentsDetail2: (owner: string, repo: string, commentId: number, params?: RequestParams) => Promise<PullsComment>;
+        /**
+         * @name pullsCommentsPartialUpdate
+         * @request PATCH:/repos/{owner}/{repo}/pulls/comments/{commentId}
+         * @description Edit a comment.
+         */
+        pullsCommentsPartialUpdate: (owner: string, repo: string, commentId: number, body: CommentBody, params?: RequestParams) => Promise<PullsComment>;
+        /**
+         * @name pullsDetail
+         * @request GET:/repos/{owner}/{repo}/pulls/{number}
+         * @description Get a single pull request.
+         * @originalName pullsDetail
+         * @duplicate
+         */
+        pullsDetail2: (owner: string, repo: string, number: number, params?: RequestParams) => Promise<PullRequest>;
+        /**
+         * @name pullsPartialUpdate
+         * @request PATCH:/repos/{owner}/{repo}/pulls/{number}
+         * @description Update a pull request.
+         */
+        pullsPartialUpdate: (owner: string, repo: string, number: number, body: PullUpdate, params?: RequestParams) => Promise<Repo>;
+        /**
+         * @name pullsCommentsDetail
+         * @request GET:/repos/{owner}/{repo}/pulls/{number}/comments
+         * @description List comments on a pull request.
+         * @originalName pullsCommentsDetail
+         * @duplicate
+         */
+        pullsCommentsDetail3: (owner: string, repo: string, number: number, params?: RequestParams) => Promise<PullsComment>;
+        /**
+         * @name pullsCommentsCreate
+         * @request POST:/repos/{owner}/{repo}/pulls/{number}/comments
+         * @description Create a comment. #TODO Alternative input ( http://developer.github.com/v3/pulls/comments/ ) description: | Alternative Input. Instead of passing commit_id, path, and position you can reply to an existing Pull Request Comment like this: body Required string in_reply_to Required number - Comment id to reply to.
+         */
+        pullsCommentsCreate: (owner: string, repo: string, number: number, body: PullsCommentPost, params?: RequestParams) => Promise<PullsComment>;
+        /**
+         * @name pullsCommitsDetail
+         * @request GET:/repos/{owner}/{repo}/pulls/{number}/commits
+         * @description List commits on a pull request.
+         */
+        pullsCommitsDetail: (owner: string, repo: string, number: number, params?: RequestParams) => Promise<Commits>;
+        /**
+         * @name pullsFilesDetail
+         * @request GET:/repos/{owner}/{repo}/pulls/{number}/files
+         * @description List pull requests files.
+         */
+        pullsFilesDetail: (owner: string, repo: string, number: number, params?: RequestParams) => Promise<Pulls>;
+        /**
+         * @name pullsMergeDetail
+         * @request GET:/repos/{owner}/{repo}/pulls/{number}/merge
+         * @description Get if a pull request has been merged.
+         */
+        pullsMergeDetail: (owner: string, repo: string, number: number, params?: RequestParams) => Promise<any>;
+        /**
+         * @name pullsMergeUpdate
+         * @request PUT:/repos/{owner}/{repo}/pulls/{number}/merge
+         * @description Merge a pull request (Merge Button's)
+         */
+        pullsMergeUpdate: (owner: string, repo: string, number: number, body: MergePullBody, params?: RequestParams) => Promise<Merge>;
+        /**
+         * @name readmeDetail
+         * @request GET:/repos/{owner}/{repo}/readme
+         * @description Get the README. This method returns the preferred README for a repository.
+         */
+        readmeDetail: (owner: string, repo: string, query?: {
+            ref?: string;
+        }, params?: RequestParams) => Promise<ContentsPath>;
+        /**
+         * @name releasesDetail
+         * @request GET:/repos/{owner}/{repo}/releases
+         * @description Users with push access to the repository will receive all releases (i.e., published releases and draft releases). Users with pull access will receive published releases only
+         */
+        releasesDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Releases>;
+        /**
+         * @name releasesCreate
+         * @request POST:/repos/{owner}/{repo}/releases
+         * @description Create a release Users with push access to the repository can create a release.
+         */
+        releasesCreate: (owner: string, repo: string, body: ReleaseCreate, params?: RequestParams) => Promise<Release>;
+        /**
+         * @name releasesAssetsDelete
+         * @request DELETE:/repos/{owner}/{repo}/releases/assets/{id}
+         * @description Delete a release asset
+         */
+        releasesAssetsDelete: (owner: string, repo: string, id: string, params?: RequestParams) => Promise<any>;
+        /**
+         * @name releasesAssetsDetail
+         * @request GET:/repos/{owner}/{repo}/releases/assets/{id}
+         * @description Get a single release asset
+         */
+        releasesAssetsDetail: (owner: string, repo: string, id: string, params?: RequestParams) => Promise<Asset>;
+        /**
+         * @name releasesAssetsPartialUpdate
+         * @request PATCH:/repos/{owner}/{repo}/releases/assets/{id}
+         * @description Edit a release asset Users with push access to the repository can edit a release asset.
+         */
+        releasesAssetsPartialUpdate: (owner: string, repo: string, id: string, body: AssetPatch, params?: RequestParams) => Promise<Asset>;
+        /**
+         * @name releasesDelete
+         * @request DELETE:/repos/{owner}/{repo}/releases/{id}
+         * @description Users with push access to the repository can delete a release.
+         */
+        releasesDelete: (owner: string, repo: string, id: string, params?: RequestParams) => Promise<any>;
+        /**
+         * @name releasesDetail
+         * @request GET:/repos/{owner}/{repo}/releases/{id}
+         * @description Get a single release
+         * @originalName releasesDetail
+         * @duplicate
+         */
+        releasesDetail2: (owner: string, repo: string, id: string, params?: RequestParams) => Promise<Release>;
+        /**
+         * @name releasesPartialUpdate
+         * @request PATCH:/repos/{owner}/{repo}/releases/{id}
+         * @description Users with push access to the repository can edit a release
+         */
+        releasesPartialUpdate: (owner: string, repo: string, id: string, body: ReleaseCreate, params?: RequestParams) => Promise<Release>;
+        /**
+         * @name releasesAssetsDetail
+         * @request GET:/repos/{owner}/{repo}/releases/{id}/assets
+         * @description List assets for a release
+         * @originalName releasesAssetsDetail
+         * @duplicate
+         */
+        releasesAssetsDetail2: (owner: string, repo: string, id: string, params?: RequestParams) => Promise<Assets>;
+        /**
+         * @name stargazersDetail
+         * @request GET:/repos/{owner}/{repo}/stargazers
+         * @description List Stargazers.
+         */
+        stargazersDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Users>;
+        /**
+         * @name statsCodeFrequencyDetail
+         * @request GET:/repos/{owner}/{repo}/stats/code_frequency
+         * @description Get the number of additions and deletions per week. Returns a weekly aggregate of the number of additions and deletions pushed to a repository.
+         */
+        statsCodeFrequencyDetail: (owner: string, repo: string, params?: RequestParams) => Promise<CodeFrequencyStats>;
+        /**
+         * @name statsCommitActivityDetail
+         * @request GET:/repos/{owner}/{repo}/stats/commit_activity
+         * @description Get the last year of commit activity data. Returns the last year of commit activity grouped by week. The days array is a group of commits per day, starting on Sunday.
+         */
+        statsCommitActivityDetail: (owner: string, repo: string, params?: RequestParams) => Promise<CommitActivityStats>;
+        /**
+         * @name statsContributorsDetail
+         * @request GET:/repos/{owner}/{repo}/stats/contributors
+         * @description Get contributors list with additions, deletions, and commit counts.
+         */
+        statsContributorsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<ContributorsStats>;
+        /**
+         * @name statsParticipationDetail
+         * @request GET:/repos/{owner}/{repo}/stats/participation
+         * @description Get the weekly commit count for the repo owner and everyone else.
+         */
+        statsParticipationDetail: (owner: string, repo: string, params?: RequestParams) => Promise<ParticipationStats>;
+        /**
+         * @name statsPunchCardDetail
+         * @request GET:/repos/{owner}/{repo}/stats/punch_card
+         * @description Get the number of commits per hour in each day. Each array contains the day number, hour number, and number of commits 0-6 Sunday - Saturday 0-23 Hour of day Number of commits For example, [2, 14, 25] indicates that there were 25 total commits, during the 2.00pm hour on Tuesdays. All times are based on the time zone of individual commits.
+         */
+        statsPunchCardDetail: (owner: string, repo: string, params?: RequestParams) => Promise<CodeFrequencyStats>;
+        /**
+         * @name statusesDetail
+         * @request GET:/repos/{owner}/{repo}/statuses/{ref}
+         * @description List Statuses for a specific Ref.
+         */
+        statusesDetail: (owner: string, repo: string, ref: string, params?: RequestParams) => Promise<Ref>;
+        /**
+         * @name statusesCreate
+         * @request POST:/repos/{owner}/{repo}/statuses/{ref}
+         * @description Create a Status.
+         */
+        statusesCreate: (owner: string, repo: string, ref: string, body: HeadBranch, params?: RequestParams) => Promise<Ref>;
+        /**
+         * @name subscribersDetail
+         * @request GET:/repos/{owner}/{repo}/subscribers
+         * @description List watchers.
+         */
+        subscribersDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Users>;
+        /**
+         * @name subscriptionDelete
+         * @request DELETE:/repos/{owner}/{repo}/subscription
+         * @description Delete a Repository Subscription.
+         */
+        subscriptionDelete: (owner: string, repo: string, params?: RequestParams) => Promise<any>;
+        /**
+         * @name subscriptionDetail
+         * @request GET:/repos/{owner}/{repo}/subscription
+         * @description Get a Repository Subscription.
+         */
+        subscriptionDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Subscription>;
+        /**
+         * @name subscriptionUpdate
+         * @request PUT:/repos/{owner}/{repo}/subscription
+         * @description Set a Repository Subscription
+         */
+        subscriptionUpdate: (owner: string, repo: string, body: SubscriptionBody, params?: RequestParams) => Promise<Subscription>;
+        /**
+         * @name tagsDetail
+         * @request GET:/repos/{owner}/{repo}/tags
+         * @description Get list of tags.
+         */
+        tagsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Tags>;
+        /**
+         * @name teamsDetail
+         * @request GET:/repos/{owner}/{repo}/teams
+         * @description Get list of teams
+         */
+        teamsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Teams>;
+        /**
+         * @name watchersDetail
+         * @request GET:/repos/{owner}/{repo}/watchers
+         * @description List Stargazers. New implementation.
+         */
+        watchersDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Users>;
+        /**
+         * @name reposDetail
+         * @request GET:/repos/{owner}/{repo}/{archive_format}/{path}
+         * @description Get archive link. This method will return a 302 to a URL to download a tarball or zipball archive for a repository. Please make sure your HTTP framework is configured to follow redirects or you will need to use the Location header to make a second GET request. Note: For private repositories, these links are temporary and expire quickly.
+         * @originalName reposDetail
+         * @duplicate
+         */
+        reposDetail2: (owner: string, repo: string, archive_format: "tarball" | "zipball", path: string, params?: RequestParams) => Promise<any>;
+    };
+    repositories: {
+        /**
+         * @name repositoriesList
+         * @request GET:/repositories
+         * @description List all public repositories. This provides a dump of every public repository, in the order that they were created. Note: Pagination is powered exclusively by the since parameter. is the Link header to get the URL for the next page of repositories.
+         */
+        repositoriesList: (query?: {
+            since?: string;
+        }, params?: RequestParams) => Promise<Repos>;
+    };
+    search: {
+        /**
+         * @name codeList
+         * @request GET:/search/code
+         * @description Search code.
+         */
+        codeList: (query: {
+            order?: "desc" | "asc";
+            q: string;
+            sort?: "indexed";
+        }, params?: RequestParams) => Promise<SearchCode>;
+        /**
+         * @name issuesList
+         * @request GET:/search/issues
+         * @description Find issues by state and keyword. (This method returns up to 100 results per page.)
+         */
+        issuesList: (query: {
+            order?: "desc" | "asc";
+            q: string;
+            sort?: "updated" | "created" | "comments";
+        }, params?: RequestParams) => Promise<SearchIssues>;
+        /**
+         * @name repositoriesList
+         * @request GET:/search/repositories
+         * @description Search repositories.
+         */
+        repositoriesList: (query: {
+            order?: "desc" | "asc";
+            q: string;
+            sort?: "stars" | "forks" | "updated";
+        }, params?: RequestParams) => Promise<SearchRepositories>;
+        /**
+         * @name usersList
+         * @request GET:/search/users
+         * @description Search users.
+         */
+        usersList: (query: {
+            order?: "desc" | "asc";
+            q: string;
+            sort?: "followers" | "repositories" | "joined";
+        }, params?: RequestParams) => Promise<SearchUsers>;
+    };
+    teams: {
+        /**
+         * @name teamsDelete
+         * @request DELETE:/teams/{teamId}
+         * @description Delete team. In order to delete a team, the authenticated user must be an owner of the org that the team is associated with.
+         */
+        teamsDelete: (teamId: number, params?: RequestParams) => Promise<any>;
+        /**
+         * @name teamsDetail
+         * @request GET:/teams/{teamId}
+         * @description Get team.
+         */
+        teamsDetail: (teamId: number, params?: RequestParams) => Promise<Team>;
+        /**
+         * @name teamsPartialUpdate
+         * @request PATCH:/teams/{teamId}
+         * @description Edit team. In order to edit a team, the authenticated user must be an owner of the org that the team is associated with.
+         */
+        teamsPartialUpdate: (teamId: number, body: EditTeam, params?: RequestParams) => Promise<Team>;
+        /**
+         * @name membersDetail
+         * @request GET:/teams/{teamId}/members
+         * @description List team members. In order to list members in a team, the authenticated user must be a member of the team.
+         */
+        membersDetail: (teamId: number, params?: RequestParams) => Promise<Users>;
+        /**
+         * @name membersDelete
+         * @request DELETE:/teams/{teamId}/members/{username}
+         * @description The "Remove team member" API is deprecated and is scheduled for removal in the next major version of the API. We recommend using the Remove team membership API instead. It allows you to remove both active and pending memberships. Remove team member. In order to remove a user from a team, the authenticated user must have 'admin' permissions to the team or be an owner of the org that the team is associated with. NOTE This does not delete the user, it just remove them from the team.
+         */
+        membersDelete: (teamId: number, username: string, params?: RequestParams) => Promise<any>;
+        /**
+         * @name membersDetail
+         * @request GET:/teams/{teamId}/members/{username}
+         * @description The "Get team member" API is deprecated and is scheduled for removal in the next major version of the API. We recommend using the Get team membership API instead. It allows you to get both active and pending memberships. Get team member. In order to get if a user is a member of a team, the authenticated user mus be a member of the team.
+         * @originalName membersDetail
+         * @duplicate
+         */
+        membersDetail2: (teamId: number, username: string, params?: RequestParams) => Promise<any>;
+        /**
+         * @name membersUpdate
+         * @request PUT:/teams/{teamId}/members/{username}
+         * @description The API (described below) is deprecated and is scheduled for removal in the next major version of the API. We recommend using the Add team membership API instead. It allows you to invite new organization members to your teams. Add team member. In order to add a user to a team, the authenticated user must have 'admin' permissions to the team or be an owner of the org that the team is associated with.
+         */
+        membersUpdate: (teamId: number, username: string, params?: RequestParams) => Promise<any>;
+        /**
+         * @name membershipsDelete
+         * @request DELETE:/teams/{teamId}/memberships/{username}
+         * @description Remove team membership. In order to remove a membership between a user and a team, the authenticated user must have 'admin' permissions to the team or be an owner of the organization that the team is associated with. NOTE: This does not delete the user, it just removes their membership from the team.
+         */
+        membershipsDelete: (teamId: number, username: string, params?: RequestParams) => Promise<any>;
+        /**
+         * @name membershipsDetail
+         * @request GET:/teams/{teamId}/memberships/{username}
+         * @description Get team membership. In order to get a user's membership with a team, the authenticated user must be a member of the team or an owner of the team's organization.
+         */
+        membershipsDetail: (teamId: number, username: string, params?: RequestParams) => Promise<TeamMembership>;
+        /**
+         * @name membershipsUpdate
+         * @request PUT:/teams/{teamId}/memberships/{username}
+         * @description Add team membership. In order to add a membership between a user and a team, the authenticated user must have 'admin' permissions to the team or be an owner of the organization that the team is associated with. If the user is already a part of the team's organization (meaning they're on at least one other team in the organization), this endpoint will add the user to the team. If the user is completely unaffiliated with the team's organization (meaning they're on none of the organization's teams), this endpoint will send an invitation to the user via email. This newly-created membership will be in the 'pending' state until the user accepts the invitation, at which point the membership will transition to the 'active' state and the user will be added as a member of the team.
+         */
+        membershipsUpdate: (teamId: number, username: string, params?: RequestParams) => Promise<TeamMembership>;
+        /**
+         * @name reposDetail
+         * @request GET:/teams/{teamId}/repos
+         * @description List team repos
+         */
+        reposDetail: (teamId: number, params?: RequestParams) => Promise<Repos>;
+        /**
+         * @name reposDelete
+         * @request DELETE:/teams/{teamId}/repos/{owner}/{repo}
+         * @description In order to remove a repository from a team, the authenticated user must be an owner of the org that the team is associated with. NOTE: This does not delete the repository, it just removes it from the team.
+         */
+        reposDelete: (teamId: number, owner: string, repo: string, params?: RequestParams) => Promise<any>;
+        /**
+         * @name reposDetail
+         * @request GET:/teams/{teamId}/repos/{owner}/{repo}
+         * @description Check if a team manages a repository
+         * @originalName reposDetail
+         * @duplicate
+         */
+        reposDetail2: (teamId: number, owner: string, repo: string, params?: RequestParams) => Promise<any>;
+        /**
+         * @name reposUpdate
+         * @request PUT:/teams/{teamId}/repos/{owner}/{repo}
+         * @description In order to add a repository to a team, the authenticated user must be an owner of the org that the team is associated with. Also, the repository must be owned by the organization, or a direct fork of a repository owned by the organization.
+         */
+        reposUpdate: (teamId: number, owner: string, repo: string, params?: RequestParams) => Promise<any>;
+    };
+    user: {
+        /**
+         * @name userList
+         * @request GET:/user
+         * @description Get the authenticated user.
+         */
+        userList: (params?: RequestParams) => Promise<any>;
+        /**
+         * @name userPartialUpdate
+         * @request PATCH:/user
+         * @description Update the authenticated user.
+         */
+        userPartialUpdate: (body: UserUpdate, params?: RequestParams) => Promise<any>;
+        /**
+         * @name emailsDelete
+         * @request DELETE:/user/emails
+         * @description Delete email address(es). You can include a single email address or an array of addresses.
+         */
+        emailsDelete: (body: UserEmails, params?: RequestParams) => Promise<any>;
+        /**
+         * @name emailsList
+         * @request GET:/user/emails
+         * @description List email addresses for a user. In the final version of the API, this method will return an array of hashes with extended information for each email address indicating if the address has been verified and if it's primary email address for GitHub. Until API v3 is finalized, use the application/vnd.github.v3 media type to get other response format.
+         */
+        emailsList: (params?: RequestParams) => Promise<UserEmails>;
+        /**
+         * @name emailsCreate
+         * @request POST:/user/emails
+         * @description Add email address(es). You can post a single email address or an array of addresses.
+         */
+        emailsCreate: (body: EmailsPost, params?: RequestParams) => Promise<any>;
+        /**
+         * @name followersList
+         * @request GET:/user/followers
+         * @description List the authenticated user's followers
+         */
+        followersList: (params?: RequestParams) => Promise<Users>;
+        /**
+         * @name followingList
+         * @request GET:/user/following
+         * @description List who the authenticated user is following.
+         */
+        followingList: (params?: RequestParams) => Promise<Users>;
+        /**
+         * @name followingDelete
+         * @request DELETE:/user/following/{username}
+         * @description Unfollow a user. Unfollowing a user requires the user to be logged in and authenticated with basic auth or OAuth with the user:follow scope.
+         */
+        followingDelete: (username: string, params?: RequestParams) => Promise<any>;
+        /**
+         * @name followingDetail
+         * @request GET:/user/following/{username}
+         * @description Check if you are following a user.
+         */
+        followingDetail: (username: string, params?: RequestParams) => Promise<any>;
+        /**
+         * @name followingUpdate
+         * @request PUT:/user/following/{username}
+         * @description Follow a user. Following a user requires the user to be logged in and authenticated with basic auth or OAuth with the user:follow scope.
+         */
+        followingUpdate: (username: string, params?: RequestParams) => Promise<any>;
+        /**
+         * @name issuesList
+         * @request GET:/user/issues
+         * @description List issues. List all issues across owned and member repositories for the authenticated user.
+         */
+        issuesList: (query: {
+            filter: "assigned" | "created" | "mentioned" | "subscribed" | "all";
+            state: "open" | "closed";
+            labels: string;
+            sort: "created" | "updated" | "comments";
+            direction: "asc" | "desc";
+            since?: string;
+        }, params?: RequestParams) => Promise<Issues>;
+        /**
+         * @name keysList
+         * @request GET:/user/keys
+         * @description List your public keys. Lists the current user's keys. Management of public keys via the API requires that you are authenticated through basic auth, or OAuth with the 'user', 'write:public_key' scopes.
+         */
+        keysList: (params?: RequestParams) => Promise<Gitignore>;
+        /**
+         * @name keysCreate
+         * @request POST:/user/keys
+         * @description Create a public key.
+         */
+        keysCreate: (body: UserKeysPost, params?: RequestParams) => Promise<UserKeysKeyId>;
+        /**
+         * @name keysDelete
+         * @request DELETE:/user/keys/{keyId}
+         * @description Delete a public key. Removes a public key. Requires that you are authenticated via Basic Auth or via OAuth with at least admin:public_key scope.
+         */
+        keysDelete: (keyId: number, params?: RequestParams) => Promise<any>;
+        /**
+         * @name keysDetail
+         * @request GET:/user/keys/{keyId}
+         * @description Get a single public key.
+         */
+        keysDetail: (keyId: number, params?: RequestParams) => Promise<UserKeysKeyId>;
+        /**
+         * @name orgsList
+         * @request GET:/user/orgs
+         * @description List public and private organizations for the authenticated user.
+         */
+        orgsList: (params?: RequestParams) => Promise<Gitignore>;
+        /**
+         * @name reposList
+         * @request GET:/user/repos
+         * @description List repositories for the authenticated user. Note that this does not include repositories owned by organizations which the user can access. You can lis user organizations and list organization repositories separately.
+         */
+        reposList: (query?: {
+            type?: "all" | "public" | "private" | "forks" | "sources" | "member";
+        }, params?: RequestParams) => Promise<Repos>;
+        /**
+         * @name reposCreate
+         * @request POST:/user/repos
+         * @description Create a new repository for the authenticated user. OAuth users must supply repo scope.
+         */
+        reposCreate: (body: PostRepo, params?: RequestParams) => Promise<Repos>;
+        /**
+         * @name starredList
+         * @request GET:/user/starred
+         * @description List repositories being starred by the authenticated user.
+         */
+        starredList: (query?: {
+            direction?: string;
+            sort?: "created" | "updated";
+        }, params?: RequestParams) => Promise<Gitignore>;
+        /**
+         * @name starredDelete
+         * @request DELETE:/user/starred/{owner}/{repo}
+         * @description Unstar a repository
+         */
+        starredDelete: (owner: string, repo: string, params?: RequestParams) => Promise<any>;
+        /**
+         * @name starredDetail
+         * @request GET:/user/starred/{owner}/{repo}
+         * @description Check if you are starring a repository.
+         */
+        starredDetail: (owner: string, repo: string, params?: RequestParams) => Promise<any>;
+        /**
+         * @name starredUpdate
+         * @request PUT:/user/starred/{owner}/{repo}
+         * @description Star a repository.
+         */
+        starredUpdate: (owner: string, repo: string, params?: RequestParams) => Promise<any>;
+        /**
+         * @name subscriptionsList
+         * @request GET:/user/subscriptions
+         * @description List repositories being watched by the authenticated user.
+         */
+        subscriptionsList: (params?: RequestParams) => Promise<Repos>;
+        /**
+         * @name subscriptionsDelete
+         * @request DELETE:/user/subscriptions/{owner}/{repo}
+         * @description Stop watching a repository
+         */
+        subscriptionsDelete: (owner: string, repo: string, params?: RequestParams) => Promise<any>;
+        /**
+         * @name subscriptionsDetail
+         * @request GET:/user/subscriptions/{owner}/{repo}
+         * @description Check if you are watching a repository.
+         */
+        subscriptionsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<any>;
+        /**
+         * @name subscriptionsUpdate
+         * @request PUT:/user/subscriptions/{owner}/{repo}
+         * @description Watch a repository.
+         */
+        subscriptionsUpdate: (owner: string, repo: string, params?: RequestParams) => Promise<any>;
+        /**
+         * @name teamsList
+         * @request GET:/user/teams
+         * @description List all of the teams across all of the organizations to which the authenticated user belongs. This method requires user or repo scope when authenticating via OAuth.
+         */
+        teamsList: (params?: RequestParams) => Promise<TeamsList>;
+    };
+    users: {
+        /**
+         * @name usersList
+         * @request GET:/users
+         * @description Get all users. This provides a dump of every user, in the order that they signed up for GitHub. Note: Pagination is powered exclusively by the since parameter. Use the Link header to get the URL for the next page of users.
+         */
+        usersList: (query?: {
+            since?: number;
+        }, params?: RequestParams) => Promise<Users>;
+        /**
+         * @name usersDetail
+         * @request GET:/users/{username}
+         * @description Get a single user.
+         */
+        usersDetail: (username: string, params?: RequestParams) => Promise<any>;
+        /**
+         * @name eventsDetail
+         * @request GET:/users/{username}/events
+         * @description If you are authenticated as the given user, you will see your private events. Otherwise, you'll only see public events.
+         */
+        eventsDetail: (username: string, params?: RequestParams) => Promise<any>;
+        /**
+         * @name eventsOrgsDetail
+         * @request GET:/users/{username}/events/orgs/{org}
+         * @description This is the user's organization dashboard. You must be authenticated as the user to view this.
+         */
+        eventsOrgsDetail: (username: string, org: string, params?: RequestParams) => Promise<any>;
+        /**
+         * @name followersDetail
+         * @request GET:/users/{username}/followers
+         * @description List a user's followers
+         */
+        followersDetail: (username: string, params?: RequestParams) => Promise<Users>;
+        /**
+         * @name followingDetail
+         * @request GET:/users/{username}/following/{targetUser}
+         * @description Check if one user follows another.
+         */
+        followingDetail: (username: string, targetUser: string, params?: RequestParams) => Promise<any>;
+        /**
+         * @name gistsDetail
+         * @request GET:/users/{username}/gists
+         * @description List a users gists.
+         */
+        gistsDetail: (username: string, query?: {
+            since?: string;
+        }, params?: RequestParams) => Promise<Gists>;
+        /**
+         * @name keysDetail
+         * @request GET:/users/{username}/keys
+         * @description List public keys for a user. Lists the verified public keys for a user. This is accessible by anyone.
+         */
+        keysDetail: (username: string, params?: RequestParams) => Promise<Gitignore>;
+        /**
+         * @name orgsDetail
+         * @request GET:/users/{username}/orgs
+         * @description List all public organizations for a user.
+         */
+        orgsDetail: (username: string, params?: RequestParams) => Promise<Gitignore>;
+        /**
+         * @name receivedEventsDetail
+         * @request GET:/users/{username}/received_events
+         * @description These are events that you'll only see public events.
+         */
+        receivedEventsDetail: (username: string, params?: RequestParams) => Promise<any>;
+        /**
+         * @name receivedEventsPublicDetail
+         * @request GET:/users/{username}/received_events/public
+         * @description List public events that a user has received
+         */
+        receivedEventsPublicDetail: (username: string, params?: RequestParams) => Promise<any>;
+        /**
+         * @name reposDetail
+         * @request GET:/users/{username}/repos
+         * @description List public repositories for the specified user.
+         */
+        reposDetail: (username: string, query?: {
+            type?: "all" | "public" | "private" | "forks" | "sources" | "member";
+        }, params?: RequestParams) => Promise<Repos>;
+        /**
+         * @name starredDetail
+         * @request GET:/users/{username}/starred
+         * @description List repositories being starred by a user.
+         */
+        starredDetail: (username: string, params?: RequestParams) => Promise<any>;
+        /**
+         * @name subscriptionsDetail
+         * @request GET:/users/{username}/subscriptions
+         * @description List repositories being watched by a user.
+         */
+        subscriptionsDetail: (username: string, params?: RequestParams) => Promise<any>;
+    };
+}
+export {};

--- a/tests/spec/js/schema.d.ts
+++ b/tests/spec/js/schema.d.ts
@@ -2,51 +2,1252 @@
  * A user or organization
  */
 export interface Actor {
-    avatar_url?: string;
-    bio?: string;
-    /** The website URL from the profile page */
-    blog?: string;
+  avatar_url?: string;
+  bio?: string;
+  /** The website URL from the profile page */
+  blog?: string;
+  collaborators?: number;
+  company?: string;
+  /** ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ */
+  created_at?: string;
+  disk_usage?: number;
+  /** Note: The returned email is the user’s publicly visible email address (or null if the user has not specified a public email address in their profile). */
+  email?: string;
+  followers?: number;
+  followers_url?: string;
+  following?: number;
+  following_url?: string;
+  gists_url?: string;
+  gravatar_id?: string;
+  hireable?: boolean;
+  html_url?: string;
+  id?: number;
+  location?: string;
+  /** The account username */
+  login?: string;
+  /** The full account name */
+  name?: string;
+  organizations_url?: string;
+  owned_private_repos?: number;
+  plan?: {
     collaborators?: number;
-    company?: string;
-    /** ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ */
-    created_at?: string;
-    disk_usage?: number;
-    /** Note: The returned email is the user’s publicly visible email address (or null if the user has not specified a public email address in their profile). */
-    email?: string;
-    followers?: number;
-    followers_url?: string;
-    following?: number;
-    following_url?: string;
-    gists_url?: string;
-    gravatar_id?: string;
-    hireable?: boolean;
-    html_url?: string;
-    id?: number;
-    location?: string;
-    /** The account username */
-    login?: string;
-    /** The full account name */
     name?: string;
-    organizations_url?: string;
-    owned_private_repos?: number;
-    plan?: {
-        collaborators?: number;
-        name?: string;
-        private_repos?: number;
-        space?: number;
-    };
-    private_gists?: number;
-    public_gists?: number;
-    public_repos?: number;
-    starred_url?: string;
-    subscriptions_url?: string;
-    total_private_repos?: number;
-    type?: "User" | "Organization";
-    /** ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ */
-    updated_at?: string;
-    url?: string;
+    private_repos?: number;
+    space?: number;
+  };
+  private_gists?: number;
+  public_gists?: number;
+  public_repos?: number;
+  starred_url?: string;
+  subscriptions_url?: string;
+  total_private_repos?: number;
+  type?: "User" | "Organization";
+  /** ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ */
+  updated_at?: string;
+  url?: string;
 }
 export interface Asset {
+  content_type?: string;
+  created_at?: string;
+  download_count?: number;
+  id?: number;
+  label?: string;
+  name?: string;
+  size?: number;
+  state?: string;
+  updated_at?: string;
+  uploader?: User;
+  url?: string;
+}
+export interface AssetPatch {
+  label?: string;
+  name: string;
+}
+export declare type Assets = Asset[];
+export declare type Assignees = User[];
+export interface Blob {
+  content?: string;
+  encoding?: "utf-8" | "base64";
+  sha?: string;
+  size?: number;
+}
+export interface Blobs {
+  sha?: string;
+}
+export interface Branch {
+  _links?: {
+    html?: string;
+    self?: string;
+  };
+  commit?: {
+    author?: User;
+    commit?: {
+      author?: {
+        date?: string;
+        email?: string;
+        name?: string;
+      };
+      committer?: {
+        date?: string;
+        email?: string;
+        name?: string;
+      };
+      message?: string;
+      tree?: {
+        sha?: string;
+        url?: string;
+      };
+      url?: string;
+    };
+    committer?: User;
+    parents?: {
+      sha?: string;
+      url?: string;
+    }[];
+    sha?: string;
+    url?: string;
+  };
+  name?: string;
+}
+export declare type Branches = {
+  commit?: {
+    sha?: string;
+    url?: string;
+  };
+  name?: string;
+}[];
+export declare type CodeFrequencyStats = number[];
+export interface Comment {
+  body?: string;
+}
+export interface CommentBody {
+  body: string;
+}
+export declare type Comments = {
+  body?: string;
+  created_at?: string;
+  id?: number;
+  url?: string;
+  user?: User;
+}[];
+export interface Commit {
+  author?: User;
+  commit?: {
+    author?: {
+      date?: string;
+      email?: string;
+      name?: string;
+    };
+    committer?: {
+      date?: string;
+      email?: string;
+      name?: string;
+    };
+    message?: string;
+    tree?: {
+      sha?: string;
+      url?: string;
+    };
+    url?: string;
+  };
+  committer?: User;
+  files?: {
+    additions?: number;
+    blob_url?: string;
+    changes?: number;
+    deletions?: number;
+    filename?: string;
+    patch?: string;
+    raw_url?: string;
+    status?: string;
+  }[];
+  parents?: {
+    sha?: string;
+    url?: string;
+  }[];
+  sha?: string;
+  stats?: {
+    additions?: number;
+    deletions?: number;
+    total?: number;
+  };
+  url?: string;
+}
+export declare type CommitActivityStats = {
+  days?: number[];
+  total?: number;
+  week?: number;
+}[];
+export interface CommitComment {
+  body?: string;
+  commit_id?: string;
+  /** ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ */
+  created_at?: string;
+  html_url?: string;
+  id?: number;
+  line?: number;
+  path?: string;
+  position?: number;
+  /** ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ */
+  updated_at?: string;
+  url?: string;
+  user?: User;
+}
+export interface CommitCommentBody {
+  body: string;
+  /** Deprecated - Use position parameter instead. */
+  line?: string;
+  /** Line number in the file to comment on. Defaults to null. */
+  number?: string;
+  /** Relative path of the file to comment on. */
+  path?: string;
+  /** Line index in the diff to comment on. */
+  position?: number;
+  /** SHA of the commit to comment on. */
+  sha: string;
+}
+export declare type Commits = {
+  author?: User;
+  commit?: {
+    author?: {
+      date?: string;
+      email?: string;
+      name?: string;
+    };
+    committer?: {
+      date?: string;
+      email?: string;
+      name?: string;
+    };
+    message?: string;
+    tree?: {
+      sha?: string;
+      url?: string;
+    };
+    url?: string;
+  };
+  committer?: User;
+  parents?: {
+    sha?: string;
+    url?: string;
+  }[];
+  sha?: string;
+  url?: string;
+}[];
+export interface CompareCommits {
+  ahead_by?: number;
+  base_commit?: {
+    author?: User;
+    commit?: {
+      author?: {
+        date?: string;
+        email?: string;
+        name?: string;
+      };
+      committer?: {
+        date?: string;
+        email?: string;
+        name?: string;
+      };
+      message?: string;
+      tree?: {
+        sha?: string;
+        url?: string;
+      };
+      url?: string;
+    };
+    committer?: User;
+    parents?: {
+      sha?: string;
+      url?: string;
+    }[];
+    sha?: string;
+    url?: string;
+  };
+  behind_by?: number;
+  commits?: {
+    author?: User;
+    commit?: {
+      author?: {
+        date?: string;
+        email?: string;
+        name?: string;
+      };
+      committer?: {
+        date?: string;
+        email?: string;
+        name?: string;
+      };
+      message?: string;
+      tree?: {
+        sha?: string;
+        url?: string;
+      };
+      url?: string;
+    };
+    committer?: User;
+    parents?: {
+      sha?: string;
+      url?: string;
+    }[];
+    sha?: string;
+    url?: string;
+  }[];
+  diff_url?: string;
+  files?: {
+    additions?: number;
+    blob_url?: string;
+    changes?: number;
+    contents_url?: string;
+    deletions?: number;
+    filename?: string;
+    patch?: string;
+    raw_url?: string;
+    sha?: string;
+    status?: string;
+  }[];
+  html_url?: string;
+  patch_url?: string;
+  permalink_url?: string;
+  status?: string;
+  total_commits?: number;
+  url?: string;
+}
+export interface ContentsPath {
+  _links?: {
+    git?: string;
+    html?: string;
+    self?: string;
+  };
+  content?: string;
+  encoding?: string;
+  git_url?: string;
+  html_url?: string;
+  name?: string;
+  path?: string;
+  sha?: string;
+  size?: number;
+  type?: string;
+  url?: string;
+}
+export declare type ContributorsStats = {
+  author?: {
+    avatar_url?: string;
+    gravatar_id?: string;
+    id?: number;
+    login?: string;
+    url?: string;
+  };
+  total?: number;
+  weeks?: {
+    a?: number;
+    c?: number;
+    d?: number;
+    w?: string;
+  }[];
+}[];
+export interface CreateFile {
+  commit?: {
+    author?: {
+      date?: string;
+      email?: string;
+      name?: string;
+    };
+    committer?: {
+      date?: string;
+      email?: string;
+      name?: string;
+    };
+    html_url?: string;
+    message?: string;
+    parents?: {
+      html_url?: string;
+      sha?: string;
+      url?: string;
+    }[];
+    sha?: string;
+    tree?: {
+      sha?: string;
+      url?: string;
+    };
+    url?: string;
+  };
+  content?: {
+    _links?: {
+      git?: string;
+      html?: string;
+      self?: string;
+    };
+    git_url?: string;
+    html_url?: string;
+    name?: string;
+    path?: string;
+    sha?: string;
+    size?: number;
+    type?: string;
+    url?: string;
+  };
+}
+export interface CreateFileBody {
+  committer?: {
+    email?: string;
+    name?: string;
+  };
+  content?: string;
+  message?: string;
+}
+export interface DeleteFile {
+  commit?: {
+    author?: {
+      date?: string;
+      email?: string;
+      name?: string;
+    };
+    committer?: {
+      date?: string;
+      email?: string;
+      name?: string;
+    };
+    html_url?: string;
+    message?: string;
+    parents?: {
+      html_url?: string;
+      sha?: string;
+      url?: string;
+    };
+    sha?: string;
+    tree?: {
+      sha?: string;
+      url?: string;
+    };
+    url?: string;
+  };
+  content?: string;
+}
+export interface DeleteFileBody {
+  committer?: {
+    email?: string;
+    name?: string;
+  };
+  message?: string;
+  sha?: string;
+}
+export interface Deployment {
+  description?: string;
+  payload?: {
+    deploy_user?: string;
+    environment?: string;
+    room_id?: number;
+  };
+  ref?: string;
+}
+export interface DeploymentResp {
+  created_at?: string;
+  creator?: User;
+  description?: string;
+  id?: number;
+  payload?: string;
+  sha?: string;
+  statuses_url?: string;
+  updated_at?: string;
+  url?: string;
+}
+export declare type DeploymentStatuses = {
+  created_at?: string;
+  creator?: User;
+  description?: string;
+  id?: number;
+  payload?: string;
+  state?: string;
+  target_url?: string;
+  updated_at?: string;
+  url?: string;
+}[];
+export interface DeploymentStatusesCreate {
+  description?: string;
+  state?: string;
+  target_url?: string;
+}
+export interface Download {
+  content_type?: string;
+  description?: string;
+  download_count?: number;
+  html_url?: string;
+  id?: number;
+  name?: string;
+  size?: number;
+  url?: string;
+}
+export declare type Downloads = Download[];
+export interface EditTeam {
+  name: string;
+  permission?: "pull" | "push" | "admin";
+}
+export declare type EmailsPost = string[];
+export declare type Emojis = Record<string, string>;
+export interface Event {
+  actor?: Actor;
+  created_at?: object;
+  id?: number;
+  org?: Organization;
+  payload?: object;
+  public?: boolean;
+  repo?: {
+    id?: number;
+    name?: string;
+    url?: string;
+  };
+  type?: string;
+}
+export declare type Events = Event[];
+export interface Feeds {
+  _links?: {
+    current_user?: {
+      href?: string;
+      type?: string;
+    };
+    current_user_actor?: {
+      href?: string;
+      type?: string;
+    };
+    current_user_organization?: {
+      href?: string;
+      type?: string;
+    };
+    current_user_public?: {
+      href?: string;
+      type?: string;
+    };
+    timeline?: {
+      href?: string;
+      type?: string;
+    };
+    user?: {
+      href?: string;
+      type?: string;
+    };
+  };
+  current_user_actor_url?: string;
+  current_user_organization_url?: string;
+  current_user_public?: string;
+  current_user_url?: string;
+  timeline_url?: string;
+  user_url?: string;
+}
+export interface ForkBody {
+  organization?: string;
+}
+export declare type Forks = Repos;
+export interface Gist {
+  comments?: number;
+  comments_url?: string;
+  /** Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ. */
+  created_at?: string;
+  description?: string;
+  files?: {
+    "ring.erl"?: {
+      filename?: string;
+      raw_url?: string;
+      size?: number;
+    };
+  };
+  forks?: {
+    created_at?: string;
+    url?: string;
+    user?: User;
+  }[];
+  git_pull_url?: string;
+  git_push_url?: string;
+  history?: {
+    change_status?: {
+      additions?: number;
+      deletions?: number;
+      total?: number;
+    };
+    committed_at?: string;
+    url?: string;
+    user?: User;
+    version?: string;
+  }[];
+  html_url?: string;
+  id?: string;
+  public?: boolean;
+  url?: string;
+  user?: User;
+}
+export declare type Gists = {
+  comments?: number;
+  comments_url?: string;
+  created_at?: string;
+  description?: string;
+  files?: {
+    "ring.erl"?: {
+      filename?: string;
+      raw_url?: string;
+      size?: number;
+    };
+  };
+  git_pull_url?: string;
+  git_push_url?: string;
+  html_url?: string;
+  id?: string;
+  public?: boolean;
+  url?: string;
+  user?: User;
+}[];
+export interface GitCommit {
+  author?: {
+    date?: string;
+    email?: string;
+    name?: string;
+  };
+  message?: string;
+  parents?: string;
+  tree?: string;
+}
+export interface GitRefPatch {
+  force?: boolean;
+  sha?: string;
+}
+export declare type Gitignore = any[];
+export interface GitignoreLang {
+  name?: string;
+  source?: string;
+}
+export interface HeadBranch {
+  object?: {
+    sha?: string;
+    type?: string;
+    url?: string;
+  };
+  ref?: string;
+  url?: string;
+}
+export declare type Hook = {
+  active?: boolean;
+  config?: {
+    content_type?: string;
+    url?: string;
+  };
+  created_at?: string;
+  events?: (
+    | "push"
+    | "issues"
+    | "issue_comment"
+    | "commit_comment"
+    | "pull_request"
+    | "pull_request_review_comment"
+    | "gollum"
+    | "watch"
+    | "download"
+    | "fork"
+    | "fork_apply"
+    | "member"
+    | "public"
+    | "team_add"
+    | "status"
+  )[];
+  id?: number;
+  name?: string;
+  updated_at?: string;
+  url?: string;
+}[];
+export interface HookBody {
+  active?: boolean;
+  add_events?: string[];
+}
+export interface Issue {
+  assignee?: string;
+  body?: string;
+  labels?: string[];
+  milestone?: number;
+  title?: string;
+}
+export interface IssueEvent {
+  actor?: Actor;
+  commit_id?: string;
+  /** ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ */
+  created_at?: string;
+  event?: string;
+  issue?: {
+    assignee?: User;
+    body?: string;
+    closed_at?: string;
+    comments?: number;
+    created_at?: string;
+    html_url?: string;
+    labels?: {
+      color?: string;
+      name?: string;
+      url?: string;
+    }[];
+    milestone?: {
+      closed_issues?: number;
+      created_at?: string;
+      creator?: User;
+      description?: string;
+      due_on?: string;
+      number?: number;
+      open_issues?: number;
+      state?: "open" | "closed";
+      title?: string;
+      url?: string;
+    };
+    number?: number;
+    pull_request?: {
+      diff_url?: string;
+      html_url?: string;
+      patch_url?: string;
+    };
+    state?: "open" | "closed";
+    title?: string;
+    updated_at?: string;
+    url?: string;
+    user?: User;
+  };
+  url?: string;
+}
+export declare type IssueEvents = IssueEvent[];
+export declare type Issues = {
+  assignee?: User;
+  body?: string;
+  closed_at?: string;
+  comments?: number;
+  created_at?: string;
+  html_url?: string;
+  labels?: {
+    color?: string;
+    name?: string;
+    url?: string;
+  }[];
+  milestone?: {
+    closed_issues?: number;
+    created_at?: string;
+    creator?: User;
+    description?: string;
+    due_on?: string;
+    number?: number;
+    open_issues?: number;
+    state?: "open" | "closed";
+    title?: string;
+    url?: string;
+  };
+  number?: number;
+  pull_request?: {
+    diff_url?: string;
+    html_url?: string;
+    patch_url?: string;
+  };
+  state?: "open" | "closed";
+  title?: string;
+  updated_at?: string;
+  url?: string;
+  user?: User;
+}[];
+export interface IssuesComment {
+  body?: string;
+  /** ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ */
+  created_at?: string;
+  html_url?: string;
+  id?: number;
+  /** ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ */
+  updated_at?: string;
+  url?: string;
+  user?: User;
+}
+export declare type IssuesComments = {
+  _links?: {
+    html?: {
+      href?: string;
+    };
+    pull_request?: {
+      href?: string;
+    };
+    self?: {
+      href?: string;
+    };
+  };
+  body?: string;
+  commit_id?: string;
+  created_at?: string;
+  id?: number;
+  path?: string;
+  position?: number;
+  updated_at?: string;
+  url?: string;
+  user?: User;
+}[];
+export declare type Keys = {
+  id?: number;
+  key?: string;
+  title?: string;
+  url?: string;
+}[];
+export interface Label {
+  color?: string;
+  name?: string;
+  url?: string;
+}
+export declare type Labels = {
+  color?: string;
+  name?: string;
+  url?: string;
+}[];
+export declare type Languages = Record<string, number>;
+export interface Markdown {
+  context?: string;
+  mode?: string;
+  text?: string;
+}
+export interface Merge {
+  merged?: boolean;
+  message?: string;
+  sha?: string;
+}
+export interface MergePullBody {
+  commit_message?: string;
+}
+export interface MergesBody {
+  base?: string;
+  commit_message?: string;
+  head?: string;
+}
+export interface MergesConflict {
+  /** Error message */
+  message?: string;
+}
+export interface MergesSuccessful {
+  author?: User;
+  comments_url?: string;
+  commit?: {
+    author?: {
+      date?: string;
+      email?: string;
+      name?: string;
+    };
+    comment_count?: number;
+    committer?: {
+      date?: string;
+      email?: string;
+      name?: string;
+    };
+    message?: string;
+    tree?: {
+      sha?: string;
+      url?: string;
+    };
+    url?: string;
+  };
+  committer?: User;
+  merged?: boolean;
+  message?: string;
+  parents?: {
+    sha?: string;
+    url?: string;
+  }[];
+  sha?: string;
+  url?: string;
+}
+export interface Meta {
+  git?: string[];
+  hooks?: string[];
+}
+export interface Milestone {
+  closed_issues?: number;
+  /** ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ */
+  created_at?: string;
+  creator?: User;
+  description?: string;
+  /** ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ */
+  due_on?: string;
+  number?: number;
+  open_issues?: number;
+  state?: "open" | "closed";
+  title?: string;
+  url?: string;
+}
+export interface MilestoneUpdate {
+  description?: string;
+  due_on?: string;
+  state?: string;
+  title?: string;
+}
+export interface NotificationMarkRead {
+  last_read_at?: string;
+}
+export interface Notifications {
+  id?: number;
+  last_read_at?: string;
+  reason?: string;
+  repository?: {
+    description?: string;
+    fork?: boolean;
+    full_name?: string;
+    html_url?: string;
+    id?: number;
+    name?: string;
+    owner?: Actor;
+    private?: boolean;
+    url?: string;
+  };
+  subject?: {
+    latest_comment_url?: string;
+    title?: string;
+    type?: string;
+    url?: string;
+  };
+  unread?: boolean;
+  updated_at?: string;
+  url?: string;
+}
+export interface OrgTeamsPost {
+  name: string;
+  permission?: "pull" | "push" | "admin";
+  repo_names?: string[];
+}
+export declare type Organization = Actor & any;
+export interface OrganizationAsTeamMember {
+  errors?: {
+    code?: string;
+    field?: string;
+    resource?: string;
+  }[];
+  message?: string;
+}
+export interface ParticipationStats {
+  all?: number[];
+  owner?: number[];
+}
+export interface PatchGist {
+  description?: string;
+  files?: {
+    "delete_this_file.txt"?: string;
+    "file1.txt"?: {
+      content?: string;
+    };
+    "new_file.txt"?: {
+      content?: string;
+    };
+    "old_name.txt"?: {
+      content?: string;
+      filename?: string;
+    };
+  };
+}
+export interface PatchOrg {
+  /** Billing email address. This address is not publicized. */
+  billing_email?: string;
+  company?: string;
+  /** Publicly visible email address. */
+  email?: string;
+  location?: string;
+  name?: string;
+}
+export interface PostGist {
+  description?: string;
+  files?: {
+    "file1.txt"?: {
+      content?: string;
+    };
+  };
+  public?: boolean;
+}
+export interface PostRepo {
+  /** True to create an initial commit with empty README. Default is false. */
+  auto_init?: boolean;
+  description?: string;
+  /** Desired language or platform .gitignore template to apply. Use the name of the template without the extension. For example, "Haskell" Ignored if auto_init parameter is not provided.  */
+  gitignore_template?: string;
+  /** True to enable downloads for this repository, false to disable them. Default is true. */
+  has_downloads?: boolean;
+  /** True to enable issues for this repository, false to disable them. Default is true. */
+  has_issues?: boolean;
+  /** True to enable the wiki for this repository, false to disable it. Default is true. */
+  has_wiki?: boolean;
+  homepage?: string;
+  name: string;
+  /** True to create a private repository, false to create a public one. Creating private repositories requires a paid GitHub account. */
+  private?: boolean;
+  /** The id of the team that will be granted access to this repository. This is only valid when creating a repo in an organization. */
+  team_id?: number;
+}
+export interface PullRequest {
+  _links?: {
+    comments?: {
+      href?: string;
+    };
+    html?: {
+      href?: string;
+    };
+    review_comments?: {
+      href?: string;
+    };
+    self?: {
+      href?: string;
+    };
+  };
+  additions?: number;
+  base?: {
+    label?: string;
+    ref?: string;
+    repo?: Repo;
+    sha?: string;
+    user?: {
+      avatar_url?: string;
+      gravatar_id?: string;
+      id?: number;
+      login?: string;
+      url?: string;
+    };
+  };
+  body?: string;
+  changed_files?: number;
+  closed_at?: string;
+  comments?: number;
+  commits?: number;
+  created_at?: string;
+  deletions?: number;
+  diff_url?: string;
+  head?: {
+    label?: string;
+    ref?: string;
+    repo?: Repo;
+    sha?: string;
+    user?: {
+      avatar_url?: string;
+      gravatar_id?: string;
+      id?: number;
+      login?: string;
+      url?: string;
+    };
+  };
+  html_url?: string;
+  issue_url?: string;
+  merge_commit_sha?: string;
+  mergeable?: boolean;
+  merged?: boolean;
+  merged_at?: string;
+  merged_by?: {
+    avatar_url?: string;
+    gravatar_id?: string;
+    id?: number;
+    login?: string;
+    url?: string;
+  };
+  number?: number;
+  patch_url?: string;
+  state?: string;
+  title?: string;
+  updated_at?: string;
+  url?: string;
+  user?: {
+    avatar_url?: string;
+    gravatar_id?: string;
+    id?: number;
+    login?: string;
+    url?: string;
+  };
+}
+export interface PullUpdate {
+  body?: string;
+  state?: string;
+  title?: string;
+}
+export declare type Pulls = {
+  _links?: {
+    comments?: {
+      href?: string;
+    };
+    html?: {
+      href?: string;
+    };
+    review_comments?: {
+      href?: string;
+    };
+    self?: {
+      href?: string;
+    };
+  };
+  base?: {
+    label?: string;
+    ref?: string;
+    repo?: Repo;
+    sha?: string;
+    user?: {
+      avatar_url?: string;
+      gravatar_id?: string;
+      id?: number;
+      login?: string;
+      url?: string;
+    };
+  };
+  body?: string;
+  closed_at?: string;
+  created_at?: string;
+  diff_url?: string;
+  head?: {
+    label?: string;
+    ref?: string;
+    repo?: Repo;
+    sha?: string;
+    user?: {
+      avatar_url?: string;
+      gravatar_id?: string;
+      id?: number;
+      login?: string;
+      url?: string;
+    };
+  };
+  html_url?: string;
+  issue_url?: string;
+  merged_at?: string;
+  number?: number;
+  patch_url?: string;
+  state?: "open" | "closed";
+  title?: string;
+  updated_at?: string;
+  url?: string;
+  user?: {
+    avatar_url?: string;
+    gravatar_id?: string;
+    id?: number;
+    login?: string;
+    url?: string;
+  };
+}[];
+export interface PullsComment {
+  _links?: {
+    html?: {
+      href?: string;
+    };
+    pull_request?: {
+      href?: string;
+    };
+    self?: {
+      href?: string;
+    };
+  };
+  body?: string;
+  commit_id?: string;
+  /** ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ */
+  created_at?: string;
+  id?: number;
+  path?: string;
+  position?: number;
+  /** ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ */
+  updated_at?: string;
+  url?: string;
+  user?: {
+    avatar_url?: string;
+    gravatar_id?: string;
+    id?: number;
+    login?: string;
+    url?: string;
+  };
+}
+export interface PullsCommentPost {
+  body?: string;
+  commit_id?: string;
+  path?: string;
+  position?: number;
+}
+export declare type PullsComments = {
+  _links?: {
+    html?: {
+      href?: string;
+    };
+    pull_request?: {
+      href?: string;
+    };
+    self?: {
+      href?: string;
+    };
+  };
+  body?: string;
+  commit_id?: string;
+  created_at?: string;
+  id?: number;
+  path?: string;
+  position?: number;
+  updated_at?: string;
+  url?: string;
+  user?: {
+    avatar_url?: string;
+    gravatar_id?: string;
+    id?: number;
+    login?: string;
+    url?: string;
+  };
+}[];
+export interface PullsPost {
+  base?: string;
+  body?: string;
+  head?: string;
+  title?: string;
+}
+export interface PutSubscription {
+  created_at?: string;
+  ignored?: boolean;
+  reason?: object;
+  subscribed?: boolean;
+  thread_url?: string;
+  url?: string;
+}
+export interface RateLimit {
+  rate?: {
+    limit?: number;
+    remaining?: number;
+    reset?: number;
+  };
+}
+export declare type Ref = {
+  created_at?: string;
+  creator?: {
+    avatar_url?: string;
+    gravatar_id?: string;
+    id?: number;
+    login?: string;
+    url?: string;
+  };
+  description?: string;
+  id?: number;
+  state?: string;
+  target_url?: string;
+  updated_at?: string;
+  url?: string;
+}[];
+export declare type RefStatus = {
+  commit_url?: string;
+  name?: string;
+  repository_url?: string;
+  sha?: string;
+  state?: string;
+  statuses?: {
+    context?: string;
+    created_at?: string;
+    description?: string;
+    id?: number;
+    state?: string;
+    target_url?: string;
+    updated_at?: string;
+    url?: string;
+  }[];
+}[];
+export declare type Refs = {
+  object?: {
+    sha?: string;
+    type?: string;
+    url?: string;
+  };
+  ref?: string;
+  url?: string;
+}[];
+export interface RefsBody {
+  ref?: string;
+  sha?: string;
+}
+export interface Release {
+  assets?: {
     content_type?: string;
     created_at?: string;
     download_count?: number;
@@ -58,1623 +1259,445 @@ export interface Asset {
     updated_at?: string;
     uploader?: User;
     url?: string;
-}
-export interface AssetPatch {
-    label?: string;
-    name: string;
-}
-export declare type Assets = Asset[];
-export declare type Assignees = User[];
-export interface Blob {
-    content?: string;
-    encoding?: "utf-8" | "base64";
-    sha?: string;
-    size?: number;
-}
-export interface Blobs {
-    sha?: string;
-}
-export interface Branch {
-    _links?: {
-        html?: string;
-        self?: string;
-    };
-    commit?: {
-        author?: User;
-        commit?: {
-            author?: {
-                date?: string;
-                email?: string;
-                name?: string;
-            };
-            committer?: {
-                date?: string;
-                email?: string;
-                name?: string;
-            };
-            message?: string;
-            tree?: {
-                sha?: string;
-                url?: string;
-            };
-            url?: string;
-        };
-        committer?: User;
-        parents?: {
-            sha?: string;
-            url?: string;
-        }[];
-        sha?: string;
-        url?: string;
-    };
-    name?: string;
-}
-export declare type Branches = {
-    commit?: {
-        sha?: string;
-        url?: string;
-    };
-    name?: string;
-}[];
-export declare type CodeFrequencyStats = number[];
-export interface Comment {
-    body?: string;
-}
-export interface CommentBody {
-    body: string;
-}
-export declare type Comments = {
-    body?: string;
-    created_at?: string;
-    id?: number;
-    url?: string;
-    user?: User;
-}[];
-export interface Commit {
-    author?: User;
-    commit?: {
-        author?: {
-            date?: string;
-            email?: string;
-            name?: string;
-        };
-        committer?: {
-            date?: string;
-            email?: string;
-            name?: string;
-        };
-        message?: string;
-        tree?: {
-            sha?: string;
-            url?: string;
-        };
-        url?: string;
-    };
-    committer?: User;
-    files?: {
-        additions?: number;
-        blob_url?: string;
-        changes?: number;
-        deletions?: number;
-        filename?: string;
-        patch?: string;
-        raw_url?: string;
-        status?: string;
-    }[];
-    parents?: {
-        sha?: string;
-        url?: string;
-    }[];
-    sha?: string;
-    stats?: {
-        additions?: number;
-        deletions?: number;
-        total?: number;
-    };
-    url?: string;
-}
-export declare type CommitActivityStats = {
-    days?: number[];
-    total?: number;
-    week?: number;
-}[];
-export interface CommitComment {
-    body?: string;
-    commit_id?: string;
-    /** ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ */
-    created_at?: string;
-    html_url?: string;
-    id?: number;
-    line?: number;
-    path?: string;
-    position?: number;
-    /** ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ */
-    updated_at?: string;
-    url?: string;
-    user?: User;
-}
-export interface CommitCommentBody {
-    body: string;
-    /** Deprecated - Use position parameter instead. */
-    line?: string;
-    /** Line number in the file to comment on. Defaults to null. */
-    number?: string;
-    /** Relative path of the file to comment on. */
-    path?: string;
-    /** Line index in the diff to comment on. */
-    position?: number;
-    /** SHA of the commit to comment on. */
-    sha: string;
-}
-export declare type Commits = {
-    author?: User;
-    commit?: {
-        author?: {
-            date?: string;
-            email?: string;
-            name?: string;
-        };
-        committer?: {
-            date?: string;
-            email?: string;
-            name?: string;
-        };
-        message?: string;
-        tree?: {
-            sha?: string;
-            url?: string;
-        };
-        url?: string;
-    };
-    committer?: User;
-    parents?: {
-        sha?: string;
-        url?: string;
-    }[];
-    sha?: string;
-    url?: string;
-}[];
-export interface CompareCommits {
-    ahead_by?: number;
-    base_commit?: {
-        author?: User;
-        commit?: {
-            author?: {
-                date?: string;
-                email?: string;
-                name?: string;
-            };
-            committer?: {
-                date?: string;
-                email?: string;
-                name?: string;
-            };
-            message?: string;
-            tree?: {
-                sha?: string;
-                url?: string;
-            };
-            url?: string;
-        };
-        committer?: User;
-        parents?: {
-            sha?: string;
-            url?: string;
-        }[];
-        sha?: string;
-        url?: string;
-    };
-    behind_by?: number;
-    commits?: {
-        author?: User;
-        commit?: {
-            author?: {
-                date?: string;
-                email?: string;
-                name?: string;
-            };
-            committer?: {
-                date?: string;
-                email?: string;
-                name?: string;
-            };
-            message?: string;
-            tree?: {
-                sha?: string;
-                url?: string;
-            };
-            url?: string;
-        };
-        committer?: User;
-        parents?: {
-            sha?: string;
-            url?: string;
-        }[];
-        sha?: string;
-        url?: string;
-    }[];
-    diff_url?: string;
-    files?: {
-        additions?: number;
-        blob_url?: string;
-        changes?: number;
-        contents_url?: string;
-        deletions?: number;
-        filename?: string;
-        patch?: string;
-        raw_url?: string;
-        sha?: string;
-        status?: string;
-    }[];
-    html_url?: string;
-    patch_url?: string;
-    permalink_url?: string;
-    status?: string;
-    total_commits?: number;
-    url?: string;
-}
-export interface ContentsPath {
-    _links?: {
-        git?: string;
-        html?: string;
-        self?: string;
-    };
-    content?: string;
-    encoding?: string;
-    git_url?: string;
-    html_url?: string;
-    name?: string;
-    path?: string;
-    sha?: string;
-    size?: number;
-    type?: string;
-    url?: string;
-}
-export declare type ContributorsStats = {
-    author?: {
-        avatar_url?: string;
-        gravatar_id?: string;
-        id?: number;
-        login?: string;
-        url?: string;
-    };
-    total?: number;
-    weeks?: {
-        a?: number;
-        c?: number;
-        d?: number;
-        w?: string;
-    }[];
-}[];
-export interface CreateFile {
-    commit?: {
-        author?: {
-            date?: string;
-            email?: string;
-            name?: string;
-        };
-        committer?: {
-            date?: string;
-            email?: string;
-            name?: string;
-        };
-        html_url?: string;
-        message?: string;
-        parents?: {
-            html_url?: string;
-            sha?: string;
-            url?: string;
-        }[];
-        sha?: string;
-        tree?: {
-            sha?: string;
-            url?: string;
-        };
-        url?: string;
-    };
-    content?: {
-        _links?: {
-            git?: string;
-            html?: string;
-            self?: string;
-        };
-        git_url?: string;
-        html_url?: string;
-        name?: string;
-        path?: string;
-        sha?: string;
-        size?: number;
-        type?: string;
-        url?: string;
-    };
-}
-export interface CreateFileBody {
-    committer?: {
-        email?: string;
-        name?: string;
-    };
-    content?: string;
-    message?: string;
-}
-export interface DeleteFile {
-    commit?: {
-        author?: {
-            date?: string;
-            email?: string;
-            name?: string;
-        };
-        committer?: {
-            date?: string;
-            email?: string;
-            name?: string;
-        };
-        html_url?: string;
-        message?: string;
-        parents?: {
-            html_url?: string;
-            sha?: string;
-            url?: string;
-        };
-        sha?: string;
-        tree?: {
-            sha?: string;
-            url?: string;
-        };
-        url?: string;
-    };
-    content?: string;
-}
-export interface DeleteFileBody {
-    committer?: {
-        email?: string;
-        name?: string;
-    };
-    message?: string;
-    sha?: string;
-}
-export interface Deployment {
-    description?: string;
-    payload?: {
-        deploy_user?: string;
-        environment?: string;
-        room_id?: number;
-    };
-    ref?: string;
-}
-export interface DeploymentResp {
-    created_at?: string;
-    creator?: User;
-    description?: string;
-    id?: number;
-    payload?: string;
-    sha?: string;
-    statuses_url?: string;
-    updated_at?: string;
-    url?: string;
-}
-export declare type DeploymentStatuses = {
-    created_at?: string;
-    creator?: User;
-    description?: string;
-    id?: number;
-    payload?: string;
-    state?: string;
-    target_url?: string;
-    updated_at?: string;
-    url?: string;
-}[];
-export interface DeploymentStatusesCreate {
-    description?: string;
-    state?: string;
-    target_url?: string;
-}
-export interface Download {
-    content_type?: string;
-    description?: string;
-    download_count?: number;
-    html_url?: string;
-    id?: number;
-    name?: string;
-    size?: number;
-    url?: string;
-}
-export declare type Downloads = Download[];
-export interface EditTeam {
-    name: string;
-    permission?: "pull" | "push" | "admin";
-}
-export declare type EmailsPost = string[];
-export declare type Emojis = Record<string, string>;
-export interface Event {
-    actor?: Actor;
-    created_at?: object;
-    id?: number;
-    org?: Organization;
-    payload?: object;
-    public?: boolean;
-    repo?: {
-        id?: number;
-        name?: string;
-        url?: string;
-    };
-    type?: string;
-}
-export declare type Events = Event[];
-export interface Feeds {
-    _links?: {
-        current_user?: {
-            href?: string;
-            type?: string;
-        };
-        current_user_actor?: {
-            href?: string;
-            type?: string;
-        };
-        current_user_organization?: {
-            href?: string;
-            type?: string;
-        };
-        current_user_public?: {
-            href?: string;
-            type?: string;
-        };
-        timeline?: {
-            href?: string;
-            type?: string;
-        };
-        user?: {
-            href?: string;
-            type?: string;
-        };
-    };
-    current_user_actor_url?: string;
-    current_user_organization_url?: string;
-    current_user_public?: string;
-    current_user_url?: string;
-    timeline_url?: string;
-    user_url?: string;
-}
-export interface ForkBody {
-    organization?: string;
-}
-export declare type Forks = Repos;
-export interface Gist {
-    comments?: number;
-    comments_url?: string;
-    /** Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ. */
-    created_at?: string;
-    description?: string;
-    files?: {
-        "ring.erl"?: {
-            filename?: string;
-            raw_url?: string;
-            size?: number;
-        };
-    };
-    forks?: {
-        created_at?: string;
-        url?: string;
-        user?: User;
-    }[];
-    git_pull_url?: string;
-    git_push_url?: string;
-    history?: {
-        change_status?: {
-            additions?: number;
-            deletions?: number;
-            total?: number;
-        };
-        committed_at?: string;
-        url?: string;
-        user?: User;
-        version?: string;
-    }[];
-    html_url?: string;
-    id?: string;
-    public?: boolean;
-    url?: string;
-    user?: User;
-}
-export declare type Gists = {
-    comments?: number;
-    comments_url?: string;
-    created_at?: string;
-    description?: string;
-    files?: {
-        "ring.erl"?: {
-            filename?: string;
-            raw_url?: string;
-            size?: number;
-        };
-    };
-    git_pull_url?: string;
-    git_push_url?: string;
-    html_url?: string;
-    id?: string;
-    public?: boolean;
-    url?: string;
-    user?: User;
-}[];
-export interface GitCommit {
-    author?: {
-        date?: string;
-        email?: string;
-        name?: string;
-    };
-    message?: string;
-    parents?: string;
-    tree?: string;
-}
-export interface GitRefPatch {
-    force?: boolean;
-    sha?: string;
-}
-export declare type Gitignore = any[];
-export interface GitignoreLang {
-    name?: string;
-    source?: string;
-}
-export interface HeadBranch {
-    object?: {
-        sha?: string;
-        type?: string;
-        url?: string;
-    };
-    ref?: string;
-    url?: string;
-}
-export declare type Hook = {
-    active?: boolean;
-    config?: {
-        content_type?: string;
-        url?: string;
-    };
-    created_at?: string;
-    events?: ("push" | "issues" | "issue_comment" | "commit_comment" | "pull_request" | "pull_request_review_comment" | "gollum" | "watch" | "download" | "fork" | "fork_apply" | "member" | "public" | "team_add" | "status")[];
-    id?: number;
-    name?: string;
-    updated_at?: string;
-    url?: string;
-}[];
-export interface HookBody {
-    active?: boolean;
-    add_events?: string[];
-}
-export interface Issue {
-    assignee?: string;
-    body?: string;
-    labels?: string[];
-    milestone?: number;
-    title?: string;
-}
-export interface IssueEvent {
-    actor?: Actor;
-    commit_id?: string;
-    /** ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ */
-    created_at?: string;
-    event?: string;
-    issue?: {
-        assignee?: User;
-        body?: string;
-        closed_at?: string;
-        comments?: number;
-        created_at?: string;
-        html_url?: string;
-        labels?: {
-            color?: string;
-            name?: string;
-            url?: string;
-        }[];
-        milestone?: {
-            closed_issues?: number;
-            created_at?: string;
-            creator?: User;
-            description?: string;
-            due_on?: string;
-            number?: number;
-            open_issues?: number;
-            state?: "open" | "closed";
-            title?: string;
-            url?: string;
-        };
-        number?: number;
-        pull_request?: {
-            diff_url?: string;
-            html_url?: string;
-            patch_url?: string;
-        };
-        state?: "open" | "closed";
-        title?: string;
-        updated_at?: string;
-        url?: string;
-        user?: User;
-    };
-    url?: string;
-}
-export declare type IssueEvents = IssueEvent[];
-export declare type Issues = {
-    assignee?: User;
-    body?: string;
-    closed_at?: string;
-    comments?: number;
-    created_at?: string;
-    html_url?: string;
-    labels?: {
-        color?: string;
-        name?: string;
-        url?: string;
-    }[];
-    milestone?: {
-        closed_issues?: number;
-        created_at?: string;
-        creator?: User;
-        description?: string;
-        due_on?: string;
-        number?: number;
-        open_issues?: number;
-        state?: "open" | "closed";
-        title?: string;
-        url?: string;
-    };
-    number?: number;
-    pull_request?: {
-        diff_url?: string;
-        html_url?: string;
-        patch_url?: string;
-    };
-    state?: "open" | "closed";
-    title?: string;
-    updated_at?: string;
-    url?: string;
-    user?: User;
-}[];
-export interface IssuesComment {
-    body?: string;
-    /** ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ */
-    created_at?: string;
-    html_url?: string;
-    id?: number;
-    /** ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ */
-    updated_at?: string;
-    url?: string;
-    user?: User;
-}
-export declare type IssuesComments = {
-    _links?: {
-        html?: {
-            href?: string;
-        };
-        pull_request?: {
-            href?: string;
-        };
-        self?: {
-            href?: string;
-        };
-    };
-    body?: string;
-    commit_id?: string;
-    created_at?: string;
-    id?: number;
-    path?: string;
-    position?: number;
-    updated_at?: string;
-    url?: string;
-    user?: User;
-}[];
-export declare type Keys = {
-    id?: number;
-    key?: string;
-    title?: string;
-    url?: string;
-}[];
-export interface Label {
-    color?: string;
-    name?: string;
-    url?: string;
-}
-export declare type Labels = {
-    color?: string;
-    name?: string;
-    url?: string;
-}[];
-export declare type Languages = Record<string, number>;
-export interface Markdown {
-    context?: string;
-    mode?: string;
-    text?: string;
-}
-export interface Merge {
-    merged?: boolean;
-    message?: string;
-    sha?: string;
-}
-export interface MergePullBody {
-    commit_message?: string;
-}
-export interface MergesBody {
-    base?: string;
-    commit_message?: string;
-    head?: string;
-}
-export interface MergesConflict {
-    /** Error message */
-    message?: string;
-}
-export interface MergesSuccessful {
-    author?: User;
-    comments_url?: string;
-    commit?: {
-        author?: {
-            date?: string;
-            email?: string;
-            name?: string;
-        };
-        comment_count?: number;
-        committer?: {
-            date?: string;
-            email?: string;
-            name?: string;
-        };
-        message?: string;
-        tree?: {
-            sha?: string;
-            url?: string;
-        };
-        url?: string;
-    };
-    committer?: User;
-    merged?: boolean;
-    message?: string;
-    parents?: {
-        sha?: string;
-        url?: string;
-    }[];
-    sha?: string;
-    url?: string;
-}
-export interface Meta {
-    git?: string[];
-    hooks?: string[];
-}
-export interface Milestone {
-    closed_issues?: number;
-    /** ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ */
-    created_at?: string;
-    creator?: User;
-    description?: string;
-    /** ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ */
-    due_on?: string;
-    number?: number;
-    open_issues?: number;
-    state?: "open" | "closed";
-    title?: string;
-    url?: string;
-}
-export interface MilestoneUpdate {
-    description?: string;
-    due_on?: string;
-    state?: string;
-    title?: string;
-}
-export interface NotificationMarkRead {
-    last_read_at?: string;
-}
-export interface Notifications {
-    id?: number;
-    last_read_at?: string;
-    reason?: string;
-    repository?: {
-        description?: string;
-        fork?: boolean;
-        full_name?: string;
-        html_url?: string;
-        id?: number;
-        name?: string;
-        owner?: Actor;
-        private?: boolean;
-        url?: string;
-    };
-    subject?: {
-        latest_comment_url?: string;
-        title?: string;
-        type?: string;
-        url?: string;
-    };
-    unread?: boolean;
-    updated_at?: string;
-    url?: string;
-}
-export interface OrgTeamsPost {
-    name: string;
-    permission?: "pull" | "push" | "admin";
-    repo_names?: string[];
-}
-export declare type Organization = Actor & any;
-export interface OrganizationAsTeamMember {
-    errors?: {
-        code?: string;
-        field?: string;
-        resource?: string;
-    }[];
-    message?: string;
-}
-export interface ParticipationStats {
-    all?: number[];
-    owner?: number[];
-}
-export interface PatchGist {
-    description?: string;
-    files?: {
-        "delete_this_file.txt"?: string;
-        "file1.txt"?: {
-            content?: string;
-        };
-        "new_file.txt"?: {
-            content?: string;
-        };
-        "old_name.txt"?: {
-            content?: string;
-            filename?: string;
-        };
-    };
-}
-export interface PatchOrg {
-    /** Billing email address. This address is not publicized. */
-    billing_email?: string;
-    company?: string;
-    /** Publicly visible email address. */
-    email?: string;
-    location?: string;
-    name?: string;
-}
-export interface PostGist {
-    description?: string;
-    files?: {
-        "file1.txt"?: {
-            content?: string;
-        };
-    };
-    public?: boolean;
-}
-export interface PostRepo {
-    /** True to create an initial commit with empty README. Default is false. */
-    auto_init?: boolean;
-    description?: string;
-    /** Desired language or platform .gitignore template to apply. Use the name of the template without the extension. For example, "Haskell" Ignored if auto_init parameter is not provided.  */
-    gitignore_template?: string;
-    /** True to enable downloads for this repository, false to disable them. Default is true. */
-    has_downloads?: boolean;
-    /** True to enable issues for this repository, false to disable them. Default is true. */
-    has_issues?: boolean;
-    /** True to enable the wiki for this repository, false to disable it. Default is true. */
-    has_wiki?: boolean;
-    homepage?: string;
-    name: string;
-    /** True to create a private repository, false to create a public one. Creating private repositories requires a paid GitHub account. */
-    private?: boolean;
-    /** The id of the team that will be granted access to this repository. This is only valid when creating a repo in an organization. */
-    team_id?: number;
-}
-export interface PullRequest {
-    _links?: {
-        comments?: {
-            href?: string;
-        };
-        html?: {
-            href?: string;
-        };
-        review_comments?: {
-            href?: string;
-        };
-        self?: {
-            href?: string;
-        };
-    };
-    additions?: number;
-    base?: {
-        label?: string;
-        ref?: string;
-        repo?: Repo;
-        sha?: string;
-        user?: {
-            avatar_url?: string;
-            gravatar_id?: string;
-            id?: number;
-            login?: string;
-            url?: string;
-        };
-    };
-    body?: string;
-    changed_files?: number;
-    closed_at?: string;
-    comments?: number;
-    commits?: number;
-    created_at?: string;
-    deletions?: number;
-    diff_url?: string;
-    head?: {
-        label?: string;
-        ref?: string;
-        repo?: Repo;
-        sha?: string;
-        user?: {
-            avatar_url?: string;
-            gravatar_id?: string;
-            id?: number;
-            login?: string;
-            url?: string;
-        };
-    };
-    html_url?: string;
-    issue_url?: string;
-    merge_commit_sha?: string;
-    mergeable?: boolean;
-    merged?: boolean;
-    merged_at?: string;
-    merged_by?: {
-        avatar_url?: string;
-        gravatar_id?: string;
-        id?: number;
-        login?: string;
-        url?: string;
-    };
-    number?: number;
-    patch_url?: string;
-    state?: string;
-    title?: string;
-    updated_at?: string;
-    url?: string;
-    user?: {
-        avatar_url?: string;
-        gravatar_id?: string;
-        id?: number;
-        login?: string;
-        url?: string;
-    };
-}
-export interface PullUpdate {
-    body?: string;
-    state?: string;
-    title?: string;
-}
-export declare type Pulls = {
-    _links?: {
-        comments?: {
-            href?: string;
-        };
-        html?: {
-            href?: string;
-        };
-        review_comments?: {
-            href?: string;
-        };
-        self?: {
-            href?: string;
-        };
-    };
-    base?: {
-        label?: string;
-        ref?: string;
-        repo?: Repo;
-        sha?: string;
-        user?: {
-            avatar_url?: string;
-            gravatar_id?: string;
-            id?: number;
-            login?: string;
-            url?: string;
-        };
-    };
-    body?: string;
-    closed_at?: string;
-    created_at?: string;
-    diff_url?: string;
-    head?: {
-        label?: string;
-        ref?: string;
-        repo?: Repo;
-        sha?: string;
-        user?: {
-            avatar_url?: string;
-            gravatar_id?: string;
-            id?: number;
-            login?: string;
-            url?: string;
-        };
-    };
-    html_url?: string;
-    issue_url?: string;
-    merged_at?: string;
-    number?: number;
-    patch_url?: string;
-    state?: "open" | "closed";
-    title?: string;
-    updated_at?: string;
-    url?: string;
-    user?: {
-        avatar_url?: string;
-        gravatar_id?: string;
-        id?: number;
-        login?: string;
-        url?: string;
-    };
-}[];
-export interface PullsComment {
-    _links?: {
-        html?: {
-            href?: string;
-        };
-        pull_request?: {
-            href?: string;
-        };
-        self?: {
-            href?: string;
-        };
-    };
-    body?: string;
-    commit_id?: string;
-    /** ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ */
-    created_at?: string;
-    id?: number;
-    path?: string;
-    position?: number;
-    /** ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ */
-    updated_at?: string;
-    url?: string;
-    user?: {
-        avatar_url?: string;
-        gravatar_id?: string;
-        id?: number;
-        login?: string;
-        url?: string;
-    };
-}
-export interface PullsCommentPost {
-    body?: string;
-    commit_id?: string;
-    path?: string;
-    position?: number;
-}
-export declare type PullsComments = {
-    _links?: {
-        html?: {
-            href?: string;
-        };
-        pull_request?: {
-            href?: string;
-        };
-        self?: {
-            href?: string;
-        };
-    };
-    body?: string;
-    commit_id?: string;
-    created_at?: string;
-    id?: number;
-    path?: string;
-    position?: number;
-    updated_at?: string;
-    url?: string;
-    user?: {
-        avatar_url?: string;
-        gravatar_id?: string;
-        id?: number;
-        login?: string;
-        url?: string;
-    };
-}[];
-export interface PullsPost {
-    base?: string;
-    body?: string;
-    head?: string;
-    title?: string;
-}
-export interface PutSubscription {
-    created_at?: string;
-    ignored?: boolean;
-    reason?: object;
-    subscribed?: boolean;
-    thread_url?: string;
-    url?: string;
-}
-export interface RateLimit {
-    rate?: {
-        limit?: number;
-        remaining?: number;
-        reset?: number;
-    };
-}
-export declare type Ref = {
-    created_at?: string;
-    creator?: {
-        avatar_url?: string;
-        gravatar_id?: string;
-        id?: number;
-        login?: string;
-        url?: string;
-    };
-    description?: string;
-    id?: number;
-    state?: string;
-    target_url?: string;
-    updated_at?: string;
-    url?: string;
-}[];
-export declare type RefStatus = {
-    commit_url?: string;
-    name?: string;
-    repository_url?: string;
-    sha?: string;
-    state?: string;
-    statuses?: {
-        context?: string;
-        created_at?: string;
-        description?: string;
-        id?: number;
-        state?: string;
-        target_url?: string;
-        updated_at?: string;
-        url?: string;
-    }[];
-}[];
-export declare type Refs = {
-    object?: {
-        sha?: string;
-        type?: string;
-        url?: string;
-    };
-    ref?: string;
-    url?: string;
-}[];
-export interface RefsBody {
-    ref?: string;
-    sha?: string;
-}
-export interface Release {
-    assets?: {
-        content_type?: string;
-        created_at?: string;
-        download_count?: number;
-        id?: number;
-        label?: string;
-        name?: string;
-        size?: number;
-        state?: string;
-        updated_at?: string;
-        uploader?: User;
-        url?: string;
-    }[];
-    assets_url?: string;
-    author?: User;
-    body?: string;
-    created_at?: string;
-    draft?: boolean;
-    html_url?: string;
-    id?: number;
-    name?: string;
-    prerelease?: boolean;
-    published_at?: string;
-    tag_name?: string;
-    tarball_url?: string;
-    target_commitish?: string;
-    upload_url?: string;
-    url?: string;
-    zipball_url?: string;
+  }[];
+  assets_url?: string;
+  author?: User;
+  body?: string;
+  created_at?: string;
+  draft?: boolean;
+  html_url?: string;
+  id?: number;
+  name?: string;
+  prerelease?: boolean;
+  published_at?: string;
+  tag_name?: string;
+  tarball_url?: string;
+  target_commitish?: string;
+  upload_url?: string;
+  url?: string;
+  zipball_url?: string;
 }
 export interface ReleaseCreate {
-    body?: string;
-    draft?: boolean;
-    name?: string;
-    prerelease?: boolean;
-    tag_name?: string;
-    target_commitish?: string;
+  body?: string;
+  draft?: boolean;
+  name?: string;
+  prerelease?: boolean;
+  tag_name?: string;
+  target_commitish?: string;
 }
 export declare type Releases = {
-    assets?: {
-        content_type?: string;
-        created_at?: string;
-        download_count?: number;
-        id?: number;
-        label?: string;
-        name?: string;
-        size?: number;
-        state?: string;
-        updated_at?: string;
-        uploader?: User;
-        url?: string;
-    }[];
-    assets_url?: string;
-    author?: User;
-    body?: string;
+  assets?: {
+    content_type?: string;
     created_at?: string;
-    draft?: boolean;
-    html_url?: string;
+    download_count?: number;
     id?: number;
+    label?: string;
     name?: string;
-    prerelease?: boolean;
-    published_at?: string;
-    tag_name?: string;
-    tarball_url?: string;
-    target_commitish?: string;
-    upload_url?: string;
+    size?: number;
+    state?: string;
+    updated_at?: string;
+    uploader?: User;
     url?: string;
-    zipball_url?: string;
+  }[];
+  assets_url?: string;
+  author?: User;
+  body?: string;
+  created_at?: string;
+  draft?: boolean;
+  html_url?: string;
+  id?: number;
+  name?: string;
+  prerelease?: boolean;
+  published_at?: string;
+  tag_name?: string;
+  tarball_url?: string;
+  target_commitish?: string;
+  upload_url?: string;
+  url?: string;
+  zipball_url?: string;
 }[];
 export interface Repo {
-    clone_url?: string;
-    /** ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ */
-    created_at?: string;
-    description?: string;
-    fork?: boolean;
-    forks?: number;
-    forks_count?: number;
-    full_name?: string;
-    git_url?: string;
-    has_downloads?: boolean;
-    has_issues?: boolean;
-    has_wiki?: boolean;
-    homepage?: string;
-    html_url?: string;
-    id?: number;
-    language?: string;
-    master_branch?: string;
-    mirror_url?: string;
-    name?: string;
-    open_issues?: number;
-    open_issues_count?: number;
-    organization?: Organization;
-    owner?: Actor;
-    parent?: Repo & any;
-    private?: boolean;
-    /** ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ */
-    pushed_at?: string;
-    size?: number;
-    source?: Repo & any;
-    ssh_url?: string;
-    svn_url?: string;
-    /** ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ */
-    updated_at?: string;
-    url?: string;
-    watchers?: number;
-    watchers_count?: number;
+  clone_url?: string;
+  /** ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ */
+  created_at?: string;
+  description?: string;
+  fork?: boolean;
+  forks?: number;
+  forks_count?: number;
+  full_name?: string;
+  git_url?: string;
+  has_downloads?: boolean;
+  has_issues?: boolean;
+  has_wiki?: boolean;
+  homepage?: string;
+  html_url?: string;
+  id?: number;
+  language?: string;
+  master_branch?: string;
+  mirror_url?: string;
+  name?: string;
+  open_issues?: number;
+  open_issues_count?: number;
+  organization?: Organization;
+  owner?: Actor;
+  parent?: Repo & any;
+  private?: boolean;
+  /** ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ */
+  pushed_at?: string;
+  size?: number;
+  source?: Repo & any;
+  ssh_url?: string;
+  svn_url?: string;
+  /** ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ */
+  updated_at?: string;
+  url?: string;
+  watchers?: number;
+  watchers_count?: number;
 }
 export declare type RepoDeployments = {
-    created_at?: string;
-    creator?: User;
-    description?: string;
-    id?: number;
-    payload?: string;
-    sha?: string;
-    statuses_url?: string;
-    updated_at?: string;
-    url?: string;
+  created_at?: string;
+  creator?: User;
+  description?: string;
+  id?: number;
+  payload?: string;
+  sha?: string;
+  statuses_url?: string;
+  updated_at?: string;
+  url?: string;
 }[];
 export declare type RepoComments = {
-    body?: string;
-    commit_id?: string;
-    created_at?: string;
-    html_url?: string;
-    id?: number;
-    line?: number;
-    path?: string;
-    position?: number;
-    updated_at?: string;
-    url?: string;
-    user?: User;
+  body?: string;
+  commit_id?: string;
+  created_at?: string;
+  html_url?: string;
+  id?: number;
+  line?: number;
+  path?: string;
+  position?: number;
+  updated_at?: string;
+  url?: string;
+  user?: User;
 }[];
 export interface RepoCommit {
-    author?: {
-        date?: string;
-        email?: string;
-        name?: string;
-    };
-    committer?: {
-        date?: string;
-        email?: string;
-        name?: string;
-    };
-    message?: string;
-    parents?: {
-        sha?: string;
-        url?: string;
-    }[];
+  author?: {
+    date?: string;
+    email?: string;
+    name?: string;
+  };
+  committer?: {
+    date?: string;
+    email?: string;
+    name?: string;
+  };
+  message?: string;
+  parents?: {
     sha?: string;
-    tree?: {
-        sha?: string;
-        url?: string;
-    };
     url?: string;
+  }[];
+  sha?: string;
+  tree?: {
+    sha?: string;
+    url?: string;
+  };
+  url?: string;
 }
 export interface RepoCommitBody {
-    author?: {
-        date?: string;
-        email?: string;
-        name?: string;
-    };
-    message: string;
-    parents: string[];
-    tree: string;
+  author?: {
+    date?: string;
+    email?: string;
+    name?: string;
+  };
+  message: string;
+  parents: string[];
+  tree: string;
 }
 export interface RepoEdit {
-    description?: string;
-    has_downloads?: boolean;
-    has_issues?: boolean;
-    has_wiki?: boolean;
-    homepage?: string;
-    name?: string;
-    private?: boolean;
+  description?: string;
+  has_downloads?: boolean;
+  has_issues?: boolean;
+  has_wiki?: boolean;
+  homepage?: string;
+  name?: string;
+  private?: boolean;
 }
 export declare type Repos = Repo[];
 export interface SearchCode {
-    items?: {
-        git_url?: string;
-        html_url?: string;
-        name?: string;
-        path?: string;
-        repository?: {
-            archive_url?: string;
-            assignees_url?: string;
-            blobs_url?: string;
-            branches_url?: string;
-            collaborators_url?: string;
-            comments_url?: string;
-            commits_url?: string;
-            compare_url?: string;
-            contents_url?: string;
-            contributors_url?: string;
-            description?: string;
-            downloads_url?: string;
-            events_url?: string;
-            fork?: boolean;
-            forks_url?: string;
-            full_name?: string;
-            git_commits_url?: string;
-            git_refs_url?: string;
-            git_tags_url?: string;
-            hooks_url?: string;
-            html_url?: string;
-            id?: number;
-            issue_comment_url?: string;
-            issue_events_url?: string;
-            issues_url?: string;
-            keys_url?: string;
-            labels_url?: string;
-            languages_url?: string;
-            merges_url?: string;
-            milestones_url?: string;
-            name?: string;
-            notifications_url?: string;
-            owner?: Actor;
-            private?: boolean;
-            pulls_url?: string;
-            stargazers_url?: string;
-            statuses_url?: string;
-            subscribers_url?: string;
-            subscription_url?: string;
-            tags_url?: string;
-            teams_url?: string;
-            trees_url?: string;
-            url?: string;
-        };
-        score?: number;
-        sha?: string;
-        url?: string;
-    }[];
-    total_count?: number;
+  items?: {
+    git_url?: string;
+    html_url?: string;
+    name?: string;
+    path?: string;
+    repository?: {
+      archive_url?: string;
+      assignees_url?: string;
+      blobs_url?: string;
+      branches_url?: string;
+      collaborators_url?: string;
+      comments_url?: string;
+      commits_url?: string;
+      compare_url?: string;
+      contents_url?: string;
+      contributors_url?: string;
+      description?: string;
+      downloads_url?: string;
+      events_url?: string;
+      fork?: boolean;
+      forks_url?: string;
+      full_name?: string;
+      git_commits_url?: string;
+      git_refs_url?: string;
+      git_tags_url?: string;
+      hooks_url?: string;
+      html_url?: string;
+      id?: number;
+      issue_comment_url?: string;
+      issue_events_url?: string;
+      issues_url?: string;
+      keys_url?: string;
+      labels_url?: string;
+      languages_url?: string;
+      merges_url?: string;
+      milestones_url?: string;
+      name?: string;
+      notifications_url?: string;
+      owner?: Actor;
+      private?: boolean;
+      pulls_url?: string;
+      stargazers_url?: string;
+      statuses_url?: string;
+      subscribers_url?: string;
+      subscription_url?: string;
+      tags_url?: string;
+      teams_url?: string;
+      trees_url?: string;
+      url?: string;
+    };
+    score?: number;
+    sha?: string;
+    url?: string;
+  }[];
+  total_count?: number;
 }
 export interface SearchIssues {
-    items?: {
-        assignee?: any;
-        body?: string;
-        closed_at?: any;
-        comments?: number;
-        comments_url?: string;
-        created_at?: string;
-        events_url?: string;
-        html_url?: string;
-        id?: number;
-        labels?: {
-            color?: string;
-            name?: string;
-            url?: string;
-        }[];
-        labels_url?: string;
-        milestone?: any;
-        number?: number;
-        pull_request?: {
-            diff_url?: any;
-            html_url?: any;
-            patch_url?: any;
-        };
-        score?: number;
-        state?: string;
-        title?: string;
-        updated_at?: string;
-        url?: string;
-        user?: User;
+  items?: {
+    assignee?: any;
+    body?: string;
+    closed_at?: any;
+    comments?: number;
+    comments_url?: string;
+    created_at?: string;
+    events_url?: string;
+    html_url?: string;
+    id?: number;
+    labels?: {
+      color?: string;
+      name?: string;
+      url?: string;
     }[];
-    total_count?: number;
+    labels_url?: string;
+    milestone?: any;
+    number?: number;
+    pull_request?: {
+      diff_url?: any;
+      html_url?: any;
+      patch_url?: any;
+    };
+    score?: number;
+    state?: string;
+    title?: string;
+    updated_at?: string;
+    url?: string;
+    user?: User;
+  }[];
+  total_count?: number;
 }
 export interface SearchIssuesByKeyword {
-    issues?: {
-        body?: string;
-        comments?: number;
-        created_at?: string;
-        gravatar_id?: string;
-        html_url?: string;
-        labels?: string[];
-        number?: number;
-        position?: number;
-        state?: string;
-        title?: string;
-        updated_at?: string;
-        user?: string;
-        votes?: number;
-    }[];
+  issues?: {
+    body?: string;
+    comments?: number;
+    created_at?: string;
+    gravatar_id?: string;
+    html_url?: string;
+    labels?: string[];
+    number?: number;
+    position?: number;
+    state?: string;
+    title?: string;
+    updated_at?: string;
+    user?: string;
+    votes?: number;
+  }[];
 }
 export interface SearchRepositories {
-    items?: Repo[];
-    total_count?: number;
+  items?: Repo[];
+  total_count?: number;
 }
 export interface SearchRepositoriesByKeyword {
-    repositories?: Repo[];
+  repositories?: Repo[];
 }
 export interface SearchUserByEmail {
-    user?: User;
+  user?: User;
 }
 export interface SearchUsers {
-    items?: Users;
-    total_count?: number;
+  items?: Users;
+  total_count?: number;
 }
 export interface SearchUsersByKeyword {
-    users?: Users;
+  users?: Users;
 }
 export interface Subscription {
-    /** ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ */
-    created_at?: string;
-    ignored?: boolean;
-    reason?: string;
-    repository_url?: string;
-    subscribed?: boolean;
-    thread_url?: string;
-    url?: string;
+  /** ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ */
+  created_at?: string;
+  ignored?: boolean;
+  reason?: string;
+  repository_url?: string;
+  subscribed?: boolean;
+  thread_url?: string;
+  url?: string;
 }
 export interface SubscriptionBody {
-    ignored?: boolean;
-    subscribed?: boolean;
+  ignored?: boolean;
+  subscribed?: boolean;
 }
 export interface Tag {
-    /** String of the tag message. */
-    message?: string;
-    object?: {
-        sha?: string;
-        type?: "commit" | "tree" | "blob";
-        url?: string;
-    };
+  /** String of the tag message. */
+  message?: string;
+  object?: {
     sha?: string;
-    /** The tag's name. This is typically a version (e.g., "v0.0.1"). */
-    tag?: string;
-    tagger?: {
-        date?: string;
-        email?: string;
-        name?: string;
-    };
+    type?: "commit" | "tree" | "blob";
     url?: string;
+  };
+  sha?: string;
+  /** The tag's name. This is typically a version (e.g., "v0.0.1"). */
+  tag?: string;
+  tagger?: {
+    date?: string;
+    email?: string;
+    name?: string;
+  };
+  url?: string;
 }
 export interface TagBody {
-    /** String of the tag message. */
-    message: string;
-    /** String of the SHA of the git object this is tagging. */
-    object: string;
-    /** The tag's name. This is typically a version (e.g., "v0.0.1"). */
-    tag: string;
-    tagger: {
-        date?: string;
-        email?: string;
-        name?: string;
-    };
-    /** String of the type of the object we’re tagging. Normally this is a commit but it can also be a tree or a blob. */
-    type: "commit" | "tree" | "blob";
+  /** String of the tag message. */
+  message: string;
+  /** String of the SHA of the git object this is tagging. */
+  object: string;
+  /** The tag's name. This is typically a version (e.g., "v0.0.1"). */
+  tag: string;
+  tagger: {
+    date?: string;
+    email?: string;
+    name?: string;
+  };
+  /** String of the type of the object we’re tagging. Normally this is a commit but it can also be a tree or a blob. */
+  type: "commit" | "tree" | "blob";
 }
 export declare type Tags = Tag[];
 export interface Team {
-    id?: number;
-    members_count?: number;
-    name?: string;
-    permission?: string;
-    repos_count?: number;
-    url?: string;
+  id?: number;
+  members_count?: number;
+  name?: string;
+  permission?: string;
+  repos_count?: number;
+  url?: string;
 }
 export interface TeamMembership {
-    state?: string;
-    url?: string;
+  state?: string;
+  url?: string;
 }
 export declare type TeamRepos = Repos;
 export declare type Teams = {
-    id?: number;
-    name?: string;
-    url?: string;
+  id?: number;
+  name?: string;
+  url?: string;
 }[];
 export declare type TeamsList = {
+  id?: number;
+  members_count?: number;
+  name?: string;
+  organization?: {
+    avatar_url?: string;
     id?: number;
-    members_count?: number;
-    name?: string;
-    organization?: {
-        avatar_url?: string;
-        id?: number;
-        login?: string;
-        url?: string;
-    };
-    permission?: string;
-    repos_count?: number;
+    login?: string;
     url?: string;
+  };
+  permission?: string;
+  repos_count?: number;
+  url?: string;
 }[];
 export interface Tree {
+  sha?: string;
+  tree?: {
+    mode?: "100644" | "100755" | "040000" | "160000" | "120000";
+    path?: string;
     sha?: string;
-    tree?: {
-        mode?: "100644" | "100755" | "040000" | "160000" | "120000";
-        path?: string;
-        sha?: string;
-        size?: number;
-        type?: "blob" | "tree" | "commit";
-        url?: string;
-    }[];
+    size?: number;
+    type?: "blob" | "tree" | "commit";
     url?: string;
+  }[];
+  url?: string;
 }
 export interface Trees {
-    base_tree?: string;
-    /** SHA1 checksum ID of the object in the tree. */
-    sha?: string;
-    tree?: Tree[];
-    url?: string;
+  base_tree?: string;
+  /** SHA1 checksum ID of the object in the tree. */
+  sha?: string;
+  tree?: Tree[];
+  url?: string;
 }
 export declare type User = Actor & any;
 export declare type UserEmails = string[];
 export interface UserKeysKeyId {
-    id?: number;
-    key?: string;
-    title?: string;
-    url?: string;
+  id?: number;
+  key?: string;
+  title?: string;
+  url?: string;
 }
 export interface UserKeysPost {
-    key?: string;
-    title?: string;
+  key?: string;
+  title?: string;
 }
 export interface UserUpdate {
-    bio?: string;
-    blog?: string;
-    company?: string;
-    email?: string;
-    hireable?: boolean;
-    location?: string;
-    name?: string;
+  bio?: string;
+  blog?: string;
+  company?: string;
+  email?: string;
+  hireable?: boolean;
+  location?: string;
+  name?: string;
 }
 export declare type Users = User[];
 export declare type RequestParams = Omit<RequestInit, "body" | "method"> & {
-    secure?: boolean;
+  secure?: boolean;
 };
 export declare type RequestQueryParamsType = Record<string | number, any>;
 declare type ApiConfig<SecurityDataType> = {
-    baseUrl?: string;
-    baseApiParams?: RequestParams;
-    securityWorker?: (securityData: SecurityDataType) => RequestParams;
+  baseUrl?: string;
+  baseApiParams?: RequestParams;
+  securityWorker?: (securityData: SecurityDataType) => RequestParams;
 };
 declare enum BodyType {
-    Json = 0
+  Json = 0,
 }
 declare class HttpClient<SecurityDataType> {
-    baseUrl: string;
-    private securityData;
-    private securityWorker;
-    private baseApiParams;
-    constructor({ baseUrl, baseApiParams, securityWorker }?: ApiConfig<SecurityDataType>);
-    setSecurityData: (data: SecurityDataType) => void;
-    private addQueryParam;
-    protected addQueryParams(rawQuery?: RequestQueryParamsType): string;
-    private bodyFormatters;
-    private mergeRequestOptions;
-    private safeParseResponse;
-    request: <T = any, E = any>(path: string, method: string, { secure, ...params }?: RequestParams, body?: any, bodyType?: BodyType, secureByDefault?: boolean) => Promise<T>;
+  baseUrl: string;
+  private securityData;
+  private securityWorker;
+  private baseApiParams;
+  constructor({ baseUrl, baseApiParams, securityWorker }?: ApiConfig<SecurityDataType>);
+  setSecurityData: (data: SecurityDataType) => void;
+  private addQueryParam;
+  protected addQueryParams(rawQuery?: RequestQueryParamsType): string;
+  private bodyFormatters;
+  private mergeRequestOptions;
+  private safeParseResponse;
+  request: <T = any, E = any>(
+    path: string,
+    method: string,
+    { secure, ...params }?: RequestParams,
+    body?: any,
+    bodyType?: BodyType,
+    secureByDefault?: boolean,
+  ) => Promise<T>;
 }
 /**
  * @title GitHub
@@ -1683,1678 +1706,2006 @@ declare class HttpClient<SecurityDataType> {
  * Powerful collaboration, code review, and code management for open source and private projects.
  */
 export declare class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
-    emojis: {
-        /**
-         * @name emojisList
-         * @request GET:/emojis
-         * @description Lists all the emojis available to use on GitHub.
-         */
-        emojisList: (params?: RequestParams) => Promise<Record<string, string>>;
-    };
-    events: {
-        /**
-         * @name eventsList
-         * @request GET:/events
-         * @description List public events.
-         */
-        eventsList: (params?: RequestParams) => Promise<Events>;
-    };
-    feeds: {
-        /**
-         * @name feedsList
-         * @request GET:/feeds
-         * @description List Feeds. GitHub provides several timeline resources in Atom format. The Feeds API lists all the feeds available to the authenticating user.
-         */
-        feedsList: (params?: RequestParams) => Promise<Feeds>;
-    };
-    gists: {
-        /**
-         * @name gistsList
-         * @request GET:/gists
-         * @description List the authenticated user's gists or if called anonymously, this will return all public gists.
-         */
-        gistsList: (query?: {
-            since?: string;
-        }, params?: RequestParams) => Promise<Gists>;
-        /**
-         * @name gistsCreate
-         * @request POST:/gists
-         * @description Create a gist.
-         */
-        gistsCreate: (body: PostGist, params?: RequestParams) => Promise<Gist>;
-        /**
-         * @name publicList
-         * @request GET:/gists/public
-         * @description List all public gists.
-         */
-        publicList: (query?: {
-            since?: string;
-        }, params?: RequestParams) => Promise<Gists>;
-        /**
-         * @name starredList
-         * @request GET:/gists/starred
-         * @description List the authenticated user's starred gists.
-         */
-        starredList: (query?: {
-            since?: string;
-        }, params?: RequestParams) => Promise<Gists>;
-        /**
-         * @name gistsDelete
-         * @request DELETE:/gists/{id}
-         * @description Delete a gist.
-         */
-        gistsDelete: (id: number, params?: RequestParams) => Promise<any>;
-        /**
-         * @name gistsDetail
-         * @request GET:/gists/{id}
-         * @description Get a single gist.
-         */
-        gistsDetail: (id: number, params?: RequestParams) => Promise<Gist>;
-        /**
-         * @name gistsPartialUpdate
-         * @request PATCH:/gists/{id}
-         * @description Edit a gist.
-         */
-        gistsPartialUpdate: (id: number, body: PatchGist, params?: RequestParams) => Promise<Gist>;
-        /**
-         * @name commentsDetail
-         * @request GET:/gists/{id}/comments
-         * @description List comments on a gist.
-         */
-        commentsDetail: (id: number, params?: RequestParams) => Promise<Comments>;
-        /**
-         * @name commentsCreate
-         * @request POST:/gists/{id}/comments
-         * @description Create a commen
-         */
-        commentsCreate: (id: number, body: CommentBody, params?: RequestParams) => Promise<Comment>;
-        /**
-         * @name commentsDelete
-         * @request DELETE:/gists/{id}/comments/{commentId}
-         * @description Delete a comment.
-         */
-        commentsDelete: (id: number, commentId: number, params?: RequestParams) => Promise<any>;
-        /**
-         * @name commentsDetail
-         * @request GET:/gists/{id}/comments/{commentId}
-         * @description Get a single comment.
-         * @originalName commentsDetail
-         * @duplicate
-         */
-        commentsDetail2: (id: number, commentId: number, params?: RequestParams) => Promise<Comment>;
-        /**
-         * @name commentsPartialUpdate
-         * @request PATCH:/gists/{id}/comments/{commentId}
-         * @description Edit a comment.
-         */
-        commentsPartialUpdate: (id: number, commentId: number, body: Comment, params?: RequestParams) => Promise<Comment>;
-        /**
-         * @name forksCreate
-         * @request POST:/gists/{id}/forks
-         * @description Fork a gist.
-         */
-        forksCreate: (id: number, params?: RequestParams) => Promise<any>;
-        /**
-         * @name starDelete
-         * @request DELETE:/gists/{id}/star
-         * @description Unstar a gist.
-         */
-        starDelete: (id: number, params?: RequestParams) => Promise<any>;
-        /**
-         * @name starDetail
-         * @request GET:/gists/{id}/star
-         * @description Check if a gist is starred.
-         */
-        starDetail: (id: number, params?: RequestParams) => Promise<any>;
-        /**
-         * @name starUpdate
-         * @request PUT:/gists/{id}/star
-         * @description Star a gist.
-         */
-        starUpdate: (id: number, params?: RequestParams) => Promise<any>;
-    };
-    gitignore: {
-        /**
-         * @name templatesList
-         * @request GET:/gitignore/templates
-         * @description Listing available templates. List all templates available to pass as an option when creating a repository.
-         */
-        templatesList: (params?: RequestParams) => Promise<Gitignore>;
-        /**
-         * @name templatesDetail
-         * @request GET:/gitignore/templates/{language}
-         * @description Get a single template.
-         */
-        templatesDetail: (language: string, params?: RequestParams) => Promise<GitignoreLang>;
-    };
-    issues: {
-        /**
-         * @name issuesList
-         * @request GET:/issues
-         * @description List issues. List all issues across all the authenticated user's visible repositories.
-         */
-        issuesList: (query: {
-            filter: "assigned" | "created" | "mentioned" | "subscribed" | "all";
-            state: "open" | "closed";
-            labels: string;
-            sort: "created" | "updated" | "comments";
-            direction: "asc" | "desc";
-            since?: string;
-        }, params?: RequestParams) => Promise<Issues>;
-    };
-    legacy: {
-        /**
-         * @name issuesSearchDetail
-         * @request GET:/legacy/issues/search/{owner}/{repository}/{state}/{keyword}
-         * @description Find issues by state and keyword.
-         */
-        issuesSearchDetail: (keyword: string, state: "open" | "closed", owner: string, repository: string, params?: RequestParams) => Promise<SearchIssuesByKeyword>;
-        /**
-         * @name reposSearchDetail
-         * @request GET:/legacy/repos/search/{keyword}
-         * @description Find repositories by keyword. Note, this legacy method does not follow the v3 pagination pattern. This method returns up to 100 results per page and pages can be fetched using the start_page parameter.
-         */
-        reposSearchDetail: (keyword: string, query?: {
-            order?: "desc" | "asc";
-            language?: string;
-            start_page?: string;
-            sort?: "updated" | "stars" | "forks";
-        }, params?: RequestParams) => Promise<SearchRepositoriesByKeyword>;
-        /**
-         * @name userEmailDetail
-         * @request GET:/legacy/user/email/{email}
-         * @description This API call is added for compatibility reasons only.
-         */
-        userEmailDetail: (email: string, params?: RequestParams) => Promise<SearchUserByEmail>;
-        /**
-         * @name userSearchDetail
-         * @request GET:/legacy/user/search/{keyword}
-         * @description Find users by keyword.
-         */
-        userSearchDetail: (keyword: string, query?: {
-            order?: "desc" | "asc";
-            start_page?: string;
-            sort?: "updated" | "stars" | "forks";
-        }, params?: RequestParams) => Promise<SearchUsersByKeyword>;
-    };
-    markdown: {
-        /**
-         * @name markdownCreate
-         * @request POST:/markdown
-         * @description Render an arbitrary Markdown document
-         */
-        markdownCreate: (body: Markdown, params?: RequestParams) => Promise<any>;
-        /**
-         * @name postMarkdown
-         * @request POST:/markdown/raw
-         * @description Render a Markdown document in raw mode
-         */
-        postMarkdown: (params?: RequestParams) => Promise<any>;
-    };
-    meta: {
-        /**
-         * @name metaList
-         * @request GET:/meta
-         * @description This gives some information about GitHub.com, the service.
-         */
-        metaList: (params?: RequestParams) => Promise<Meta>;
-    };
-    networks: {
-        /**
-         * @name eventsDetail
-         * @request GET:/networks/{owner}/{repo}/events
-         * @description List public events for a network of repositories.
-         */
-        eventsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Events>;
-    };
-    notifications: {
-        /**
-         * @name notificationsList
-         * @request GET:/notifications
-         * @description List your notifications. List all notifications for the current user, grouped by repository.
-         */
-        notificationsList: (query?: {
-            all?: boolean;
-            participating?: boolean;
-            since?: string;
-        }, params?: RequestParams) => Promise<Notifications>;
-        /**
-         * @name notificationsUpdate
-         * @request PUT:/notifications
-         * @description Mark as read. Marking a notification as "read" removes it from the default view on GitHub.com.
-         */
-        notificationsUpdate: (body: NotificationMarkRead, params?: RequestParams) => Promise<any>;
-        /**
-         * @name threadsDetail
-         * @request GET:/notifications/threads/{id}
-         * @description View a single thread.
-         */
-        threadsDetail: (id: number, params?: RequestParams) => Promise<Notifications>;
-        /**
-         * @name threadsPartialUpdate
-         * @request PATCH:/notifications/threads/{id}
-         * @description Mark a thread as read
-         */
-        threadsPartialUpdate: (id: number, params?: RequestParams) => Promise<any>;
-        /**
-         * @name threadsSubscriptionDelete
-         * @request DELETE:/notifications/threads/{id}/subscription
-         * @description Delete a Thread Subscription.
-         */
-        threadsSubscriptionDelete: (id: number, params?: RequestParams) => Promise<any>;
-        /**
-         * @name threadsSubscriptionDetail
-         * @request GET:/notifications/threads/{id}/subscription
-         * @description Get a Thread Subscription.
-         */
-        threadsSubscriptionDetail: (id: number, params?: RequestParams) => Promise<Subscription>;
-        /**
-         * @name threadsSubscriptionUpdate
-         * @request PUT:/notifications/threads/{id}/subscription
-         * @description Set a Thread Subscription. This lets you subscribe to a thread, or ignore it. Subscribing to a thread is unnecessary if the user is already subscribed to the repository. Ignoring a thread will mute all future notifications (until you comment or get @mentioned).
-         */
-        threadsSubscriptionUpdate: (id: number, body: PutSubscription, params?: RequestParams) => Promise<Subscription>;
-    };
-    orgs: {
-        /**
-         * @name orgsDetail
-         * @request GET:/orgs/{org}
-         * @description Get an Organization.
-         */
-        orgsDetail: (org: string, params?: RequestParams) => Promise<any>;
-        /**
-         * @name orgsPartialUpdate
-         * @request PATCH:/orgs/{org}
-         * @description Edit an Organization.
-         */
-        orgsPartialUpdate: (org: string, body: PatchOrg, params?: RequestParams) => Promise<any>;
-        /**
-         * @name eventsDetail
-         * @request GET:/orgs/{org}/events
-         * @description List public events for an organization.
-         */
-        eventsDetail: (org: string, params?: RequestParams) => Promise<Events>;
-        /**
-         * @name issuesDetail
-         * @request GET:/orgs/{org}/issues
-         * @description List issues. List all issues for a given organization for the authenticated user.
-         */
-        issuesDetail: (org: string, query: {
-            filter: "assigned" | "created" | "mentioned" | "subscribed" | "all";
-            state: "open" | "closed";
-            labels: string;
-            sort: "created" | "updated" | "comments";
-            direction: "asc" | "desc";
-            since?: string;
-        }, params?: RequestParams) => Promise<Issues>;
-        /**
-         * @name membersDetail
-         * @request GET:/orgs/{org}/members
-         * @description Members list. List all users who are members of an organization. A member is a user tha belongs to at least 1 team in the organization. If the authenticated user is also an owner of this organization then both concealed and public members will be returned. If the requester is not an owner of the organization the query will be redirected to the public members list.
-         */
-        membersDetail: (org: string, params?: RequestParams) => Promise<Users>;
-        /**
-         * @name membersDelete
-         * @request DELETE:/orgs/{org}/members/{username}
-         * @description Remove a member. Removing a user from this list will remove them from all teams and they will no longer have any access to the organization's repositories.
-         */
-        membersDelete: (org: string, username: string, params?: RequestParams) => Promise<any>;
-        /**
-         * @name membersDetail
-         * @request GET:/orgs/{org}/members/{username}
-         * @description Check if a user is, publicly or privately, a member of the organization.
-         * @originalName membersDetail
-         * @duplicate
-         */
-        membersDetail2: (org: string, username: string, params?: RequestParams) => Promise<any>;
-        /**
-         * @name publicMembersDetail
-         * @request GET:/orgs/{org}/public_members
-         * @description Public members list. Members of an organization can choose to have their membership publicized or not.
-         */
-        publicMembersDetail: (org: string, params?: RequestParams) => Promise<Users>;
-        /**
-         * @name publicMembersDelete
-         * @request DELETE:/orgs/{org}/public_members/{username}
-         * @description Conceal a user's membership.
-         */
-        publicMembersDelete: (org: string, username: string, params?: RequestParams) => Promise<any>;
-        /**
-         * @name publicMembersDetail
-         * @request GET:/orgs/{org}/public_members/{username}
-         * @description Check public membership.
-         * @originalName publicMembersDetail
-         * @duplicate
-         */
-        publicMembersDetail2: (org: string, username: string, params?: RequestParams) => Promise<any>;
-        /**
-         * @name publicMembersUpdate
-         * @request PUT:/orgs/{org}/public_members/{username}
-         * @description Publicize a user's membership.
-         */
-        publicMembersUpdate: (org: string, username: string, params?: RequestParams) => Promise<any>;
-        /**
-         * @name reposDetail
-         * @request GET:/orgs/{org}/repos
-         * @description List repositories for the specified org.
-         */
-        reposDetail: (org: string, query?: {
-            type?: "all" | "public" | "private" | "forks" | "sources" | "member";
-        }, params?: RequestParams) => Promise<Repos>;
-        /**
-         * @name reposCreate
-         * @request POST:/orgs/{org}/repos
-         * @description Create a new repository for the authenticated user. OAuth users must supply repo scope.
-         */
-        reposCreate: (org: string, body: PostRepo, params?: RequestParams) => Promise<Repos>;
-        /**
-         * @name teamsDetail
-         * @request GET:/orgs/{org}/teams
-         * @description List teams.
-         */
-        teamsDetail: (org: string, params?: RequestParams) => Promise<Teams>;
-        /**
-         * @name teamsCreate
-         * @request POST:/orgs/{org}/teams
-         * @description Create team. In order to create a team, the authenticated user must be an owner of organization.
-         */
-        teamsCreate: (org: string, body: OrgTeamsPost, params?: RequestParams) => Promise<Team>;
-    };
-    rateLimit: {
-        /**
-         * @name rateLimitList
-         * @request GET:/rate_limit
-         * @description Get your current rate limit status Note: Accessing this endpoint does not count against your rate limit.
-         */
-        rateLimitList: (params?: RequestParams) => Promise<RateLimit>;
-    };
-    repos: {
-        /**
-         * @name reposDelete
-         * @request DELETE:/repos/{owner}/{repo}
-         * @description Delete a Repository. Deleting a repository requires admin access. If OAuth is used, the delete_repo scope is required.
-         */
-        reposDelete: (owner: string, repo: string, params?: RequestParams) => Promise<any>;
-        /**
-         * @name reposDetail
-         * @request GET:/repos/{owner}/{repo}
-         * @description Get repository.
-         */
-        reposDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Repo>;
-        /**
-         * @name reposPartialUpdate
-         * @request PATCH:/repos/{owner}/{repo}
-         * @description Edit repository.
-         */
-        reposPartialUpdate: (owner: string, repo: string, body: RepoEdit, params?: RequestParams) => Promise<Repo>;
-        /**
-         * @name assigneesDetail
-         * @request GET:/repos/{owner}/{repo}/assignees
-         * @description List assignees. This call lists all the available assignees (owner + collaborators) to which issues may be assigned.
-         */
-        assigneesDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Assignees>;
-        /**
-         * @name assigneesDetail
-         * @request GET:/repos/{owner}/{repo}/assignees/{assignee}
-         * @description Check assignee. You may also check to see if a particular user is an assignee for a repository.
-         * @originalName assigneesDetail
-         * @duplicate
-         */
-        assigneesDetail2: (owner: string, repo: string, assignee: string, params?: RequestParams) => Promise<any>;
-        /**
-         * @name branchesDetail
-         * @request GET:/repos/{owner}/{repo}/branches
-         * @description Get list of branches
-         */
-        branchesDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Branches>;
-        /**
-         * @name branchesDetail
-         * @request GET:/repos/{owner}/{repo}/branches/{branch}
-         * @description Get Branch
-         * @originalName branchesDetail
-         * @duplicate
-         */
-        branchesDetail2: (owner: string, repo: string, branch: string, params?: RequestParams) => Promise<Branch>;
-        /**
-         * @name collaboratorsDetail
-         * @request GET:/repos/{owner}/{repo}/collaborators
-         * @description List. When authenticating as an organization owner of an organization-owned repository, all organization owners are included in the list of collaborators. Otherwise, only users with access to the repository are returned in the collaborators list.
-         */
-        collaboratorsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Users>;
-        /**
-         * @name collaboratorsDelete
-         * @request DELETE:/repos/{owner}/{repo}/collaborators/{user}
-         * @description Remove collaborator.
-         */
-        collaboratorsDelete: (owner: string, repo: string, user: string, params?: RequestParams) => Promise<any>;
-        /**
-         * @name collaboratorsDetail
-         * @request GET:/repos/{owner}/{repo}/collaborators/{user}
-         * @description Check if user is a collaborator
-         * @originalName collaboratorsDetail
-         * @duplicate
-         */
-        collaboratorsDetail2: (owner: string, repo: string, user: string, params?: RequestParams) => Promise<any>;
-        /**
-         * @name collaboratorsUpdate
-         * @request PUT:/repos/{owner}/{repo}/collaborators/{user}
-         * @description Add collaborator.
-         */
-        collaboratorsUpdate: (owner: string, repo: string, user: string, params?: RequestParams) => Promise<any>;
-        /**
-         * @name commentsDetail
-         * @request GET:/repos/{owner}/{repo}/comments
-         * @description List commit comments for a repository. Comments are ordered by ascending ID.
-         */
-        commentsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<RepoComments>;
-        /**
-         * @name commentsDelete
-         * @request DELETE:/repos/{owner}/{repo}/comments/{commentId}
-         * @description Delete a commit comment
-         */
-        commentsDelete: (owner: string, repo: string, commentId: number, params?: RequestParams) => Promise<any>;
-        /**
-         * @name commentsDetail
-         * @request GET:/repos/{owner}/{repo}/comments/{commentId}
-         * @description Get a single commit comment.
-         * @originalName commentsDetail
-         * @duplicate
-         */
-        commentsDetail2: (owner: string, repo: string, commentId: number, params?: RequestParams) => Promise<CommitComment>;
-        /**
-         * @name commentsPartialUpdate
-         * @request PATCH:/repos/{owner}/{repo}/comments/{commentId}
-         * @description Update a commit comment.
-         */
-        commentsPartialUpdate: (owner: string, repo: string, commentId: number, body: CommentBody, params?: RequestParams) => Promise<CommitComment>;
-        /**
-         * @name commitsDetail
-         * @request GET:/repos/{owner}/{repo}/commits
-         * @description List commits on a repository.
-         */
-        commitsDetail: (owner: string, repo: string, query?: {
-            since?: string;
-            sha?: string;
-            path?: string;
-            author?: string;
-            until?: string;
-        }, params?: RequestParams) => Promise<Commits>;
-        /**
-         * @name commitsStatusDetail
-         * @request GET:/repos/{owner}/{repo}/commits/{ref}/status
-         * @description Get the combined Status for a specific Ref The Combined status endpoint is currently available for developers to preview. During the preview period, the API may change without advance notice. Please see the blog post for full details. To access this endpoint during the preview period, you must provide a custom media type in the Accept header: application/vnd.github.she-hulk-preview+json
-         */
-        commitsStatusDetail: (owner: string, repo: string, ref: string, params?: RequestParams) => Promise<RefStatus>;
-        /**
-         * @name commitsDetail
-         * @request GET:/repos/{owner}/{repo}/commits/{shaCode}
-         * @description Get a single commit.
-         * @originalName commitsDetail
-         * @duplicate
-         */
-        commitsDetail2: (owner: string, repo: string, shaCode: string, params?: RequestParams) => Promise<Commit>;
-        /**
-         * @name commitsCommentsDetail
-         * @request GET:/repos/{owner}/{repo}/commits/{shaCode}/comments
-         * @description List comments for a single commitList comments for a single commit.
-         */
-        commitsCommentsDetail: (owner: string, repo: string, shaCode: string, params?: RequestParams) => Promise<RepoComments>;
-        /**
-         * @name commitsCommentsCreate
-         * @request POST:/repos/{owner}/{repo}/commits/{shaCode}/comments
-         * @description Create a commit comment.
-         */
-        commitsCommentsCreate: (owner: string, repo: string, shaCode: string, body: CommitCommentBody, params?: RequestParams) => Promise<CommitComment>;
-        /**
-         * @name compareDetail
-         * @request GET:/repos/{owner}/{repo}/compare/{baseId}...{headId}
-         * @description Compare two commits
-         */
-        compareDetail: (owner: string, repo: string, baseId: string, headId: string, params?: RequestParams) => Promise<CompareCommits>;
-        /**
-         * @name contentsDelete
-         * @request DELETE:/repos/{owner}/{repo}/contents/{path}
-         * @description Delete a file. This method deletes a file in a repository.
-         */
-        contentsDelete: (owner: string, repo: string, path: string, body: DeleteFileBody, params?: RequestParams) => Promise<DeleteFile>;
-        /**
-         * @name contentsDetail
-         * @request GET:/repos/{owner}/{repo}/contents/{path}
-         * @description Get contents. This method returns the contents of a file or directory in a repository. Files and symlinks support a custom media type for getting the raw content. Directories and submodules do not support custom media types. Note: This API supports files up to 1 megabyte in size. Here can be many outcomes. For details see "http://developer.github.com/v3/repos/contents/"
-         */
-        contentsDetail: (owner: string, repo: string, path: string, query?: {
-            path?: string;
-            ref?: string;
-        }, params?: RequestParams) => Promise<ContentsPath>;
-        /**
-         * @name contentsUpdate
-         * @request PUT:/repos/{owner}/{repo}/contents/{path}
-         * @description Create a file.
-         */
-        contentsUpdate: (owner: string, repo: string, path: string, body: CreateFileBody, params?: RequestParams) => Promise<CreateFile>;
-        /**
-         * @name contributorsDetail
-         * @request GET:/repos/{owner}/{repo}/contributors
-         * @description Get list of contributors.
-         */
-        contributorsDetail: (owner: string, repo: string, query: {
-            anon: string;
-        }, params?: RequestParams) => Promise<Users>;
-        /**
-         * @name deploymentsDetail
-         * @request GET:/repos/{owner}/{repo}/deployments
-         * @description Users with pull access can view deployments for a repository
-         */
-        deploymentsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<RepoDeployments>;
-        /**
-         * @name deploymentsCreate
-         * @request POST:/repos/{owner}/{repo}/deployments
-         * @description Users with push access can create a deployment for a given ref
-         */
-        deploymentsCreate: (owner: string, repo: string, body: Deployment, params?: RequestParams) => Promise<DeploymentResp>;
-        /**
-         * @name deploymentsStatusesDetail
-         * @request GET:/repos/{owner}/{repo}/deployments/{id}/statuses
-         * @description Users with pull access can view deployment statuses for a deployment
-         */
-        deploymentsStatusesDetail: (owner: string, repo: string, id: number, params?: RequestParams) => Promise<DeploymentStatuses>;
-        /**
-         * @name deploymentsStatusesCreate
-         * @request POST:/repos/{owner}/{repo}/deployments/{id}/statuses
-         * @description Create a Deployment Status Users with push access can create deployment statuses for a given deployment:
-         */
-        deploymentsStatusesCreate: (owner: string, repo: string, id: number, body: DeploymentStatusesCreate, params?: RequestParams) => Promise<any>;
-        /**
-         * @name downloadsDetail
-         * @request GET:/repos/{owner}/{repo}/downloads
-         * @description Deprecated. List downloads for a repository.
-         */
-        downloadsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Downloads>;
-        /**
-         * @name downloadsDelete
-         * @request DELETE:/repos/{owner}/{repo}/downloads/{downloadId}
-         * @description Deprecated. Delete a download.
-         */
-        downloadsDelete: (owner: string, repo: string, downloadId: number, params?: RequestParams) => Promise<any>;
-        /**
-         * @name downloadsDetail
-         * @request GET:/repos/{owner}/{repo}/downloads/{downloadId}
-         * @description Deprecated. Get a single download.
-         * @originalName downloadsDetail
-         * @duplicate
-         */
-        downloadsDetail2: (owner: string, repo: string, downloadId: number, params?: RequestParams) => Promise<Download>;
-        /**
-         * @name eventsDetail
-         * @request GET:/repos/{owner}/{repo}/events
-         * @description Get list of repository events.
-         */
-        eventsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Events>;
-        /**
-         * @name forksDetail
-         * @request GET:/repos/{owner}/{repo}/forks
-         * @description List forks.
-         */
-        forksDetail: (owner: string, repo: string, query?: {
-            sort?: "newes" | "oldes" | "watchers";
-        }, params?: RequestParams) => Promise<Repos>;
-        /**
-         * @name forksCreate
-         * @request POST:/repos/{owner}/{repo}/forks
-         * @description Create a fork. Forking a Repository happens asynchronously. Therefore, you may have to wai a short period before accessing the git objects. If this takes longer than 5 minutes, be sure to contact Support.
-         */
-        forksCreate: (owner: string, repo: string, body: ForkBody, params?: RequestParams) => Promise<Repo>;
-        /**
-         * @name gitBlobsCreate
-         * @request POST:/repos/{owner}/{repo}/git/blobs
-         * @description Create a Blob.
-         */
-        gitBlobsCreate: (owner: string, repo: string, body: Blob, params?: RequestParams) => Promise<Blobs>;
-        /**
-         * @name gitBlobsDetail
-         * @request GET:/repos/{owner}/{repo}/git/blobs/{shaCode}
-         * @description Get a Blob. Since blobs can be any arbitrary binary data, the input and responses for the blob API takes an encoding parameter that can be either utf-8 or base64. If your data cannot be losslessly sent as a UTF-8 string, you can base64 encode it.
-         */
-        gitBlobsDetail: (owner: string, repo: string, shaCode: string, params?: RequestParams) => Promise<Blob>;
-        /**
-         * @name gitCommitsCreate
-         * @request POST:/repos/{owner}/{repo}/git/commits
-         * @description Create a Commit.
-         */
-        gitCommitsCreate: (owner: string, repo: string, body: RepoCommitBody, params?: RequestParams) => Promise<GitCommit>;
-        /**
-         * @name gitCommitsDetail
-         * @request GET:/repos/{owner}/{repo}/git/commits/{shaCode}
-         * @description Get a Commit.
-         */
-        gitCommitsDetail: (owner: string, repo: string, shaCode: string, params?: RequestParams) => Promise<RepoCommit>;
-        /**
-         * @name gitRefsDetail
-         * @request GET:/repos/{owner}/{repo}/git/refs
-         * @description Get all References
-         */
-        gitRefsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Refs>;
-        /**
-         * @name gitRefsCreate
-         * @request POST:/repos/{owner}/{repo}/git/refs
-         * @description Create a Reference
-         */
-        gitRefsCreate: (owner: string, repo: string, body: RefsBody, params?: RequestParams) => Promise<HeadBranch>;
-        /**
-         * @name gitRefsDelete
-         * @request DELETE:/repos/{owner}/{repo}/git/refs/{ref}
-         * @description Delete a Reference Example: Deleting a branch: DELETE /repos/octocat/Hello-World/git/refs/heads/feature-a Example: Deleting a tag:        DELETE /repos/octocat/Hello-World/git/refs/tags/v1.0
-         */
-        gitRefsDelete: (owner: string, repo: string, ref: string, params?: RequestParams) => Promise<any>;
-        /**
-         * @name gitRefsDetail
-         * @request GET:/repos/{owner}/{repo}/git/refs/{ref}
-         * @description Get a Reference
-         * @originalName gitRefsDetail
-         * @duplicate
-         */
-        gitRefsDetail2: (owner: string, repo: string, ref: string, params?: RequestParams) => Promise<HeadBranch>;
-        /**
-         * @name gitRefsPartialUpdate
-         * @request PATCH:/repos/{owner}/{repo}/git/refs/{ref}
-         * @description Update a Reference
-         */
-        gitRefsPartialUpdate: (owner: string, repo: string, ref: string, body: GitRefPatch, params?: RequestParams) => Promise<HeadBranch>;
-        /**
-         * @name gitTagsCreate
-         * @request POST:/repos/{owner}/{repo}/git/tags
-         * @description Create a Tag Object. Note that creating a tag object does not create the reference that makes a tag in Git. If you want to create an annotated tag in Git, you have to do this call to create the tag object, and then create the refs/tags/[tag] reference. If you want to create a lightweight tag, you only have to create the tag reference - this call would be unnecessary.
-         */
-        gitTagsCreate: (owner: string, repo: string, body: TagBody, params?: RequestParams) => Promise<Tag>;
-        /**
-         * @name gitTagsDetail
-         * @request GET:/repos/{owner}/{repo}/git/tags/{shaCode}
-         * @description Get a Tag.
-         */
-        gitTagsDetail: (owner: string, repo: string, shaCode: string, params?: RequestParams) => Promise<Tag>;
-        /**
-         * @name gitTreesCreate
-         * @request POST:/repos/{owner}/{repo}/git/trees
-         * @description Create a Tree. The tree creation API will take nested entries as well. If both a tree and a nested path modifying that tree are specified, it will overwrite the contents of that tree with the new path contents and write a new tree out.
-         */
-        gitTreesCreate: (owner: string, repo: string, body: Tree, params?: RequestParams) => Promise<Trees>;
-        /**
-         * @name gitTreesDetail
-         * @request GET:/repos/{owner}/{repo}/git/trees/{shaCode}
-         * @description Get a Tree.
-         */
-        gitTreesDetail: (owner: string, repo: string, shaCode: string, query?: {
-            recursive?: number;
-        }, params?: RequestParams) => Promise<Tree>;
-        /**
-         * @name hooksDetail
-         * @request GET:/repos/{owner}/{repo}/hooks
-         * @description Get list of hooks.
-         */
-        hooksDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Hook>;
-        /**
-         * @name hooksCreate
-         * @request POST:/repos/{owner}/{repo}/hooks
-         * @description Create a hook.
-         */
-        hooksCreate: (owner: string, repo: string, body: HookBody, params?: RequestParams) => Promise<Hook>;
-        /**
-         * @name hooksDelete
-         * @request DELETE:/repos/{owner}/{repo}/hooks/{hookId}
-         * @description Delete a hook.
-         */
-        hooksDelete: (owner: string, repo: string, hookId: number, params?: RequestParams) => Promise<any>;
-        /**
-         * @name hooksDetail
-         * @request GET:/repos/{owner}/{repo}/hooks/{hookId}
-         * @description Get single hook.
-         * @originalName hooksDetail
-         * @duplicate
-         */
-        hooksDetail2: (owner: string, repo: string, hookId: number, params?: RequestParams) => Promise<Hook>;
-        /**
-         * @name hooksPartialUpdate
-         * @request PATCH:/repos/{owner}/{repo}/hooks/{hookId}
-         * @description Edit a hook.
-         */
-        hooksPartialUpdate: (owner: string, repo: string, hookId: number, body: HookBody, params?: RequestParams) => Promise<Hook>;
-        /**
-         * @name hooksTestsCreate
-         * @request POST:/repos/{owner}/{repo}/hooks/{hookId}/tests
-         * @description Test a push hook. This will trigger the hook with the latest push to the current repository if the hook is subscribed to push events. If the hook is not subscribed to push events, the server will respond with 204 but no test POST will be generated. Note: Previously /repos/:owner/:repo/hooks/:id/tes
-         */
-        hooksTestsCreate: (owner: string, repo: string, hookId: number, params?: RequestParams) => Promise<any>;
-        /**
-         * @name issuesDetail
-         * @request GET:/repos/{owner}/{repo}/issues
-         * @description List issues for a repository.
-         */
-        issuesDetail: (owner: string, repo: string, query: {
-            filter: "assigned" | "created" | "mentioned" | "subscribed" | "all";
-            state: "open" | "closed";
-            labels: string;
-            sort: "created" | "updated" | "comments";
-            direction: "asc" | "desc";
-            since?: string;
-        }, params?: RequestParams) => Promise<Issues>;
-        /**
-         * @name issuesCreate
-         * @request POST:/repos/{owner}/{repo}/issues
-         * @description Create an issue. Any user with pull access to a repository can create an issue.
-         */
-        issuesCreate: (owner: string, repo: string, body: Issue, params?: RequestParams) => Promise<Issue>;
-        /**
-         * @name issuesCommentsDetail
-         * @request GET:/repos/{owner}/{repo}/issues/comments
-         * @description List comments in a repository.
-         */
-        issuesCommentsDetail: (owner: string, repo: string, query?: {
-            direction?: string;
-            sort?: "created" | "updated";
-            since?: string;
-        }, params?: RequestParams) => Promise<IssuesComments>;
-        /**
-         * @name issuesCommentsDelete
-         * @request DELETE:/repos/{owner}/{repo}/issues/comments/{commentId}
-         * @description Delete a comment.
-         */
-        issuesCommentsDelete: (owner: string, repo: string, commentId: number, params?: RequestParams) => Promise<any>;
-        /**
-         * @name issuesCommentsDetail
-         * @request GET:/repos/{owner}/{repo}/issues/comments/{commentId}
-         * @description Get a single comment.
-         * @originalName issuesCommentsDetail
-         * @duplicate
-         */
-        issuesCommentsDetail2: (owner: string, repo: string, commentId: number, params?: RequestParams) => Promise<IssuesComment>;
-        /**
-         * @name issuesCommentsPartialUpdate
-         * @request PATCH:/repos/{owner}/{repo}/issues/comments/{commentId}
-         * @description Edit a comment.
-         */
-        issuesCommentsPartialUpdate: (owner: string, repo: string, commentId: number, body: CommentBody, params?: RequestParams) => Promise<IssuesComment>;
-        /**
-         * @name issuesEventsDetail
-         * @request GET:/repos/{owner}/{repo}/issues/events
-         * @description List issue events for a repository.
-         */
-        issuesEventsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<IssueEvents>;
-        /**
-         * @name issuesEventsDetail
-         * @request GET:/repos/{owner}/{repo}/issues/events/{eventId}
-         * @description Get a single event.
-         * @originalName issuesEventsDetail
-         * @duplicate
-         */
-        issuesEventsDetail2: (owner: string, repo: string, eventId: number, params?: RequestParams) => Promise<IssueEvent>;
-        /**
-         * @name issuesDetail
-         * @request GET:/repos/{owner}/{repo}/issues/{number}
-         * @description Get a single issue
-         * @originalName issuesDetail
-         * @duplicate
-         */
-        issuesDetail2: (owner: string, repo: string, number: number, params?: RequestParams) => Promise<Issue>;
-        /**
-         * @name issuesPartialUpdate
-         * @request PATCH:/repos/{owner}/{repo}/issues/{number}
-         * @description Edit an issue. Issue owners and users with push access can edit an issue.
-         */
-        issuesPartialUpdate: (owner: string, repo: string, number: number, body: Issue, params?: RequestParams) => Promise<Issue>;
-        /**
-         * @name issuesCommentsDetail
-         * @request GET:/repos/{owner}/{repo}/issues/{number}/comments
-         * @description List comments on an issue.
-         * @originalName issuesCommentsDetail
-         * @duplicate
-         */
-        issuesCommentsDetail3: (owner: string, repo: string, number: number, params?: RequestParams) => Promise<IssuesComments>;
-        /**
-         * @name issuesCommentsCreate
-         * @request POST:/repos/{owner}/{repo}/issues/{number}/comments
-         * @description Create a comment.
-         */
-        issuesCommentsCreate: (owner: string, repo: string, number: number, body: CommentBody, params?: RequestParams) => Promise<IssuesComment>;
-        /**
-         * @name issuesEventsDetail
-         * @request GET:/repos/{owner}/{repo}/issues/{number}/events
-         * @description List events for an issue.
-         * @originalName issuesEventsDetail
-         * @duplicate
-         */
-        issuesEventsDetail3: (owner: string, repo: string, number: number, params?: RequestParams) => Promise<IssueEvents>;
-        /**
-         * @name issuesLabelsDelete
-         * @request DELETE:/repos/{owner}/{repo}/issues/{number}/labels
-         * @description Remove all labels from an issue.
-         */
-        issuesLabelsDelete: (owner: string, repo: string, number: number, params?: RequestParams) => Promise<any>;
-        /**
-         * @name issuesLabelsDetail
-         * @request GET:/repos/{owner}/{repo}/issues/{number}/labels
-         * @description List labels on an issue.
-         */
-        issuesLabelsDetail: (owner: string, repo: string, number: number, params?: RequestParams) => Promise<Labels>;
-        /**
-         * @name issuesLabelsCreate
-         * @request POST:/repos/{owner}/{repo}/issues/{number}/labels
-         * @description Add labels to an issue.
-         */
-        issuesLabelsCreate: (owner: string, repo: string, number: number, body: EmailsPost, params?: RequestParams) => Promise<Label>;
-        /**
-         * @name issuesLabelsUpdate
-         * @request PUT:/repos/{owner}/{repo}/issues/{number}/labels
-         * @description Replace all labels for an issue. Sending an empty array ([]) will remove all Labels from the Issue.
-         */
-        issuesLabelsUpdate: (owner: string, repo: string, number: number, body: EmailsPost, params?: RequestParams) => Promise<Label>;
-        /**
-         * @name issuesLabelsDelete
-         * @request DELETE:/repos/{owner}/{repo}/issues/{number}/labels/{name}
-         * @description Remove a label from an issue.
-         * @originalName issuesLabelsDelete
-         * @duplicate
-         */
-        issuesLabelsDelete2: (owner: string, repo: string, number: number, name: string, params?: RequestParams) => Promise<any>;
-        /**
-         * @name keysDetail
-         * @request GET:/repos/{owner}/{repo}/keys
-         * @description Get list of keys.
-         */
-        keysDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Keys>;
-        /**
-         * @name keysCreate
-         * @request POST:/repos/{owner}/{repo}/keys
-         * @description Create a key.
-         */
-        keysCreate: (owner: string, repo: string, body: UserKeysPost, params?: RequestParams) => Promise<UserKeysKeyId>;
-        /**
-         * @name keysDelete
-         * @request DELETE:/repos/{owner}/{repo}/keys/{keyId}
-         * @description Delete a key.
-         */
-        keysDelete: (owner: string, repo: string, keyId: number, params?: RequestParams) => Promise<any>;
-        /**
-         * @name keysDetail
-         * @request GET:/repos/{owner}/{repo}/keys/{keyId}
-         * @description Get a key
-         * @originalName keysDetail
-         * @duplicate
-         */
-        keysDetail2: (owner: string, repo: string, keyId: number, params?: RequestParams) => Promise<UserKeysKeyId>;
-        /**
-         * @name labelsDetail
-         * @request GET:/repos/{owner}/{repo}/labels
-         * @description List all labels for this repository.
-         */
-        labelsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Labels>;
-        /**
-         * @name labelsCreate
-         * @request POST:/repos/{owner}/{repo}/labels
-         * @description Create a label.
-         */
-        labelsCreate: (owner: string, repo: string, body: EmailsPost, params?: RequestParams) => Promise<Label>;
-        /**
-         * @name labelsDelete
-         * @request DELETE:/repos/{owner}/{repo}/labels/{name}
-         * @description Delete a label.
-         */
-        labelsDelete: (owner: string, repo: string, name: string, params?: RequestParams) => Promise<any>;
-        /**
-         * @name labelsDetail
-         * @request GET:/repos/{owner}/{repo}/labels/{name}
-         * @description Get a single label.
-         * @originalName labelsDetail
-         * @duplicate
-         */
-        labelsDetail2: (owner: string, repo: string, name: string, params?: RequestParams) => Promise<Label>;
-        /**
-         * @name labelsPartialUpdate
-         * @request PATCH:/repos/{owner}/{repo}/labels/{name}
-         * @description Update a label.
-         */
-        labelsPartialUpdate: (owner: string, repo: string, name: string, body: EmailsPost, params?: RequestParams) => Promise<Label>;
-        /**
-         * @name languagesDetail
-         * @request GET:/repos/{owner}/{repo}/languages
-         * @description List languages. List languages for the specified repository. The value on the right of a language is the number of bytes of code written in that language.
-         */
-        languagesDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Record<string, number>>;
-        /**
-         * @name mergesCreate
-         * @request POST:/repos/{owner}/{repo}/merges
-         * @description Perform a merge.
-         */
-        mergesCreate: (owner: string, repo: string, body: MergesBody, params?: RequestParams) => Promise<MergesSuccessful>;
-        /**
-         * @name milestonesDetail
-         * @request GET:/repos/{owner}/{repo}/milestones
-         * @description List milestones for a repository.
-         */
-        milestonesDetail: (owner: string, repo: string, query?: {
-            state?: "open" | "closed";
-            direction?: string;
-            sort?: "due_date" | "completeness";
-        }, params?: RequestParams) => Promise<Milestone>;
-        /**
-         * @name milestonesCreate
-         * @request POST:/repos/{owner}/{repo}/milestones
-         * @description Create a milestone.
-         */
-        milestonesCreate: (owner: string, repo: string, body: MilestoneUpdate, params?: RequestParams) => Promise<Milestone>;
-        /**
-         * @name milestonesDelete
-         * @request DELETE:/repos/{owner}/{repo}/milestones/{number}
-         * @description Delete a milestone.
-         */
-        milestonesDelete: (owner: string, repo: string, number: number, params?: RequestParams) => Promise<any>;
-        /**
-         * @name milestonesDetail
-         * @request GET:/repos/{owner}/{repo}/milestones/{number}
-         * @description Get a single milestone.
-         * @originalName milestonesDetail
-         * @duplicate
-         */
-        milestonesDetail2: (owner: string, repo: string, number: number, params?: RequestParams) => Promise<Milestone>;
-        /**
-         * @name milestonesPartialUpdate
-         * @request PATCH:/repos/{owner}/{repo}/milestones/{number}
-         * @description Update a milestone.
-         */
-        milestonesPartialUpdate: (owner: string, repo: string, number: number, body: MilestoneUpdate, params?: RequestParams) => Promise<Milestone>;
-        /**
-         * @name milestonesLabelsDetail
-         * @request GET:/repos/{owner}/{repo}/milestones/{number}/labels
-         * @description Get labels for every issue in a milestone.
-         */
-        milestonesLabelsDetail: (owner: string, repo: string, number: number, params?: RequestParams) => Promise<Labels>;
-        /**
-         * @name notificationsDetail
-         * @request GET:/repos/{owner}/{repo}/notifications
-         * @description List your notifications in a repository List all notifications for the current user.
-         */
-        notificationsDetail: (owner: string, repo: string, query?: {
-            all?: boolean;
-            participating?: boolean;
-            since?: string;
-        }, params?: RequestParams) => Promise<Notifications>;
-        /**
-         * @name notificationsUpdate
-         * @request PUT:/repos/{owner}/{repo}/notifications
-         * @description Mark notifications as read in a repository. Marking all notifications in a repository as "read" removes them from the default view on GitHub.com.
-         */
-        notificationsUpdate: (owner: string, repo: string, body: NotificationMarkRead, params?: RequestParams) => Promise<any>;
-        /**
-         * @name pullsDetail
-         * @request GET:/repos/{owner}/{repo}/pulls
-         * @description List pull requests.
-         */
-        pullsDetail: (owner: string, repo: string, query?: {
-            state?: "open" | "closed";
-            head?: string;
-            base?: string;
-        }, params?: RequestParams) => Promise<Pulls>;
-        /**
-         * @name pullsCreate
-         * @request POST:/repos/{owner}/{repo}/pulls
-         * @description Create a pull request.
-         */
-        pullsCreate: (owner: string, repo: string, body: PullsPost, params?: RequestParams) => Promise<Pulls>;
-        /**
-         * @name pullsCommentsDetail
-         * @request GET:/repos/{owner}/{repo}/pulls/comments
-         * @description List comments in a repository. By default, Review Comments are ordered by ascending ID.
-         */
-        pullsCommentsDetail: (owner: string, repo: string, query?: {
-            direction?: string;
-            sort?: "created" | "updated";
-            since?: string;
-        }, params?: RequestParams) => Promise<IssuesComments>;
-        /**
-         * @name pullsCommentsDelete
-         * @request DELETE:/repos/{owner}/{repo}/pulls/comments/{commentId}
-         * @description Delete a comment.
-         */
-        pullsCommentsDelete: (owner: string, repo: string, commentId: number, params?: RequestParams) => Promise<any>;
-        /**
-         * @name pullsCommentsDetail
-         * @request GET:/repos/{owner}/{repo}/pulls/comments/{commentId}
-         * @description Get a single comment.
-         * @originalName pullsCommentsDetail
-         * @duplicate
-         */
-        pullsCommentsDetail2: (owner: string, repo: string, commentId: number, params?: RequestParams) => Promise<PullsComment>;
-        /**
-         * @name pullsCommentsPartialUpdate
-         * @request PATCH:/repos/{owner}/{repo}/pulls/comments/{commentId}
-         * @description Edit a comment.
-         */
-        pullsCommentsPartialUpdate: (owner: string, repo: string, commentId: number, body: CommentBody, params?: RequestParams) => Promise<PullsComment>;
-        /**
-         * @name pullsDetail
-         * @request GET:/repos/{owner}/{repo}/pulls/{number}
-         * @description Get a single pull request.
-         * @originalName pullsDetail
-         * @duplicate
-         */
-        pullsDetail2: (owner: string, repo: string, number: number, params?: RequestParams) => Promise<PullRequest>;
-        /**
-         * @name pullsPartialUpdate
-         * @request PATCH:/repos/{owner}/{repo}/pulls/{number}
-         * @description Update a pull request.
-         */
-        pullsPartialUpdate: (owner: string, repo: string, number: number, body: PullUpdate, params?: RequestParams) => Promise<Repo>;
-        /**
-         * @name pullsCommentsDetail
-         * @request GET:/repos/{owner}/{repo}/pulls/{number}/comments
-         * @description List comments on a pull request.
-         * @originalName pullsCommentsDetail
-         * @duplicate
-         */
-        pullsCommentsDetail3: (owner: string, repo: string, number: number, params?: RequestParams) => Promise<PullsComment>;
-        /**
-         * @name pullsCommentsCreate
-         * @request POST:/repos/{owner}/{repo}/pulls/{number}/comments
-         * @description Create a comment. #TODO Alternative input ( http://developer.github.com/v3/pulls/comments/ ) description: | Alternative Input. Instead of passing commit_id, path, and position you can reply to an existing Pull Request Comment like this: body Required string in_reply_to Required number - Comment id to reply to.
-         */
-        pullsCommentsCreate: (owner: string, repo: string, number: number, body: PullsCommentPost, params?: RequestParams) => Promise<PullsComment>;
-        /**
-         * @name pullsCommitsDetail
-         * @request GET:/repos/{owner}/{repo}/pulls/{number}/commits
-         * @description List commits on a pull request.
-         */
-        pullsCommitsDetail: (owner: string, repo: string, number: number, params?: RequestParams) => Promise<Commits>;
-        /**
-         * @name pullsFilesDetail
-         * @request GET:/repos/{owner}/{repo}/pulls/{number}/files
-         * @description List pull requests files.
-         */
-        pullsFilesDetail: (owner: string, repo: string, number: number, params?: RequestParams) => Promise<Pulls>;
-        /**
-         * @name pullsMergeDetail
-         * @request GET:/repos/{owner}/{repo}/pulls/{number}/merge
-         * @description Get if a pull request has been merged.
-         */
-        pullsMergeDetail: (owner: string, repo: string, number: number, params?: RequestParams) => Promise<any>;
-        /**
-         * @name pullsMergeUpdate
-         * @request PUT:/repos/{owner}/{repo}/pulls/{number}/merge
-         * @description Merge a pull request (Merge Button's)
-         */
-        pullsMergeUpdate: (owner: string, repo: string, number: number, body: MergePullBody, params?: RequestParams) => Promise<Merge>;
-        /**
-         * @name readmeDetail
-         * @request GET:/repos/{owner}/{repo}/readme
-         * @description Get the README. This method returns the preferred README for a repository.
-         */
-        readmeDetail: (owner: string, repo: string, query?: {
-            ref?: string;
-        }, params?: RequestParams) => Promise<ContentsPath>;
-        /**
-         * @name releasesDetail
-         * @request GET:/repos/{owner}/{repo}/releases
-         * @description Users with push access to the repository will receive all releases (i.e., published releases and draft releases). Users with pull access will receive published releases only
-         */
-        releasesDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Releases>;
-        /**
-         * @name releasesCreate
-         * @request POST:/repos/{owner}/{repo}/releases
-         * @description Create a release Users with push access to the repository can create a release.
-         */
-        releasesCreate: (owner: string, repo: string, body: ReleaseCreate, params?: RequestParams) => Promise<Release>;
-        /**
-         * @name releasesAssetsDelete
-         * @request DELETE:/repos/{owner}/{repo}/releases/assets/{id}
-         * @description Delete a release asset
-         */
-        releasesAssetsDelete: (owner: string, repo: string, id: string, params?: RequestParams) => Promise<any>;
-        /**
-         * @name releasesAssetsDetail
-         * @request GET:/repos/{owner}/{repo}/releases/assets/{id}
-         * @description Get a single release asset
-         */
-        releasesAssetsDetail: (owner: string, repo: string, id: string, params?: RequestParams) => Promise<Asset>;
-        /**
-         * @name releasesAssetsPartialUpdate
-         * @request PATCH:/repos/{owner}/{repo}/releases/assets/{id}
-         * @description Edit a release asset Users with push access to the repository can edit a release asset.
-         */
-        releasesAssetsPartialUpdate: (owner: string, repo: string, id: string, body: AssetPatch, params?: RequestParams) => Promise<Asset>;
-        /**
-         * @name releasesDelete
-         * @request DELETE:/repos/{owner}/{repo}/releases/{id}
-         * @description Users with push access to the repository can delete a release.
-         */
-        releasesDelete: (owner: string, repo: string, id: string, params?: RequestParams) => Promise<any>;
-        /**
-         * @name releasesDetail
-         * @request GET:/repos/{owner}/{repo}/releases/{id}
-         * @description Get a single release
-         * @originalName releasesDetail
-         * @duplicate
-         */
-        releasesDetail2: (owner: string, repo: string, id: string, params?: RequestParams) => Promise<Release>;
-        /**
-         * @name releasesPartialUpdate
-         * @request PATCH:/repos/{owner}/{repo}/releases/{id}
-         * @description Users with push access to the repository can edit a release
-         */
-        releasesPartialUpdate: (owner: string, repo: string, id: string, body: ReleaseCreate, params?: RequestParams) => Promise<Release>;
-        /**
-         * @name releasesAssetsDetail
-         * @request GET:/repos/{owner}/{repo}/releases/{id}/assets
-         * @description List assets for a release
-         * @originalName releasesAssetsDetail
-         * @duplicate
-         */
-        releasesAssetsDetail2: (owner: string, repo: string, id: string, params?: RequestParams) => Promise<Assets>;
-        /**
-         * @name stargazersDetail
-         * @request GET:/repos/{owner}/{repo}/stargazers
-         * @description List Stargazers.
-         */
-        stargazersDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Users>;
-        /**
-         * @name statsCodeFrequencyDetail
-         * @request GET:/repos/{owner}/{repo}/stats/code_frequency
-         * @description Get the number of additions and deletions per week. Returns a weekly aggregate of the number of additions and deletions pushed to a repository.
-         */
-        statsCodeFrequencyDetail: (owner: string, repo: string, params?: RequestParams) => Promise<CodeFrequencyStats>;
-        /**
-         * @name statsCommitActivityDetail
-         * @request GET:/repos/{owner}/{repo}/stats/commit_activity
-         * @description Get the last year of commit activity data. Returns the last year of commit activity grouped by week. The days array is a group of commits per day, starting on Sunday.
-         */
-        statsCommitActivityDetail: (owner: string, repo: string, params?: RequestParams) => Promise<CommitActivityStats>;
-        /**
-         * @name statsContributorsDetail
-         * @request GET:/repos/{owner}/{repo}/stats/contributors
-         * @description Get contributors list with additions, deletions, and commit counts.
-         */
-        statsContributorsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<ContributorsStats>;
-        /**
-         * @name statsParticipationDetail
-         * @request GET:/repos/{owner}/{repo}/stats/participation
-         * @description Get the weekly commit count for the repo owner and everyone else.
-         */
-        statsParticipationDetail: (owner: string, repo: string, params?: RequestParams) => Promise<ParticipationStats>;
-        /**
-         * @name statsPunchCardDetail
-         * @request GET:/repos/{owner}/{repo}/stats/punch_card
-         * @description Get the number of commits per hour in each day. Each array contains the day number, hour number, and number of commits 0-6 Sunday - Saturday 0-23 Hour of day Number of commits For example, [2, 14, 25] indicates that there were 25 total commits, during the 2.00pm hour on Tuesdays. All times are based on the time zone of individual commits.
-         */
-        statsPunchCardDetail: (owner: string, repo: string, params?: RequestParams) => Promise<CodeFrequencyStats>;
-        /**
-         * @name statusesDetail
-         * @request GET:/repos/{owner}/{repo}/statuses/{ref}
-         * @description List Statuses for a specific Ref.
-         */
-        statusesDetail: (owner: string, repo: string, ref: string, params?: RequestParams) => Promise<Ref>;
-        /**
-         * @name statusesCreate
-         * @request POST:/repos/{owner}/{repo}/statuses/{ref}
-         * @description Create a Status.
-         */
-        statusesCreate: (owner: string, repo: string, ref: string, body: HeadBranch, params?: RequestParams) => Promise<Ref>;
-        /**
-         * @name subscribersDetail
-         * @request GET:/repos/{owner}/{repo}/subscribers
-         * @description List watchers.
-         */
-        subscribersDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Users>;
-        /**
-         * @name subscriptionDelete
-         * @request DELETE:/repos/{owner}/{repo}/subscription
-         * @description Delete a Repository Subscription.
-         */
-        subscriptionDelete: (owner: string, repo: string, params?: RequestParams) => Promise<any>;
-        /**
-         * @name subscriptionDetail
-         * @request GET:/repos/{owner}/{repo}/subscription
-         * @description Get a Repository Subscription.
-         */
-        subscriptionDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Subscription>;
-        /**
-         * @name subscriptionUpdate
-         * @request PUT:/repos/{owner}/{repo}/subscription
-         * @description Set a Repository Subscription
-         */
-        subscriptionUpdate: (owner: string, repo: string, body: SubscriptionBody, params?: RequestParams) => Promise<Subscription>;
-        /**
-         * @name tagsDetail
-         * @request GET:/repos/{owner}/{repo}/tags
-         * @description Get list of tags.
-         */
-        tagsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Tags>;
-        /**
-         * @name teamsDetail
-         * @request GET:/repos/{owner}/{repo}/teams
-         * @description Get list of teams
-         */
-        teamsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Teams>;
-        /**
-         * @name watchersDetail
-         * @request GET:/repos/{owner}/{repo}/watchers
-         * @description List Stargazers. New implementation.
-         */
-        watchersDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Users>;
-        /**
-         * @name reposDetail
-         * @request GET:/repos/{owner}/{repo}/{archive_format}/{path}
-         * @description Get archive link. This method will return a 302 to a URL to download a tarball or zipball archive for a repository. Please make sure your HTTP framework is configured to follow redirects or you will need to use the Location header to make a second GET request. Note: For private repositories, these links are temporary and expire quickly.
-         * @originalName reposDetail
-         * @duplicate
-         */
-        reposDetail2: (owner: string, repo: string, archive_format: "tarball" | "zipball", path: string, params?: RequestParams) => Promise<any>;
-    };
-    repositories: {
-        /**
-         * @name repositoriesList
-         * @request GET:/repositories
-         * @description List all public repositories. This provides a dump of every public repository, in the order that they were created. Note: Pagination is powered exclusively by the since parameter. is the Link header to get the URL for the next page of repositories.
-         */
-        repositoriesList: (query?: {
-            since?: string;
-        }, params?: RequestParams) => Promise<Repos>;
-    };
-    search: {
-        /**
-         * @name codeList
-         * @request GET:/search/code
-         * @description Search code.
-         */
-        codeList: (query: {
-            order?: "desc" | "asc";
-            q: string;
-            sort?: "indexed";
-        }, params?: RequestParams) => Promise<SearchCode>;
-        /**
-         * @name issuesList
-         * @request GET:/search/issues
-         * @description Find issues by state and keyword. (This method returns up to 100 results per page.)
-         */
-        issuesList: (query: {
-            order?: "desc" | "asc";
-            q: string;
-            sort?: "updated" | "created" | "comments";
-        }, params?: RequestParams) => Promise<SearchIssues>;
-        /**
-         * @name repositoriesList
-         * @request GET:/search/repositories
-         * @description Search repositories.
-         */
-        repositoriesList: (query: {
-            order?: "desc" | "asc";
-            q: string;
-            sort?: "stars" | "forks" | "updated";
-        }, params?: RequestParams) => Promise<SearchRepositories>;
-        /**
-         * @name usersList
-         * @request GET:/search/users
-         * @description Search users.
-         */
-        usersList: (query: {
-            order?: "desc" | "asc";
-            q: string;
-            sort?: "followers" | "repositories" | "joined";
-        }, params?: RequestParams) => Promise<SearchUsers>;
-    };
-    teams: {
-        /**
-         * @name teamsDelete
-         * @request DELETE:/teams/{teamId}
-         * @description Delete team. In order to delete a team, the authenticated user must be an owner of the org that the team is associated with.
-         */
-        teamsDelete: (teamId: number, params?: RequestParams) => Promise<any>;
-        /**
-         * @name teamsDetail
-         * @request GET:/teams/{teamId}
-         * @description Get team.
-         */
-        teamsDetail: (teamId: number, params?: RequestParams) => Promise<Team>;
-        /**
-         * @name teamsPartialUpdate
-         * @request PATCH:/teams/{teamId}
-         * @description Edit team. In order to edit a team, the authenticated user must be an owner of the org that the team is associated with.
-         */
-        teamsPartialUpdate: (teamId: number, body: EditTeam, params?: RequestParams) => Promise<Team>;
-        /**
-         * @name membersDetail
-         * @request GET:/teams/{teamId}/members
-         * @description List team members. In order to list members in a team, the authenticated user must be a member of the team.
-         */
-        membersDetail: (teamId: number, params?: RequestParams) => Promise<Users>;
-        /**
-         * @name membersDelete
-         * @request DELETE:/teams/{teamId}/members/{username}
-         * @description The "Remove team member" API is deprecated and is scheduled for removal in the next major version of the API. We recommend using the Remove team membership API instead. It allows you to remove both active and pending memberships. Remove team member. In order to remove a user from a team, the authenticated user must have 'admin' permissions to the team or be an owner of the org that the team is associated with. NOTE This does not delete the user, it just remove them from the team.
-         */
-        membersDelete: (teamId: number, username: string, params?: RequestParams) => Promise<any>;
-        /**
-         * @name membersDetail
-         * @request GET:/teams/{teamId}/members/{username}
-         * @description The "Get team member" API is deprecated and is scheduled for removal in the next major version of the API. We recommend using the Get team membership API instead. It allows you to get both active and pending memberships. Get team member. In order to get if a user is a member of a team, the authenticated user mus be a member of the team.
-         * @originalName membersDetail
-         * @duplicate
-         */
-        membersDetail2: (teamId: number, username: string, params?: RequestParams) => Promise<any>;
-        /**
-         * @name membersUpdate
-         * @request PUT:/teams/{teamId}/members/{username}
-         * @description The API (described below) is deprecated and is scheduled for removal in the next major version of the API. We recommend using the Add team membership API instead. It allows you to invite new organization members to your teams. Add team member. In order to add a user to a team, the authenticated user must have 'admin' permissions to the team or be an owner of the org that the team is associated with.
-         */
-        membersUpdate: (teamId: number, username: string, params?: RequestParams) => Promise<any>;
-        /**
-         * @name membershipsDelete
-         * @request DELETE:/teams/{teamId}/memberships/{username}
-         * @description Remove team membership. In order to remove a membership between a user and a team, the authenticated user must have 'admin' permissions to the team or be an owner of the organization that the team is associated with. NOTE: This does not delete the user, it just removes their membership from the team.
-         */
-        membershipsDelete: (teamId: number, username: string, params?: RequestParams) => Promise<any>;
-        /**
-         * @name membershipsDetail
-         * @request GET:/teams/{teamId}/memberships/{username}
-         * @description Get team membership. In order to get a user's membership with a team, the authenticated user must be a member of the team or an owner of the team's organization.
-         */
-        membershipsDetail: (teamId: number, username: string, params?: RequestParams) => Promise<TeamMembership>;
-        /**
-         * @name membershipsUpdate
-         * @request PUT:/teams/{teamId}/memberships/{username}
-         * @description Add team membership. In order to add a membership between a user and a team, the authenticated user must have 'admin' permissions to the team or be an owner of the organization that the team is associated with. If the user is already a part of the team's organization (meaning they're on at least one other team in the organization), this endpoint will add the user to the team. If the user is completely unaffiliated with the team's organization (meaning they're on none of the organization's teams), this endpoint will send an invitation to the user via email. This newly-created membership will be in the 'pending' state until the user accepts the invitation, at which point the membership will transition to the 'active' state and the user will be added as a member of the team.
-         */
-        membershipsUpdate: (teamId: number, username: string, params?: RequestParams) => Promise<TeamMembership>;
-        /**
-         * @name reposDetail
-         * @request GET:/teams/{teamId}/repos
-         * @description List team repos
-         */
-        reposDetail: (teamId: number, params?: RequestParams) => Promise<Repos>;
-        /**
-         * @name reposDelete
-         * @request DELETE:/teams/{teamId}/repos/{owner}/{repo}
-         * @description In order to remove a repository from a team, the authenticated user must be an owner of the org that the team is associated with. NOTE: This does not delete the repository, it just removes it from the team.
-         */
-        reposDelete: (teamId: number, owner: string, repo: string, params?: RequestParams) => Promise<any>;
-        /**
-         * @name reposDetail
-         * @request GET:/teams/{teamId}/repos/{owner}/{repo}
-         * @description Check if a team manages a repository
-         * @originalName reposDetail
-         * @duplicate
-         */
-        reposDetail2: (teamId: number, owner: string, repo: string, params?: RequestParams) => Promise<any>;
-        /**
-         * @name reposUpdate
-         * @request PUT:/teams/{teamId}/repos/{owner}/{repo}
-         * @description In order to add a repository to a team, the authenticated user must be an owner of the org that the team is associated with. Also, the repository must be owned by the organization, or a direct fork of a repository owned by the organization.
-         */
-        reposUpdate: (teamId: number, owner: string, repo: string, params?: RequestParams) => Promise<any>;
-    };
-    user: {
-        /**
-         * @name userList
-         * @request GET:/user
-         * @description Get the authenticated user.
-         */
-        userList: (params?: RequestParams) => Promise<any>;
-        /**
-         * @name userPartialUpdate
-         * @request PATCH:/user
-         * @description Update the authenticated user.
-         */
-        userPartialUpdate: (body: UserUpdate, params?: RequestParams) => Promise<any>;
-        /**
-         * @name emailsDelete
-         * @request DELETE:/user/emails
-         * @description Delete email address(es). You can include a single email address or an array of addresses.
-         */
-        emailsDelete: (body: UserEmails, params?: RequestParams) => Promise<any>;
-        /**
-         * @name emailsList
-         * @request GET:/user/emails
-         * @description List email addresses for a user. In the final version of the API, this method will return an array of hashes with extended information for each email address indicating if the address has been verified and if it's primary email address for GitHub. Until API v3 is finalized, use the application/vnd.github.v3 media type to get other response format.
-         */
-        emailsList: (params?: RequestParams) => Promise<UserEmails>;
-        /**
-         * @name emailsCreate
-         * @request POST:/user/emails
-         * @description Add email address(es). You can post a single email address or an array of addresses.
-         */
-        emailsCreate: (body: EmailsPost, params?: RequestParams) => Promise<any>;
-        /**
-         * @name followersList
-         * @request GET:/user/followers
-         * @description List the authenticated user's followers
-         */
-        followersList: (params?: RequestParams) => Promise<Users>;
-        /**
-         * @name followingList
-         * @request GET:/user/following
-         * @description List who the authenticated user is following.
-         */
-        followingList: (params?: RequestParams) => Promise<Users>;
-        /**
-         * @name followingDelete
-         * @request DELETE:/user/following/{username}
-         * @description Unfollow a user. Unfollowing a user requires the user to be logged in and authenticated with basic auth or OAuth with the user:follow scope.
-         */
-        followingDelete: (username: string, params?: RequestParams) => Promise<any>;
-        /**
-         * @name followingDetail
-         * @request GET:/user/following/{username}
-         * @description Check if you are following a user.
-         */
-        followingDetail: (username: string, params?: RequestParams) => Promise<any>;
-        /**
-         * @name followingUpdate
-         * @request PUT:/user/following/{username}
-         * @description Follow a user. Following a user requires the user to be logged in and authenticated with basic auth or OAuth with the user:follow scope.
-         */
-        followingUpdate: (username: string, params?: RequestParams) => Promise<any>;
-        /**
-         * @name issuesList
-         * @request GET:/user/issues
-         * @description List issues. List all issues across owned and member repositories for the authenticated user.
-         */
-        issuesList: (query: {
-            filter: "assigned" | "created" | "mentioned" | "subscribed" | "all";
-            state: "open" | "closed";
-            labels: string;
-            sort: "created" | "updated" | "comments";
-            direction: "asc" | "desc";
-            since?: string;
-        }, params?: RequestParams) => Promise<Issues>;
-        /**
-         * @name keysList
-         * @request GET:/user/keys
-         * @description List your public keys. Lists the current user's keys. Management of public keys via the API requires that you are authenticated through basic auth, or OAuth with the 'user', 'write:public_key' scopes.
-         */
-        keysList: (params?: RequestParams) => Promise<Gitignore>;
-        /**
-         * @name keysCreate
-         * @request POST:/user/keys
-         * @description Create a public key.
-         */
-        keysCreate: (body: UserKeysPost, params?: RequestParams) => Promise<UserKeysKeyId>;
-        /**
-         * @name keysDelete
-         * @request DELETE:/user/keys/{keyId}
-         * @description Delete a public key. Removes a public key. Requires that you are authenticated via Basic Auth or via OAuth with at least admin:public_key scope.
-         */
-        keysDelete: (keyId: number, params?: RequestParams) => Promise<any>;
-        /**
-         * @name keysDetail
-         * @request GET:/user/keys/{keyId}
-         * @description Get a single public key.
-         */
-        keysDetail: (keyId: number, params?: RequestParams) => Promise<UserKeysKeyId>;
-        /**
-         * @name orgsList
-         * @request GET:/user/orgs
-         * @description List public and private organizations for the authenticated user.
-         */
-        orgsList: (params?: RequestParams) => Promise<Gitignore>;
-        /**
-         * @name reposList
-         * @request GET:/user/repos
-         * @description List repositories for the authenticated user. Note that this does not include repositories owned by organizations which the user can access. You can lis user organizations and list organization repositories separately.
-         */
-        reposList: (query?: {
-            type?: "all" | "public" | "private" | "forks" | "sources" | "member";
-        }, params?: RequestParams) => Promise<Repos>;
-        /**
-         * @name reposCreate
-         * @request POST:/user/repos
-         * @description Create a new repository for the authenticated user. OAuth users must supply repo scope.
-         */
-        reposCreate: (body: PostRepo, params?: RequestParams) => Promise<Repos>;
-        /**
-         * @name starredList
-         * @request GET:/user/starred
-         * @description List repositories being starred by the authenticated user.
-         */
-        starredList: (query?: {
-            direction?: string;
-            sort?: "created" | "updated";
-        }, params?: RequestParams) => Promise<Gitignore>;
-        /**
-         * @name starredDelete
-         * @request DELETE:/user/starred/{owner}/{repo}
-         * @description Unstar a repository
-         */
-        starredDelete: (owner: string, repo: string, params?: RequestParams) => Promise<any>;
-        /**
-         * @name starredDetail
-         * @request GET:/user/starred/{owner}/{repo}
-         * @description Check if you are starring a repository.
-         */
-        starredDetail: (owner: string, repo: string, params?: RequestParams) => Promise<any>;
-        /**
-         * @name starredUpdate
-         * @request PUT:/user/starred/{owner}/{repo}
-         * @description Star a repository.
-         */
-        starredUpdate: (owner: string, repo: string, params?: RequestParams) => Promise<any>;
-        /**
-         * @name subscriptionsList
-         * @request GET:/user/subscriptions
-         * @description List repositories being watched by the authenticated user.
-         */
-        subscriptionsList: (params?: RequestParams) => Promise<Repos>;
-        /**
-         * @name subscriptionsDelete
-         * @request DELETE:/user/subscriptions/{owner}/{repo}
-         * @description Stop watching a repository
-         */
-        subscriptionsDelete: (owner: string, repo: string, params?: RequestParams) => Promise<any>;
-        /**
-         * @name subscriptionsDetail
-         * @request GET:/user/subscriptions/{owner}/{repo}
-         * @description Check if you are watching a repository.
-         */
-        subscriptionsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<any>;
-        /**
-         * @name subscriptionsUpdate
-         * @request PUT:/user/subscriptions/{owner}/{repo}
-         * @description Watch a repository.
-         */
-        subscriptionsUpdate: (owner: string, repo: string, params?: RequestParams) => Promise<any>;
-        /**
-         * @name teamsList
-         * @request GET:/user/teams
-         * @description List all of the teams across all of the organizations to which the authenticated user belongs. This method requires user or repo scope when authenticating via OAuth.
-         */
-        teamsList: (params?: RequestParams) => Promise<TeamsList>;
-    };
-    users: {
-        /**
-         * @name usersList
-         * @request GET:/users
-         * @description Get all users. This provides a dump of every user, in the order that they signed up for GitHub. Note: Pagination is powered exclusively by the since parameter. Use the Link header to get the URL for the next page of users.
-         */
-        usersList: (query?: {
-            since?: number;
-        }, params?: RequestParams) => Promise<Users>;
-        /**
-         * @name usersDetail
-         * @request GET:/users/{username}
-         * @description Get a single user.
-         */
-        usersDetail: (username: string, params?: RequestParams) => Promise<any>;
-        /**
-         * @name eventsDetail
-         * @request GET:/users/{username}/events
-         * @description If you are authenticated as the given user, you will see your private events. Otherwise, you'll only see public events.
-         */
-        eventsDetail: (username: string, params?: RequestParams) => Promise<any>;
-        /**
-         * @name eventsOrgsDetail
-         * @request GET:/users/{username}/events/orgs/{org}
-         * @description This is the user's organization dashboard. You must be authenticated as the user to view this.
-         */
-        eventsOrgsDetail: (username: string, org: string, params?: RequestParams) => Promise<any>;
-        /**
-         * @name followersDetail
-         * @request GET:/users/{username}/followers
-         * @description List a user's followers
-         */
-        followersDetail: (username: string, params?: RequestParams) => Promise<Users>;
-        /**
-         * @name followingDetail
-         * @request GET:/users/{username}/following/{targetUser}
-         * @description Check if one user follows another.
-         */
-        followingDetail: (username: string, targetUser: string, params?: RequestParams) => Promise<any>;
-        /**
-         * @name gistsDetail
-         * @request GET:/users/{username}/gists
-         * @description List a users gists.
-         */
-        gistsDetail: (username: string, query?: {
-            since?: string;
-        }, params?: RequestParams) => Promise<Gists>;
-        /**
-         * @name keysDetail
-         * @request GET:/users/{username}/keys
-         * @description List public keys for a user. Lists the verified public keys for a user. This is accessible by anyone.
-         */
-        keysDetail: (username: string, params?: RequestParams) => Promise<Gitignore>;
-        /**
-         * @name orgsDetail
-         * @request GET:/users/{username}/orgs
-         * @description List all public organizations for a user.
-         */
-        orgsDetail: (username: string, params?: RequestParams) => Promise<Gitignore>;
-        /**
-         * @name receivedEventsDetail
-         * @request GET:/users/{username}/received_events
-         * @description These are events that you'll only see public events.
-         */
-        receivedEventsDetail: (username: string, params?: RequestParams) => Promise<any>;
-        /**
-         * @name receivedEventsPublicDetail
-         * @request GET:/users/{username}/received_events/public
-         * @description List public events that a user has received
-         */
-        receivedEventsPublicDetail: (username: string, params?: RequestParams) => Promise<any>;
-        /**
-         * @name reposDetail
-         * @request GET:/users/{username}/repos
-         * @description List public repositories for the specified user.
-         */
-        reposDetail: (username: string, query?: {
-            type?: "all" | "public" | "private" | "forks" | "sources" | "member";
-        }, params?: RequestParams) => Promise<Repos>;
-        /**
-         * @name starredDetail
-         * @request GET:/users/{username}/starred
-         * @description List repositories being starred by a user.
-         */
-        starredDetail: (username: string, params?: RequestParams) => Promise<any>;
-        /**
-         * @name subscriptionsDetail
-         * @request GET:/users/{username}/subscriptions
-         * @description List repositories being watched by a user.
-         */
-        subscriptionsDetail: (username: string, params?: RequestParams) => Promise<any>;
-    };
+  emojis: {
+    /**
+     * @name emojisList
+     * @request GET:/emojis
+     * @description Lists all the emojis available to use on GitHub.
+     */
+    emojisList: (params?: RequestParams) => Promise<Record<string, string>>;
+  };
+  events: {
+    /**
+     * @name eventsList
+     * @request GET:/events
+     * @description List public events.
+     */
+    eventsList: (params?: RequestParams) => Promise<Events>;
+  };
+  feeds: {
+    /**
+     * @name feedsList
+     * @request GET:/feeds
+     * @description List Feeds. GitHub provides several timeline resources in Atom format. The Feeds API lists all the feeds available to the authenticating user.
+     */
+    feedsList: (params?: RequestParams) => Promise<Feeds>;
+  };
+  gists: {
+    /**
+     * @name gistsList
+     * @request GET:/gists
+     * @description List the authenticated user's gists or if called anonymously, this will return all public gists.
+     */
+    gistsList: (
+      query?: {
+        since?: string;
+      },
+      params?: RequestParams,
+    ) => Promise<Gists>;
+    /**
+     * @name gistsCreate
+     * @request POST:/gists
+     * @description Create a gist.
+     */
+    gistsCreate: (body: PostGist, params?: RequestParams) => Promise<Gist>;
+    /**
+     * @name publicList
+     * @request GET:/gists/public
+     * @description List all public gists.
+     */
+    publicList: (
+      query?: {
+        since?: string;
+      },
+      params?: RequestParams,
+    ) => Promise<Gists>;
+    /**
+     * @name starredList
+     * @request GET:/gists/starred
+     * @description List the authenticated user's starred gists.
+     */
+    starredList: (
+      query?: {
+        since?: string;
+      },
+      params?: RequestParams,
+    ) => Promise<Gists>;
+    /**
+     * @name gistsDelete
+     * @request DELETE:/gists/{id}
+     * @description Delete a gist.
+     */
+    gistsDelete: (id: number, params?: RequestParams) => Promise<any>;
+    /**
+     * @name gistsDetail
+     * @request GET:/gists/{id}
+     * @description Get a single gist.
+     */
+    gistsDetail: (id: number, params?: RequestParams) => Promise<Gist>;
+    /**
+     * @name gistsPartialUpdate
+     * @request PATCH:/gists/{id}
+     * @description Edit a gist.
+     */
+    gistsPartialUpdate: (id: number, body: PatchGist, params?: RequestParams) => Promise<Gist>;
+    /**
+     * @name commentsDetail
+     * @request GET:/gists/{id}/comments
+     * @description List comments on a gist.
+     */
+    commentsDetail: (id: number, params?: RequestParams) => Promise<Comments>;
+    /**
+     * @name commentsCreate
+     * @request POST:/gists/{id}/comments
+     * @description Create a commen
+     */
+    commentsCreate: (id: number, body: CommentBody, params?: RequestParams) => Promise<Comment>;
+    /**
+     * @name commentsDelete
+     * @request DELETE:/gists/{id}/comments/{commentId}
+     * @description Delete a comment.
+     */
+    commentsDelete: (id: number, commentId: number, params?: RequestParams) => Promise<any>;
+    /**
+     * @name commentsDetail
+     * @request GET:/gists/{id}/comments/{commentId}
+     * @description Get a single comment.
+     * @originalName commentsDetail
+     * @duplicate
+     */
+    commentsDetail2: (id: number, commentId: number, params?: RequestParams) => Promise<Comment>;
+    /**
+     * @name commentsPartialUpdate
+     * @request PATCH:/gists/{id}/comments/{commentId}
+     * @description Edit a comment.
+     */
+    commentsPartialUpdate: (id: number, commentId: number, body: Comment, params?: RequestParams) => Promise<Comment>;
+    /**
+     * @name forksCreate
+     * @request POST:/gists/{id}/forks
+     * @description Fork a gist.
+     */
+    forksCreate: (id: number, params?: RequestParams) => Promise<any>;
+    /**
+     * @name starDelete
+     * @request DELETE:/gists/{id}/star
+     * @description Unstar a gist.
+     */
+    starDelete: (id: number, params?: RequestParams) => Promise<any>;
+    /**
+     * @name starDetail
+     * @request GET:/gists/{id}/star
+     * @description Check if a gist is starred.
+     */
+    starDetail: (id: number, params?: RequestParams) => Promise<any>;
+    /**
+     * @name starUpdate
+     * @request PUT:/gists/{id}/star
+     * @description Star a gist.
+     */
+    starUpdate: (id: number, params?: RequestParams) => Promise<any>;
+  };
+  gitignore: {
+    /**
+     * @name templatesList
+     * @request GET:/gitignore/templates
+     * @description Listing available templates. List all templates available to pass as an option when creating a repository.
+     */
+    templatesList: (params?: RequestParams) => Promise<Gitignore>;
+    /**
+     * @name templatesDetail
+     * @request GET:/gitignore/templates/{language}
+     * @description Get a single template.
+     */
+    templatesDetail: (language: string, params?: RequestParams) => Promise<GitignoreLang>;
+  };
+  issues: {
+    /**
+     * @name issuesList
+     * @request GET:/issues
+     * @description List issues. List all issues across all the authenticated user's visible repositories.
+     */
+    issuesList: (
+      query: {
+        filter: "assigned" | "created" | "mentioned" | "subscribed" | "all";
+        state: "open" | "closed";
+        labels: string;
+        sort: "created" | "updated" | "comments";
+        direction: "asc" | "desc";
+        since?: string;
+      },
+      params?: RequestParams,
+    ) => Promise<Issues>;
+  };
+  legacy: {
+    /**
+     * @name issuesSearchDetail
+     * @request GET:/legacy/issues/search/{owner}/{repository}/{state}/{keyword}
+     * @description Find issues by state and keyword.
+     */
+    issuesSearchDetail: (
+      keyword: string,
+      state: "open" | "closed",
+      owner: string,
+      repository: string,
+      params?: RequestParams,
+    ) => Promise<SearchIssuesByKeyword>;
+    /**
+     * @name reposSearchDetail
+     * @request GET:/legacy/repos/search/{keyword}
+     * @description Find repositories by keyword. Note, this legacy method does not follow the v3 pagination pattern. This method returns up to 100 results per page and pages can be fetched using the start_page parameter.
+     */
+    reposSearchDetail: (
+      keyword: string,
+      query?: {
+        order?: "desc" | "asc";
+        language?: string;
+        start_page?: string;
+        sort?: "updated" | "stars" | "forks";
+      },
+      params?: RequestParams,
+    ) => Promise<SearchRepositoriesByKeyword>;
+    /**
+     * @name userEmailDetail
+     * @request GET:/legacy/user/email/{email}
+     * @description This API call is added for compatibility reasons only.
+     */
+    userEmailDetail: (email: string, params?: RequestParams) => Promise<SearchUserByEmail>;
+    /**
+     * @name userSearchDetail
+     * @request GET:/legacy/user/search/{keyword}
+     * @description Find users by keyword.
+     */
+    userSearchDetail: (
+      keyword: string,
+      query?: {
+        order?: "desc" | "asc";
+        start_page?: string;
+        sort?: "updated" | "stars" | "forks";
+      },
+      params?: RequestParams,
+    ) => Promise<SearchUsersByKeyword>;
+  };
+  markdown: {
+    /**
+     * @name markdownCreate
+     * @request POST:/markdown
+     * @description Render an arbitrary Markdown document
+     */
+    markdownCreate: (body: Markdown, params?: RequestParams) => Promise<any>;
+    /**
+     * @name postMarkdown
+     * @request POST:/markdown/raw
+     * @description Render a Markdown document in raw mode
+     */
+    postMarkdown: (params?: RequestParams) => Promise<any>;
+  };
+  meta: {
+    /**
+     * @name metaList
+     * @request GET:/meta
+     * @description This gives some information about GitHub.com, the service.
+     */
+    metaList: (params?: RequestParams) => Promise<Meta>;
+  };
+  networks: {
+    /**
+     * @name eventsDetail
+     * @request GET:/networks/{owner}/{repo}/events
+     * @description List public events for a network of repositories.
+     */
+    eventsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Events>;
+  };
+  notifications: {
+    /**
+     * @name notificationsList
+     * @request GET:/notifications
+     * @description List your notifications. List all notifications for the current user, grouped by repository.
+     */
+    notificationsList: (
+      query?: {
+        all?: boolean;
+        participating?: boolean;
+        since?: string;
+      },
+      params?: RequestParams,
+    ) => Promise<Notifications>;
+    /**
+     * @name notificationsUpdate
+     * @request PUT:/notifications
+     * @description Mark as read. Marking a notification as "read" removes it from the default view on GitHub.com.
+     */
+    notificationsUpdate: (body: NotificationMarkRead, params?: RequestParams) => Promise<any>;
+    /**
+     * @name threadsDetail
+     * @request GET:/notifications/threads/{id}
+     * @description View a single thread.
+     */
+    threadsDetail: (id: number, params?: RequestParams) => Promise<Notifications>;
+    /**
+     * @name threadsPartialUpdate
+     * @request PATCH:/notifications/threads/{id}
+     * @description Mark a thread as read
+     */
+    threadsPartialUpdate: (id: number, params?: RequestParams) => Promise<any>;
+    /**
+     * @name threadsSubscriptionDelete
+     * @request DELETE:/notifications/threads/{id}/subscription
+     * @description Delete a Thread Subscription.
+     */
+    threadsSubscriptionDelete: (id: number, params?: RequestParams) => Promise<any>;
+    /**
+     * @name threadsSubscriptionDetail
+     * @request GET:/notifications/threads/{id}/subscription
+     * @description Get a Thread Subscription.
+     */
+    threadsSubscriptionDetail: (id: number, params?: RequestParams) => Promise<Subscription>;
+    /**
+     * @name threadsSubscriptionUpdate
+     * @request PUT:/notifications/threads/{id}/subscription
+     * @description Set a Thread Subscription. This lets you subscribe to a thread, or ignore it. Subscribing to a thread is unnecessary if the user is already subscribed to the repository. Ignoring a thread will mute all future notifications (until you comment or get @mentioned).
+     */
+    threadsSubscriptionUpdate: (id: number, body: PutSubscription, params?: RequestParams) => Promise<Subscription>;
+  };
+  orgs: {
+    /**
+     * @name orgsDetail
+     * @request GET:/orgs/{org}
+     * @description Get an Organization.
+     */
+    orgsDetail: (org: string, params?: RequestParams) => Promise<any>;
+    /**
+     * @name orgsPartialUpdate
+     * @request PATCH:/orgs/{org}
+     * @description Edit an Organization.
+     */
+    orgsPartialUpdate: (org: string, body: PatchOrg, params?: RequestParams) => Promise<any>;
+    /**
+     * @name eventsDetail
+     * @request GET:/orgs/{org}/events
+     * @description List public events for an organization.
+     */
+    eventsDetail: (org: string, params?: RequestParams) => Promise<Events>;
+    /**
+     * @name issuesDetail
+     * @request GET:/orgs/{org}/issues
+     * @description List issues. List all issues for a given organization for the authenticated user.
+     */
+    issuesDetail: (
+      org: string,
+      query: {
+        filter: "assigned" | "created" | "mentioned" | "subscribed" | "all";
+        state: "open" | "closed";
+        labels: string;
+        sort: "created" | "updated" | "comments";
+        direction: "asc" | "desc";
+        since?: string;
+      },
+      params?: RequestParams,
+    ) => Promise<Issues>;
+    /**
+     * @name membersDetail
+     * @request GET:/orgs/{org}/members
+     * @description Members list. List all users who are members of an organization. A member is a user tha belongs to at least 1 team in the organization. If the authenticated user is also an owner of this organization then both concealed and public members will be returned. If the requester is not an owner of the organization the query will be redirected to the public members list.
+     */
+    membersDetail: (org: string, params?: RequestParams) => Promise<Users>;
+    /**
+     * @name membersDelete
+     * @request DELETE:/orgs/{org}/members/{username}
+     * @description Remove a member. Removing a user from this list will remove them from all teams and they will no longer have any access to the organization's repositories.
+     */
+    membersDelete: (org: string, username: string, params?: RequestParams) => Promise<any>;
+    /**
+     * @name membersDetail
+     * @request GET:/orgs/{org}/members/{username}
+     * @description Check if a user is, publicly or privately, a member of the organization.
+     * @originalName membersDetail
+     * @duplicate
+     */
+    membersDetail2: (org: string, username: string, params?: RequestParams) => Promise<any>;
+    /**
+     * @name publicMembersDetail
+     * @request GET:/orgs/{org}/public_members
+     * @description Public members list. Members of an organization can choose to have their membership publicized or not.
+     */
+    publicMembersDetail: (org: string, params?: RequestParams) => Promise<Users>;
+    /**
+     * @name publicMembersDelete
+     * @request DELETE:/orgs/{org}/public_members/{username}
+     * @description Conceal a user's membership.
+     */
+    publicMembersDelete: (org: string, username: string, params?: RequestParams) => Promise<any>;
+    /**
+     * @name publicMembersDetail
+     * @request GET:/orgs/{org}/public_members/{username}
+     * @description Check public membership.
+     * @originalName publicMembersDetail
+     * @duplicate
+     */
+    publicMembersDetail2: (org: string, username: string, params?: RequestParams) => Promise<any>;
+    /**
+     * @name publicMembersUpdate
+     * @request PUT:/orgs/{org}/public_members/{username}
+     * @description Publicize a user's membership.
+     */
+    publicMembersUpdate: (org: string, username: string, params?: RequestParams) => Promise<any>;
+    /**
+     * @name reposDetail
+     * @request GET:/orgs/{org}/repos
+     * @description List repositories for the specified org.
+     */
+    reposDetail: (
+      org: string,
+      query?: {
+        type?: "all" | "public" | "private" | "forks" | "sources" | "member";
+      },
+      params?: RequestParams,
+    ) => Promise<Repos>;
+    /**
+     * @name reposCreate
+     * @request POST:/orgs/{org}/repos
+     * @description Create a new repository for the authenticated user. OAuth users must supply repo scope.
+     */
+    reposCreate: (org: string, body: PostRepo, params?: RequestParams) => Promise<Repos>;
+    /**
+     * @name teamsDetail
+     * @request GET:/orgs/{org}/teams
+     * @description List teams.
+     */
+    teamsDetail: (org: string, params?: RequestParams) => Promise<Teams>;
+    /**
+     * @name teamsCreate
+     * @request POST:/orgs/{org}/teams
+     * @description Create team. In order to create a team, the authenticated user must be an owner of organization.
+     */
+    teamsCreate: (org: string, body: OrgTeamsPost, params?: RequestParams) => Promise<Team>;
+  };
+  rateLimit: {
+    /**
+     * @name rateLimitList
+     * @request GET:/rate_limit
+     * @description Get your current rate limit status Note: Accessing this endpoint does not count against your rate limit.
+     */
+    rateLimitList: (params?: RequestParams) => Promise<RateLimit>;
+  };
+  repos: {
+    /**
+     * @name reposDelete
+     * @request DELETE:/repos/{owner}/{repo}
+     * @description Delete a Repository. Deleting a repository requires admin access. If OAuth is used, the delete_repo scope is required.
+     */
+    reposDelete: (owner: string, repo: string, params?: RequestParams) => Promise<any>;
+    /**
+     * @name reposDetail
+     * @request GET:/repos/{owner}/{repo}
+     * @description Get repository.
+     */
+    reposDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Repo>;
+    /**
+     * @name reposPartialUpdate
+     * @request PATCH:/repos/{owner}/{repo}
+     * @description Edit repository.
+     */
+    reposPartialUpdate: (owner: string, repo: string, body: RepoEdit, params?: RequestParams) => Promise<Repo>;
+    /**
+     * @name assigneesDetail
+     * @request GET:/repos/{owner}/{repo}/assignees
+     * @description List assignees. This call lists all the available assignees (owner + collaborators) to which issues may be assigned.
+     */
+    assigneesDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Assignees>;
+    /**
+     * @name assigneesDetail
+     * @request GET:/repos/{owner}/{repo}/assignees/{assignee}
+     * @description Check assignee. You may also check to see if a particular user is an assignee for a repository.
+     * @originalName assigneesDetail
+     * @duplicate
+     */
+    assigneesDetail2: (owner: string, repo: string, assignee: string, params?: RequestParams) => Promise<any>;
+    /**
+     * @name branchesDetail
+     * @request GET:/repos/{owner}/{repo}/branches
+     * @description Get list of branches
+     */
+    branchesDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Branches>;
+    /**
+     * @name branchesDetail
+     * @request GET:/repos/{owner}/{repo}/branches/{branch}
+     * @description Get Branch
+     * @originalName branchesDetail
+     * @duplicate
+     */
+    branchesDetail2: (owner: string, repo: string, branch: string, params?: RequestParams) => Promise<Branch>;
+    /**
+     * @name collaboratorsDetail
+     * @request GET:/repos/{owner}/{repo}/collaborators
+     * @description List. When authenticating as an organization owner of an organization-owned repository, all organization owners are included in the list of collaborators. Otherwise, only users with access to the repository are returned in the collaborators list.
+     */
+    collaboratorsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Users>;
+    /**
+     * @name collaboratorsDelete
+     * @request DELETE:/repos/{owner}/{repo}/collaborators/{user}
+     * @description Remove collaborator.
+     */
+    collaboratorsDelete: (owner: string, repo: string, user: string, params?: RequestParams) => Promise<any>;
+    /**
+     * @name collaboratorsDetail
+     * @request GET:/repos/{owner}/{repo}/collaborators/{user}
+     * @description Check if user is a collaborator
+     * @originalName collaboratorsDetail
+     * @duplicate
+     */
+    collaboratorsDetail2: (owner: string, repo: string, user: string, params?: RequestParams) => Promise<any>;
+    /**
+     * @name collaboratorsUpdate
+     * @request PUT:/repos/{owner}/{repo}/collaborators/{user}
+     * @description Add collaborator.
+     */
+    collaboratorsUpdate: (owner: string, repo: string, user: string, params?: RequestParams) => Promise<any>;
+    /**
+     * @name commentsDetail
+     * @request GET:/repos/{owner}/{repo}/comments
+     * @description List commit comments for a repository. Comments are ordered by ascending ID.
+     */
+    commentsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<RepoComments>;
+    /**
+     * @name commentsDelete
+     * @request DELETE:/repos/{owner}/{repo}/comments/{commentId}
+     * @description Delete a commit comment
+     */
+    commentsDelete: (owner: string, repo: string, commentId: number, params?: RequestParams) => Promise<any>;
+    /**
+     * @name commentsDetail
+     * @request GET:/repos/{owner}/{repo}/comments/{commentId}
+     * @description Get a single commit comment.
+     * @originalName commentsDetail
+     * @duplicate
+     */
+    commentsDetail2: (owner: string, repo: string, commentId: number, params?: RequestParams) => Promise<CommitComment>;
+    /**
+     * @name commentsPartialUpdate
+     * @request PATCH:/repos/{owner}/{repo}/comments/{commentId}
+     * @description Update a commit comment.
+     */
+    commentsPartialUpdate: (
+      owner: string,
+      repo: string,
+      commentId: number,
+      body: CommentBody,
+      params?: RequestParams,
+    ) => Promise<CommitComment>;
+    /**
+     * @name commitsDetail
+     * @request GET:/repos/{owner}/{repo}/commits
+     * @description List commits on a repository.
+     */
+    commitsDetail: (
+      owner: string,
+      repo: string,
+      query?: {
+        since?: string;
+        sha?: string;
+        path?: string;
+        author?: string;
+        until?: string;
+      },
+      params?: RequestParams,
+    ) => Promise<Commits>;
+    /**
+     * @name commitsStatusDetail
+     * @request GET:/repos/{owner}/{repo}/commits/{ref}/status
+     * @description Get the combined Status for a specific Ref The Combined status endpoint is currently available for developers to preview. During the preview period, the API may change without advance notice. Please see the blog post for full details. To access this endpoint during the preview period, you must provide a custom media type in the Accept header: application/vnd.github.she-hulk-preview+json
+     */
+    commitsStatusDetail: (owner: string, repo: string, ref: string, params?: RequestParams) => Promise<RefStatus>;
+    /**
+     * @name commitsDetail
+     * @request GET:/repos/{owner}/{repo}/commits/{shaCode}
+     * @description Get a single commit.
+     * @originalName commitsDetail
+     * @duplicate
+     */
+    commitsDetail2: (owner: string, repo: string, shaCode: string, params?: RequestParams) => Promise<Commit>;
+    /**
+     * @name commitsCommentsDetail
+     * @request GET:/repos/{owner}/{repo}/commits/{shaCode}/comments
+     * @description List comments for a single commitList comments for a single commit.
+     */
+    commitsCommentsDetail: (
+      owner: string,
+      repo: string,
+      shaCode: string,
+      params?: RequestParams,
+    ) => Promise<RepoComments>;
+    /**
+     * @name commitsCommentsCreate
+     * @request POST:/repos/{owner}/{repo}/commits/{shaCode}/comments
+     * @description Create a commit comment.
+     */
+    commitsCommentsCreate: (
+      owner: string,
+      repo: string,
+      shaCode: string,
+      body: CommitCommentBody,
+      params?: RequestParams,
+    ) => Promise<CommitComment>;
+    /**
+     * @name compareDetail
+     * @request GET:/repos/{owner}/{repo}/compare/{baseId}...{headId}
+     * @description Compare two commits
+     */
+    compareDetail: (
+      owner: string,
+      repo: string,
+      baseId: string,
+      headId: string,
+      params?: RequestParams,
+    ) => Promise<CompareCommits>;
+    /**
+     * @name contentsDelete
+     * @request DELETE:/repos/{owner}/{repo}/contents/{path}
+     * @description Delete a file. This method deletes a file in a repository.
+     */
+    contentsDelete: (
+      owner: string,
+      repo: string,
+      path: string,
+      body: DeleteFileBody,
+      params?: RequestParams,
+    ) => Promise<DeleteFile>;
+    /**
+     * @name contentsDetail
+     * @request GET:/repos/{owner}/{repo}/contents/{path}
+     * @description Get contents. This method returns the contents of a file or directory in a repository. Files and symlinks support a custom media type for getting the raw content. Directories and submodules do not support custom media types. Note: This API supports files up to 1 megabyte in size. Here can be many outcomes. For details see "http://developer.github.com/v3/repos/contents/"
+     */
+    contentsDetail: (
+      owner: string,
+      repo: string,
+      path: string,
+      query?: {
+        path?: string;
+        ref?: string;
+      },
+      params?: RequestParams,
+    ) => Promise<ContentsPath>;
+    /**
+     * @name contentsUpdate
+     * @request PUT:/repos/{owner}/{repo}/contents/{path}
+     * @description Create a file.
+     */
+    contentsUpdate: (
+      owner: string,
+      repo: string,
+      path: string,
+      body: CreateFileBody,
+      params?: RequestParams,
+    ) => Promise<CreateFile>;
+    /**
+     * @name contributorsDetail
+     * @request GET:/repos/{owner}/{repo}/contributors
+     * @description Get list of contributors.
+     */
+    contributorsDetail: (
+      owner: string,
+      repo: string,
+      query: {
+        anon: string;
+      },
+      params?: RequestParams,
+    ) => Promise<Users>;
+    /**
+     * @name deploymentsDetail
+     * @request GET:/repos/{owner}/{repo}/deployments
+     * @description Users with pull access can view deployments for a repository
+     */
+    deploymentsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<RepoDeployments>;
+    /**
+     * @name deploymentsCreate
+     * @request POST:/repos/{owner}/{repo}/deployments
+     * @description Users with push access can create a deployment for a given ref
+     */
+    deploymentsCreate: (
+      owner: string,
+      repo: string,
+      body: Deployment,
+      params?: RequestParams,
+    ) => Promise<DeploymentResp>;
+    /**
+     * @name deploymentsStatusesDetail
+     * @request GET:/repos/{owner}/{repo}/deployments/{id}/statuses
+     * @description Users with pull access can view deployment statuses for a deployment
+     */
+    deploymentsStatusesDetail: (
+      owner: string,
+      repo: string,
+      id: number,
+      params?: RequestParams,
+    ) => Promise<DeploymentStatuses>;
+    /**
+     * @name deploymentsStatusesCreate
+     * @request POST:/repos/{owner}/{repo}/deployments/{id}/statuses
+     * @description Create a Deployment Status Users with push access can create deployment statuses for a given deployment:
+     */
+    deploymentsStatusesCreate: (
+      owner: string,
+      repo: string,
+      id: number,
+      body: DeploymentStatusesCreate,
+      params?: RequestParams,
+    ) => Promise<any>;
+    /**
+     * @name downloadsDetail
+     * @request GET:/repos/{owner}/{repo}/downloads
+     * @description Deprecated. List downloads for a repository.
+     */
+    downloadsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Downloads>;
+    /**
+     * @name downloadsDelete
+     * @request DELETE:/repos/{owner}/{repo}/downloads/{downloadId}
+     * @description Deprecated. Delete a download.
+     */
+    downloadsDelete: (owner: string, repo: string, downloadId: number, params?: RequestParams) => Promise<any>;
+    /**
+     * @name downloadsDetail
+     * @request GET:/repos/{owner}/{repo}/downloads/{downloadId}
+     * @description Deprecated. Get a single download.
+     * @originalName downloadsDetail
+     * @duplicate
+     */
+    downloadsDetail2: (owner: string, repo: string, downloadId: number, params?: RequestParams) => Promise<Download>;
+    /**
+     * @name eventsDetail
+     * @request GET:/repos/{owner}/{repo}/events
+     * @description Get list of repository events.
+     */
+    eventsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Events>;
+    /**
+     * @name forksDetail
+     * @request GET:/repos/{owner}/{repo}/forks
+     * @description List forks.
+     */
+    forksDetail: (
+      owner: string,
+      repo: string,
+      query?: {
+        sort?: "newes" | "oldes" | "watchers";
+      },
+      params?: RequestParams,
+    ) => Promise<Repos>;
+    /**
+     * @name forksCreate
+     * @request POST:/repos/{owner}/{repo}/forks
+     * @description Create a fork. Forking a Repository happens asynchronously. Therefore, you may have to wai a short period before accessing the git objects. If this takes longer than 5 minutes, be sure to contact Support.
+     */
+    forksCreate: (owner: string, repo: string, body: ForkBody, params?: RequestParams) => Promise<Repo>;
+    /**
+     * @name gitBlobsCreate
+     * @request POST:/repos/{owner}/{repo}/git/blobs
+     * @description Create a Blob.
+     */
+    gitBlobsCreate: (owner: string, repo: string, body: Blob, params?: RequestParams) => Promise<Blobs>;
+    /**
+     * @name gitBlobsDetail
+     * @request GET:/repos/{owner}/{repo}/git/blobs/{shaCode}
+     * @description Get a Blob. Since blobs can be any arbitrary binary data, the input and responses for the blob API takes an encoding parameter that can be either utf-8 or base64. If your data cannot be losslessly sent as a UTF-8 string, you can base64 encode it.
+     */
+    gitBlobsDetail: (owner: string, repo: string, shaCode: string, params?: RequestParams) => Promise<Blob>;
+    /**
+     * @name gitCommitsCreate
+     * @request POST:/repos/{owner}/{repo}/git/commits
+     * @description Create a Commit.
+     */
+    gitCommitsCreate: (owner: string, repo: string, body: RepoCommitBody, params?: RequestParams) => Promise<GitCommit>;
+    /**
+     * @name gitCommitsDetail
+     * @request GET:/repos/{owner}/{repo}/git/commits/{shaCode}
+     * @description Get a Commit.
+     */
+    gitCommitsDetail: (owner: string, repo: string, shaCode: string, params?: RequestParams) => Promise<RepoCommit>;
+    /**
+     * @name gitRefsDetail
+     * @request GET:/repos/{owner}/{repo}/git/refs
+     * @description Get all References
+     */
+    gitRefsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Refs>;
+    /**
+     * @name gitRefsCreate
+     * @request POST:/repos/{owner}/{repo}/git/refs
+     * @description Create a Reference
+     */
+    gitRefsCreate: (owner: string, repo: string, body: RefsBody, params?: RequestParams) => Promise<HeadBranch>;
+    /**
+     * @name gitRefsDelete
+     * @request DELETE:/repos/{owner}/{repo}/git/refs/{ref}
+     * @description Delete a Reference Example: Deleting a branch: DELETE /repos/octocat/Hello-World/git/refs/heads/feature-a Example: Deleting a tag:        DELETE /repos/octocat/Hello-World/git/refs/tags/v1.0
+     */
+    gitRefsDelete: (owner: string, repo: string, ref: string, params?: RequestParams) => Promise<any>;
+    /**
+     * @name gitRefsDetail
+     * @request GET:/repos/{owner}/{repo}/git/refs/{ref}
+     * @description Get a Reference
+     * @originalName gitRefsDetail
+     * @duplicate
+     */
+    gitRefsDetail2: (owner: string, repo: string, ref: string, params?: RequestParams) => Promise<HeadBranch>;
+    /**
+     * @name gitRefsPartialUpdate
+     * @request PATCH:/repos/{owner}/{repo}/git/refs/{ref}
+     * @description Update a Reference
+     */
+    gitRefsPartialUpdate: (
+      owner: string,
+      repo: string,
+      ref: string,
+      body: GitRefPatch,
+      params?: RequestParams,
+    ) => Promise<HeadBranch>;
+    /**
+     * @name gitTagsCreate
+     * @request POST:/repos/{owner}/{repo}/git/tags
+     * @description Create a Tag Object. Note that creating a tag object does not create the reference that makes a tag in Git. If you want to create an annotated tag in Git, you have to do this call to create the tag object, and then create the refs/tags/[tag] reference. If you want to create a lightweight tag, you only have to create the tag reference - this call would be unnecessary.
+     */
+    gitTagsCreate: (owner: string, repo: string, body: TagBody, params?: RequestParams) => Promise<Tag>;
+    /**
+     * @name gitTagsDetail
+     * @request GET:/repos/{owner}/{repo}/git/tags/{shaCode}
+     * @description Get a Tag.
+     */
+    gitTagsDetail: (owner: string, repo: string, shaCode: string, params?: RequestParams) => Promise<Tag>;
+    /**
+     * @name gitTreesCreate
+     * @request POST:/repos/{owner}/{repo}/git/trees
+     * @description Create a Tree. The tree creation API will take nested entries as well. If both a tree and a nested path modifying that tree are specified, it will overwrite the contents of that tree with the new path contents and write a new tree out.
+     */
+    gitTreesCreate: (owner: string, repo: string, body: Tree, params?: RequestParams) => Promise<Trees>;
+    /**
+     * @name gitTreesDetail
+     * @request GET:/repos/{owner}/{repo}/git/trees/{shaCode}
+     * @description Get a Tree.
+     */
+    gitTreesDetail: (
+      owner: string,
+      repo: string,
+      shaCode: string,
+      query?: {
+        recursive?: number;
+      },
+      params?: RequestParams,
+    ) => Promise<Tree>;
+    /**
+     * @name hooksDetail
+     * @request GET:/repos/{owner}/{repo}/hooks
+     * @description Get list of hooks.
+     */
+    hooksDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Hook>;
+    /**
+     * @name hooksCreate
+     * @request POST:/repos/{owner}/{repo}/hooks
+     * @description Create a hook.
+     */
+    hooksCreate: (owner: string, repo: string, body: HookBody, params?: RequestParams) => Promise<Hook>;
+    /**
+     * @name hooksDelete
+     * @request DELETE:/repos/{owner}/{repo}/hooks/{hookId}
+     * @description Delete a hook.
+     */
+    hooksDelete: (owner: string, repo: string, hookId: number, params?: RequestParams) => Promise<any>;
+    /**
+     * @name hooksDetail
+     * @request GET:/repos/{owner}/{repo}/hooks/{hookId}
+     * @description Get single hook.
+     * @originalName hooksDetail
+     * @duplicate
+     */
+    hooksDetail2: (owner: string, repo: string, hookId: number, params?: RequestParams) => Promise<Hook>;
+    /**
+     * @name hooksPartialUpdate
+     * @request PATCH:/repos/{owner}/{repo}/hooks/{hookId}
+     * @description Edit a hook.
+     */
+    hooksPartialUpdate: (
+      owner: string,
+      repo: string,
+      hookId: number,
+      body: HookBody,
+      params?: RequestParams,
+    ) => Promise<Hook>;
+    /**
+     * @name hooksTestsCreate
+     * @request POST:/repos/{owner}/{repo}/hooks/{hookId}/tests
+     * @description Test a push hook. This will trigger the hook with the latest push to the current repository if the hook is subscribed to push events. If the hook is not subscribed to push events, the server will respond with 204 but no test POST will be generated. Note: Previously /repos/:owner/:repo/hooks/:id/tes
+     */
+    hooksTestsCreate: (owner: string, repo: string, hookId: number, params?: RequestParams) => Promise<any>;
+    /**
+     * @name issuesDetail
+     * @request GET:/repos/{owner}/{repo}/issues
+     * @description List issues for a repository.
+     */
+    issuesDetail: (
+      owner: string,
+      repo: string,
+      query: {
+        filter: "assigned" | "created" | "mentioned" | "subscribed" | "all";
+        state: "open" | "closed";
+        labels: string;
+        sort: "created" | "updated" | "comments";
+        direction: "asc" | "desc";
+        since?: string;
+      },
+      params?: RequestParams,
+    ) => Promise<Issues>;
+    /**
+     * @name issuesCreate
+     * @request POST:/repos/{owner}/{repo}/issues
+     * @description Create an issue. Any user with pull access to a repository can create an issue.
+     */
+    issuesCreate: (owner: string, repo: string, body: Issue, params?: RequestParams) => Promise<Issue>;
+    /**
+     * @name issuesCommentsDetail
+     * @request GET:/repos/{owner}/{repo}/issues/comments
+     * @description List comments in a repository.
+     */
+    issuesCommentsDetail: (
+      owner: string,
+      repo: string,
+      query?: {
+        direction?: string;
+        sort?: "created" | "updated";
+        since?: string;
+      },
+      params?: RequestParams,
+    ) => Promise<IssuesComments>;
+    /**
+     * @name issuesCommentsDelete
+     * @request DELETE:/repos/{owner}/{repo}/issues/comments/{commentId}
+     * @description Delete a comment.
+     */
+    issuesCommentsDelete: (owner: string, repo: string, commentId: number, params?: RequestParams) => Promise<any>;
+    /**
+     * @name issuesCommentsDetail
+     * @request GET:/repos/{owner}/{repo}/issues/comments/{commentId}
+     * @description Get a single comment.
+     * @originalName issuesCommentsDetail
+     * @duplicate
+     */
+    issuesCommentsDetail2: (
+      owner: string,
+      repo: string,
+      commentId: number,
+      params?: RequestParams,
+    ) => Promise<IssuesComment>;
+    /**
+     * @name issuesCommentsPartialUpdate
+     * @request PATCH:/repos/{owner}/{repo}/issues/comments/{commentId}
+     * @description Edit a comment.
+     */
+    issuesCommentsPartialUpdate: (
+      owner: string,
+      repo: string,
+      commentId: number,
+      body: CommentBody,
+      params?: RequestParams,
+    ) => Promise<IssuesComment>;
+    /**
+     * @name issuesEventsDetail
+     * @request GET:/repos/{owner}/{repo}/issues/events
+     * @description List issue events for a repository.
+     */
+    issuesEventsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<IssueEvents>;
+    /**
+     * @name issuesEventsDetail
+     * @request GET:/repos/{owner}/{repo}/issues/events/{eventId}
+     * @description Get a single event.
+     * @originalName issuesEventsDetail
+     * @duplicate
+     */
+    issuesEventsDetail2: (owner: string, repo: string, eventId: number, params?: RequestParams) => Promise<IssueEvent>;
+    /**
+     * @name issuesDetail
+     * @request GET:/repos/{owner}/{repo}/issues/{number}
+     * @description Get a single issue
+     * @originalName issuesDetail
+     * @duplicate
+     */
+    issuesDetail2: (owner: string, repo: string, number: number, params?: RequestParams) => Promise<Issue>;
+    /**
+     * @name issuesPartialUpdate
+     * @request PATCH:/repos/{owner}/{repo}/issues/{number}
+     * @description Edit an issue. Issue owners and users with push access can edit an issue.
+     */
+    issuesPartialUpdate: (
+      owner: string,
+      repo: string,
+      number: number,
+      body: Issue,
+      params?: RequestParams,
+    ) => Promise<Issue>;
+    /**
+     * @name issuesCommentsDetail
+     * @request GET:/repos/{owner}/{repo}/issues/{number}/comments
+     * @description List comments on an issue.
+     * @originalName issuesCommentsDetail
+     * @duplicate
+     */
+    issuesCommentsDetail3: (
+      owner: string,
+      repo: string,
+      number: number,
+      params?: RequestParams,
+    ) => Promise<IssuesComments>;
+    /**
+     * @name issuesCommentsCreate
+     * @request POST:/repos/{owner}/{repo}/issues/{number}/comments
+     * @description Create a comment.
+     */
+    issuesCommentsCreate: (
+      owner: string,
+      repo: string,
+      number: number,
+      body: CommentBody,
+      params?: RequestParams,
+    ) => Promise<IssuesComment>;
+    /**
+     * @name issuesEventsDetail
+     * @request GET:/repos/{owner}/{repo}/issues/{number}/events
+     * @description List events for an issue.
+     * @originalName issuesEventsDetail
+     * @duplicate
+     */
+    issuesEventsDetail3: (owner: string, repo: string, number: number, params?: RequestParams) => Promise<IssueEvents>;
+    /**
+     * @name issuesLabelsDelete
+     * @request DELETE:/repos/{owner}/{repo}/issues/{number}/labels
+     * @description Remove all labels from an issue.
+     */
+    issuesLabelsDelete: (owner: string, repo: string, number: number, params?: RequestParams) => Promise<any>;
+    /**
+     * @name issuesLabelsDetail
+     * @request GET:/repos/{owner}/{repo}/issues/{number}/labels
+     * @description List labels on an issue.
+     */
+    issuesLabelsDetail: (owner: string, repo: string, number: number, params?: RequestParams) => Promise<Labels>;
+    /**
+     * @name issuesLabelsCreate
+     * @request POST:/repos/{owner}/{repo}/issues/{number}/labels
+     * @description Add labels to an issue.
+     */
+    issuesLabelsCreate: (
+      owner: string,
+      repo: string,
+      number: number,
+      body: EmailsPost,
+      params?: RequestParams,
+    ) => Promise<Label>;
+    /**
+     * @name issuesLabelsUpdate
+     * @request PUT:/repos/{owner}/{repo}/issues/{number}/labels
+     * @description Replace all labels for an issue. Sending an empty array ([]) will remove all Labels from the Issue.
+     */
+    issuesLabelsUpdate: (
+      owner: string,
+      repo: string,
+      number: number,
+      body: EmailsPost,
+      params?: RequestParams,
+    ) => Promise<Label>;
+    /**
+     * @name issuesLabelsDelete
+     * @request DELETE:/repos/{owner}/{repo}/issues/{number}/labels/{name}
+     * @description Remove a label from an issue.
+     * @originalName issuesLabelsDelete
+     * @duplicate
+     */
+    issuesLabelsDelete2: (
+      owner: string,
+      repo: string,
+      number: number,
+      name: string,
+      params?: RequestParams,
+    ) => Promise<any>;
+    /**
+     * @name keysDetail
+     * @request GET:/repos/{owner}/{repo}/keys
+     * @description Get list of keys.
+     */
+    keysDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Keys>;
+    /**
+     * @name keysCreate
+     * @request POST:/repos/{owner}/{repo}/keys
+     * @description Create a key.
+     */
+    keysCreate: (owner: string, repo: string, body: UserKeysPost, params?: RequestParams) => Promise<UserKeysKeyId>;
+    /**
+     * @name keysDelete
+     * @request DELETE:/repos/{owner}/{repo}/keys/{keyId}
+     * @description Delete a key.
+     */
+    keysDelete: (owner: string, repo: string, keyId: number, params?: RequestParams) => Promise<any>;
+    /**
+     * @name keysDetail
+     * @request GET:/repos/{owner}/{repo}/keys/{keyId}
+     * @description Get a key
+     * @originalName keysDetail
+     * @duplicate
+     */
+    keysDetail2: (owner: string, repo: string, keyId: number, params?: RequestParams) => Promise<UserKeysKeyId>;
+    /**
+     * @name labelsDetail
+     * @request GET:/repos/{owner}/{repo}/labels
+     * @description List all labels for this repository.
+     */
+    labelsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Labels>;
+    /**
+     * @name labelsCreate
+     * @request POST:/repos/{owner}/{repo}/labels
+     * @description Create a label.
+     */
+    labelsCreate: (owner: string, repo: string, body: EmailsPost, params?: RequestParams) => Promise<Label>;
+    /**
+     * @name labelsDelete
+     * @request DELETE:/repos/{owner}/{repo}/labels/{name}
+     * @description Delete a label.
+     */
+    labelsDelete: (owner: string, repo: string, name: string, params?: RequestParams) => Promise<any>;
+    /**
+     * @name labelsDetail
+     * @request GET:/repos/{owner}/{repo}/labels/{name}
+     * @description Get a single label.
+     * @originalName labelsDetail
+     * @duplicate
+     */
+    labelsDetail2: (owner: string, repo: string, name: string, params?: RequestParams) => Promise<Label>;
+    /**
+     * @name labelsPartialUpdate
+     * @request PATCH:/repos/{owner}/{repo}/labels/{name}
+     * @description Update a label.
+     */
+    labelsPartialUpdate: (
+      owner: string,
+      repo: string,
+      name: string,
+      body: EmailsPost,
+      params?: RequestParams,
+    ) => Promise<Label>;
+    /**
+     * @name languagesDetail
+     * @request GET:/repos/{owner}/{repo}/languages
+     * @description List languages. List languages for the specified repository. The value on the right of a language is the number of bytes of code written in that language.
+     */
+    languagesDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Record<string, number>>;
+    /**
+     * @name mergesCreate
+     * @request POST:/repos/{owner}/{repo}/merges
+     * @description Perform a merge.
+     */
+    mergesCreate: (owner: string, repo: string, body: MergesBody, params?: RequestParams) => Promise<MergesSuccessful>;
+    /**
+     * @name milestonesDetail
+     * @request GET:/repos/{owner}/{repo}/milestones
+     * @description List milestones for a repository.
+     */
+    milestonesDetail: (
+      owner: string,
+      repo: string,
+      query?: {
+        state?: "open" | "closed";
+        direction?: string;
+        sort?: "due_date" | "completeness";
+      },
+      params?: RequestParams,
+    ) => Promise<Milestone>;
+    /**
+     * @name milestonesCreate
+     * @request POST:/repos/{owner}/{repo}/milestones
+     * @description Create a milestone.
+     */
+    milestonesCreate: (
+      owner: string,
+      repo: string,
+      body: MilestoneUpdate,
+      params?: RequestParams,
+    ) => Promise<Milestone>;
+    /**
+     * @name milestonesDelete
+     * @request DELETE:/repos/{owner}/{repo}/milestones/{number}
+     * @description Delete a milestone.
+     */
+    milestonesDelete: (owner: string, repo: string, number: number, params?: RequestParams) => Promise<any>;
+    /**
+     * @name milestonesDetail
+     * @request GET:/repos/{owner}/{repo}/milestones/{number}
+     * @description Get a single milestone.
+     * @originalName milestonesDetail
+     * @duplicate
+     */
+    milestonesDetail2: (owner: string, repo: string, number: number, params?: RequestParams) => Promise<Milestone>;
+    /**
+     * @name milestonesPartialUpdate
+     * @request PATCH:/repos/{owner}/{repo}/milestones/{number}
+     * @description Update a milestone.
+     */
+    milestonesPartialUpdate: (
+      owner: string,
+      repo: string,
+      number: number,
+      body: MilestoneUpdate,
+      params?: RequestParams,
+    ) => Promise<Milestone>;
+    /**
+     * @name milestonesLabelsDetail
+     * @request GET:/repos/{owner}/{repo}/milestones/{number}/labels
+     * @description Get labels for every issue in a milestone.
+     */
+    milestonesLabelsDetail: (owner: string, repo: string, number: number, params?: RequestParams) => Promise<Labels>;
+    /**
+     * @name notificationsDetail
+     * @request GET:/repos/{owner}/{repo}/notifications
+     * @description List your notifications in a repository List all notifications for the current user.
+     */
+    notificationsDetail: (
+      owner: string,
+      repo: string,
+      query?: {
+        all?: boolean;
+        participating?: boolean;
+        since?: string;
+      },
+      params?: RequestParams,
+    ) => Promise<Notifications>;
+    /**
+     * @name notificationsUpdate
+     * @request PUT:/repos/{owner}/{repo}/notifications
+     * @description Mark notifications as read in a repository. Marking all notifications in a repository as "read" removes them from the default view on GitHub.com.
+     */
+    notificationsUpdate: (
+      owner: string,
+      repo: string,
+      body: NotificationMarkRead,
+      params?: RequestParams,
+    ) => Promise<any>;
+    /**
+     * @name pullsDetail
+     * @request GET:/repos/{owner}/{repo}/pulls
+     * @description List pull requests.
+     */
+    pullsDetail: (
+      owner: string,
+      repo: string,
+      query?: {
+        state?: "open" | "closed";
+        head?: string;
+        base?: string;
+      },
+      params?: RequestParams,
+    ) => Promise<Pulls>;
+    /**
+     * @name pullsCreate
+     * @request POST:/repos/{owner}/{repo}/pulls
+     * @description Create a pull request.
+     */
+    pullsCreate: (owner: string, repo: string, body: PullsPost, params?: RequestParams) => Promise<Pulls>;
+    /**
+     * @name pullsCommentsDetail
+     * @request GET:/repos/{owner}/{repo}/pulls/comments
+     * @description List comments in a repository. By default, Review Comments are ordered by ascending ID.
+     */
+    pullsCommentsDetail: (
+      owner: string,
+      repo: string,
+      query?: {
+        direction?: string;
+        sort?: "created" | "updated";
+        since?: string;
+      },
+      params?: RequestParams,
+    ) => Promise<IssuesComments>;
+    /**
+     * @name pullsCommentsDelete
+     * @request DELETE:/repos/{owner}/{repo}/pulls/comments/{commentId}
+     * @description Delete a comment.
+     */
+    pullsCommentsDelete: (owner: string, repo: string, commentId: number, params?: RequestParams) => Promise<any>;
+    /**
+     * @name pullsCommentsDetail
+     * @request GET:/repos/{owner}/{repo}/pulls/comments/{commentId}
+     * @description Get a single comment.
+     * @originalName pullsCommentsDetail
+     * @duplicate
+     */
+    pullsCommentsDetail2: (
+      owner: string,
+      repo: string,
+      commentId: number,
+      params?: RequestParams,
+    ) => Promise<PullsComment>;
+    /**
+     * @name pullsCommentsPartialUpdate
+     * @request PATCH:/repos/{owner}/{repo}/pulls/comments/{commentId}
+     * @description Edit a comment.
+     */
+    pullsCommentsPartialUpdate: (
+      owner: string,
+      repo: string,
+      commentId: number,
+      body: CommentBody,
+      params?: RequestParams,
+    ) => Promise<PullsComment>;
+    /**
+     * @name pullsDetail
+     * @request GET:/repos/{owner}/{repo}/pulls/{number}
+     * @description Get a single pull request.
+     * @originalName pullsDetail
+     * @duplicate
+     */
+    pullsDetail2: (owner: string, repo: string, number: number, params?: RequestParams) => Promise<PullRequest>;
+    /**
+     * @name pullsPartialUpdate
+     * @request PATCH:/repos/{owner}/{repo}/pulls/{number}
+     * @description Update a pull request.
+     */
+    pullsPartialUpdate: (
+      owner: string,
+      repo: string,
+      number: number,
+      body: PullUpdate,
+      params?: RequestParams,
+    ) => Promise<Repo>;
+    /**
+     * @name pullsCommentsDetail
+     * @request GET:/repos/{owner}/{repo}/pulls/{number}/comments
+     * @description List comments on a pull request.
+     * @originalName pullsCommentsDetail
+     * @duplicate
+     */
+    pullsCommentsDetail3: (
+      owner: string,
+      repo: string,
+      number: number,
+      params?: RequestParams,
+    ) => Promise<PullsComment>;
+    /**
+     * @name pullsCommentsCreate
+     * @request POST:/repos/{owner}/{repo}/pulls/{number}/comments
+     * @description Create a comment. #TODO Alternative input ( http://developer.github.com/v3/pulls/comments/ ) description: | Alternative Input. Instead of passing commit_id, path, and position you can reply to an existing Pull Request Comment like this: body Required string in_reply_to Required number - Comment id to reply to.
+     */
+    pullsCommentsCreate: (
+      owner: string,
+      repo: string,
+      number: number,
+      body: PullsCommentPost,
+      params?: RequestParams,
+    ) => Promise<PullsComment>;
+    /**
+     * @name pullsCommitsDetail
+     * @request GET:/repos/{owner}/{repo}/pulls/{number}/commits
+     * @description List commits on a pull request.
+     */
+    pullsCommitsDetail: (owner: string, repo: string, number: number, params?: RequestParams) => Promise<Commits>;
+    /**
+     * @name pullsFilesDetail
+     * @request GET:/repos/{owner}/{repo}/pulls/{number}/files
+     * @description List pull requests files.
+     */
+    pullsFilesDetail: (owner: string, repo: string, number: number, params?: RequestParams) => Promise<Pulls>;
+    /**
+     * @name pullsMergeDetail
+     * @request GET:/repos/{owner}/{repo}/pulls/{number}/merge
+     * @description Get if a pull request has been merged.
+     */
+    pullsMergeDetail: (owner: string, repo: string, number: number, params?: RequestParams) => Promise<any>;
+    /**
+     * @name pullsMergeUpdate
+     * @request PUT:/repos/{owner}/{repo}/pulls/{number}/merge
+     * @description Merge a pull request (Merge Button's)
+     */
+    pullsMergeUpdate: (
+      owner: string,
+      repo: string,
+      number: number,
+      body: MergePullBody,
+      params?: RequestParams,
+    ) => Promise<Merge>;
+    /**
+     * @name readmeDetail
+     * @request GET:/repos/{owner}/{repo}/readme
+     * @description Get the README. This method returns the preferred README for a repository.
+     */
+    readmeDetail: (
+      owner: string,
+      repo: string,
+      query?: {
+        ref?: string;
+      },
+      params?: RequestParams,
+    ) => Promise<ContentsPath>;
+    /**
+     * @name releasesDetail
+     * @request GET:/repos/{owner}/{repo}/releases
+     * @description Users with push access to the repository will receive all releases (i.e., published releases and draft releases). Users with pull access will receive published releases only
+     */
+    releasesDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Releases>;
+    /**
+     * @name releasesCreate
+     * @request POST:/repos/{owner}/{repo}/releases
+     * @description Create a release Users with push access to the repository can create a release.
+     */
+    releasesCreate: (owner: string, repo: string, body: ReleaseCreate, params?: RequestParams) => Promise<Release>;
+    /**
+     * @name releasesAssetsDelete
+     * @request DELETE:/repos/{owner}/{repo}/releases/assets/{id}
+     * @description Delete a release asset
+     */
+    releasesAssetsDelete: (owner: string, repo: string, id: string, params?: RequestParams) => Promise<any>;
+    /**
+     * @name releasesAssetsDetail
+     * @request GET:/repos/{owner}/{repo}/releases/assets/{id}
+     * @description Get a single release asset
+     */
+    releasesAssetsDetail: (owner: string, repo: string, id: string, params?: RequestParams) => Promise<Asset>;
+    /**
+     * @name releasesAssetsPartialUpdate
+     * @request PATCH:/repos/{owner}/{repo}/releases/assets/{id}
+     * @description Edit a release asset Users with push access to the repository can edit a release asset.
+     */
+    releasesAssetsPartialUpdate: (
+      owner: string,
+      repo: string,
+      id: string,
+      body: AssetPatch,
+      params?: RequestParams,
+    ) => Promise<Asset>;
+    /**
+     * @name releasesDelete
+     * @request DELETE:/repos/{owner}/{repo}/releases/{id}
+     * @description Users with push access to the repository can delete a release.
+     */
+    releasesDelete: (owner: string, repo: string, id: string, params?: RequestParams) => Promise<any>;
+    /**
+     * @name releasesDetail
+     * @request GET:/repos/{owner}/{repo}/releases/{id}
+     * @description Get a single release
+     * @originalName releasesDetail
+     * @duplicate
+     */
+    releasesDetail2: (owner: string, repo: string, id: string, params?: RequestParams) => Promise<Release>;
+    /**
+     * @name releasesPartialUpdate
+     * @request PATCH:/repos/{owner}/{repo}/releases/{id}
+     * @description Users with push access to the repository can edit a release
+     */
+    releasesPartialUpdate: (
+      owner: string,
+      repo: string,
+      id: string,
+      body: ReleaseCreate,
+      params?: RequestParams,
+    ) => Promise<Release>;
+    /**
+     * @name releasesAssetsDetail
+     * @request GET:/repos/{owner}/{repo}/releases/{id}/assets
+     * @description List assets for a release
+     * @originalName releasesAssetsDetail
+     * @duplicate
+     */
+    releasesAssetsDetail2: (owner: string, repo: string, id: string, params?: RequestParams) => Promise<Assets>;
+    /**
+     * @name stargazersDetail
+     * @request GET:/repos/{owner}/{repo}/stargazers
+     * @description List Stargazers.
+     */
+    stargazersDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Users>;
+    /**
+     * @name statsCodeFrequencyDetail
+     * @request GET:/repos/{owner}/{repo}/stats/code_frequency
+     * @description Get the number of additions and deletions per week. Returns a weekly aggregate of the number of additions and deletions pushed to a repository.
+     */
+    statsCodeFrequencyDetail: (owner: string, repo: string, params?: RequestParams) => Promise<CodeFrequencyStats>;
+    /**
+     * @name statsCommitActivityDetail
+     * @request GET:/repos/{owner}/{repo}/stats/commit_activity
+     * @description Get the last year of commit activity data. Returns the last year of commit activity grouped by week. The days array is a group of commits per day, starting on Sunday.
+     */
+    statsCommitActivityDetail: (owner: string, repo: string, params?: RequestParams) => Promise<CommitActivityStats>;
+    /**
+     * @name statsContributorsDetail
+     * @request GET:/repos/{owner}/{repo}/stats/contributors
+     * @description Get contributors list with additions, deletions, and commit counts.
+     */
+    statsContributorsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<ContributorsStats>;
+    /**
+     * @name statsParticipationDetail
+     * @request GET:/repos/{owner}/{repo}/stats/participation
+     * @description Get the weekly commit count for the repo owner and everyone else.
+     */
+    statsParticipationDetail: (owner: string, repo: string, params?: RequestParams) => Promise<ParticipationStats>;
+    /**
+     * @name statsPunchCardDetail
+     * @request GET:/repos/{owner}/{repo}/stats/punch_card
+     * @description Get the number of commits per hour in each day. Each array contains the day number, hour number, and number of commits 0-6 Sunday - Saturday 0-23 Hour of day Number of commits For example, [2, 14, 25] indicates that there were 25 total commits, during the 2.00pm hour on Tuesdays. All times are based on the time zone of individual commits.
+     */
+    statsPunchCardDetail: (owner: string, repo: string, params?: RequestParams) => Promise<CodeFrequencyStats>;
+    /**
+     * @name statusesDetail
+     * @request GET:/repos/{owner}/{repo}/statuses/{ref}
+     * @description List Statuses for a specific Ref.
+     */
+    statusesDetail: (owner: string, repo: string, ref: string, params?: RequestParams) => Promise<Ref>;
+    /**
+     * @name statusesCreate
+     * @request POST:/repos/{owner}/{repo}/statuses/{ref}
+     * @description Create a Status.
+     */
+    statusesCreate: (
+      owner: string,
+      repo: string,
+      ref: string,
+      body: HeadBranch,
+      params?: RequestParams,
+    ) => Promise<Ref>;
+    /**
+     * @name subscribersDetail
+     * @request GET:/repos/{owner}/{repo}/subscribers
+     * @description List watchers.
+     */
+    subscribersDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Users>;
+    /**
+     * @name subscriptionDelete
+     * @request DELETE:/repos/{owner}/{repo}/subscription
+     * @description Delete a Repository Subscription.
+     */
+    subscriptionDelete: (owner: string, repo: string, params?: RequestParams) => Promise<any>;
+    /**
+     * @name subscriptionDetail
+     * @request GET:/repos/{owner}/{repo}/subscription
+     * @description Get a Repository Subscription.
+     */
+    subscriptionDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Subscription>;
+    /**
+     * @name subscriptionUpdate
+     * @request PUT:/repos/{owner}/{repo}/subscription
+     * @description Set a Repository Subscription
+     */
+    subscriptionUpdate: (
+      owner: string,
+      repo: string,
+      body: SubscriptionBody,
+      params?: RequestParams,
+    ) => Promise<Subscription>;
+    /**
+     * @name tagsDetail
+     * @request GET:/repos/{owner}/{repo}/tags
+     * @description Get list of tags.
+     */
+    tagsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Tags>;
+    /**
+     * @name teamsDetail
+     * @request GET:/repos/{owner}/{repo}/teams
+     * @description Get list of teams
+     */
+    teamsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Teams>;
+    /**
+     * @name watchersDetail
+     * @request GET:/repos/{owner}/{repo}/watchers
+     * @description List Stargazers. New implementation.
+     */
+    watchersDetail: (owner: string, repo: string, params?: RequestParams) => Promise<Users>;
+    /**
+     * @name reposDetail
+     * @request GET:/repos/{owner}/{repo}/{archive_format}/{path}
+     * @description Get archive link. This method will return a 302 to a URL to download a tarball or zipball archive for a repository. Please make sure your HTTP framework is configured to follow redirects or you will need to use the Location header to make a second GET request. Note: For private repositories, these links are temporary and expire quickly.
+     * @originalName reposDetail
+     * @duplicate
+     */
+    reposDetail2: (
+      owner: string,
+      repo: string,
+      archive_format: "tarball" | "zipball",
+      path: string,
+      params?: RequestParams,
+    ) => Promise<any>;
+  };
+  repositories: {
+    /**
+     * @name repositoriesList
+     * @request GET:/repositories
+     * @description List all public repositories. This provides a dump of every public repository, in the order that they were created. Note: Pagination is powered exclusively by the since parameter. is the Link header to get the URL for the next page of repositories.
+     */
+    repositoriesList: (
+      query?: {
+        since?: string;
+      },
+      params?: RequestParams,
+    ) => Promise<Repos>;
+  };
+  search: {
+    /**
+     * @name codeList
+     * @request GET:/search/code
+     * @description Search code.
+     */
+    codeList: (
+      query: {
+        order?: "desc" | "asc";
+        q: string;
+        sort?: "indexed";
+      },
+      params?: RequestParams,
+    ) => Promise<SearchCode>;
+    /**
+     * @name issuesList
+     * @request GET:/search/issues
+     * @description Find issues by state and keyword. (This method returns up to 100 results per page.)
+     */
+    issuesList: (
+      query: {
+        order?: "desc" | "asc";
+        q: string;
+        sort?: "updated" | "created" | "comments";
+      },
+      params?: RequestParams,
+    ) => Promise<SearchIssues>;
+    /**
+     * @name repositoriesList
+     * @request GET:/search/repositories
+     * @description Search repositories.
+     */
+    repositoriesList: (
+      query: {
+        order?: "desc" | "asc";
+        q: string;
+        sort?: "stars" | "forks" | "updated";
+      },
+      params?: RequestParams,
+    ) => Promise<SearchRepositories>;
+    /**
+     * @name usersList
+     * @request GET:/search/users
+     * @description Search users.
+     */
+    usersList: (
+      query: {
+        order?: "desc" | "asc";
+        q: string;
+        sort?: "followers" | "repositories" | "joined";
+      },
+      params?: RequestParams,
+    ) => Promise<SearchUsers>;
+  };
+  teams: {
+    /**
+     * @name teamsDelete
+     * @request DELETE:/teams/{teamId}
+     * @description Delete team. In order to delete a team, the authenticated user must be an owner of the org that the team is associated with.
+     */
+    teamsDelete: (teamId: number, params?: RequestParams) => Promise<any>;
+    /**
+     * @name teamsDetail
+     * @request GET:/teams/{teamId}
+     * @description Get team.
+     */
+    teamsDetail: (teamId: number, params?: RequestParams) => Promise<Team>;
+    /**
+     * @name teamsPartialUpdate
+     * @request PATCH:/teams/{teamId}
+     * @description Edit team. In order to edit a team, the authenticated user must be an owner of the org that the team is associated with.
+     */
+    teamsPartialUpdate: (teamId: number, body: EditTeam, params?: RequestParams) => Promise<Team>;
+    /**
+     * @name membersDetail
+     * @request GET:/teams/{teamId}/members
+     * @description List team members. In order to list members in a team, the authenticated user must be a member of the team.
+     */
+    membersDetail: (teamId: number, params?: RequestParams) => Promise<Users>;
+    /**
+     * @name membersDelete
+     * @request DELETE:/teams/{teamId}/members/{username}
+     * @description The "Remove team member" API is deprecated and is scheduled for removal in the next major version of the API. We recommend using the Remove team membership API instead. It allows you to remove both active and pending memberships. Remove team member. In order to remove a user from a team, the authenticated user must have 'admin' permissions to the team or be an owner of the org that the team is associated with. NOTE This does not delete the user, it just remove them from the team.
+     */
+    membersDelete: (teamId: number, username: string, params?: RequestParams) => Promise<any>;
+    /**
+     * @name membersDetail
+     * @request GET:/teams/{teamId}/members/{username}
+     * @description The "Get team member" API is deprecated and is scheduled for removal in the next major version of the API. We recommend using the Get team membership API instead. It allows you to get both active and pending memberships. Get team member. In order to get if a user is a member of a team, the authenticated user mus be a member of the team.
+     * @originalName membersDetail
+     * @duplicate
+     */
+    membersDetail2: (teamId: number, username: string, params?: RequestParams) => Promise<any>;
+    /**
+     * @name membersUpdate
+     * @request PUT:/teams/{teamId}/members/{username}
+     * @description The API (described below) is deprecated and is scheduled for removal in the next major version of the API. We recommend using the Add team membership API instead. It allows you to invite new organization members to your teams. Add team member. In order to add a user to a team, the authenticated user must have 'admin' permissions to the team or be an owner of the org that the team is associated with.
+     */
+    membersUpdate: (teamId: number, username: string, params?: RequestParams) => Promise<any>;
+    /**
+     * @name membershipsDelete
+     * @request DELETE:/teams/{teamId}/memberships/{username}
+     * @description Remove team membership. In order to remove a membership between a user and a team, the authenticated user must have 'admin' permissions to the team or be an owner of the organization that the team is associated with. NOTE: This does not delete the user, it just removes their membership from the team.
+     */
+    membershipsDelete: (teamId: number, username: string, params?: RequestParams) => Promise<any>;
+    /**
+     * @name membershipsDetail
+     * @request GET:/teams/{teamId}/memberships/{username}
+     * @description Get team membership. In order to get a user's membership with a team, the authenticated user must be a member of the team or an owner of the team's organization.
+     */
+    membershipsDetail: (teamId: number, username: string, params?: RequestParams) => Promise<TeamMembership>;
+    /**
+     * @name membershipsUpdate
+     * @request PUT:/teams/{teamId}/memberships/{username}
+     * @description Add team membership. In order to add a membership between a user and a team, the authenticated user must have 'admin' permissions to the team or be an owner of the organization that the team is associated with. If the user is already a part of the team's organization (meaning they're on at least one other team in the organization), this endpoint will add the user to the team. If the user is completely unaffiliated with the team's organization (meaning they're on none of the organization's teams), this endpoint will send an invitation to the user via email. This newly-created membership will be in the 'pending' state until the user accepts the invitation, at which point the membership will transition to the 'active' state and the user will be added as a member of the team.
+     */
+    membershipsUpdate: (teamId: number, username: string, params?: RequestParams) => Promise<TeamMembership>;
+    /**
+     * @name reposDetail
+     * @request GET:/teams/{teamId}/repos
+     * @description List team repos
+     */
+    reposDetail: (teamId: number, params?: RequestParams) => Promise<Repos>;
+    /**
+     * @name reposDelete
+     * @request DELETE:/teams/{teamId}/repos/{owner}/{repo}
+     * @description In order to remove a repository from a team, the authenticated user must be an owner of the org that the team is associated with. NOTE: This does not delete the repository, it just removes it from the team.
+     */
+    reposDelete: (teamId: number, owner: string, repo: string, params?: RequestParams) => Promise<any>;
+    /**
+     * @name reposDetail
+     * @request GET:/teams/{teamId}/repos/{owner}/{repo}
+     * @description Check if a team manages a repository
+     * @originalName reposDetail
+     * @duplicate
+     */
+    reposDetail2: (teamId: number, owner: string, repo: string, params?: RequestParams) => Promise<any>;
+    /**
+     * @name reposUpdate
+     * @request PUT:/teams/{teamId}/repos/{owner}/{repo}
+     * @description In order to add a repository to a team, the authenticated user must be an owner of the org that the team is associated with. Also, the repository must be owned by the organization, or a direct fork of a repository owned by the organization.
+     */
+    reposUpdate: (teamId: number, owner: string, repo: string, params?: RequestParams) => Promise<any>;
+  };
+  user: {
+    /**
+     * @name userList
+     * @request GET:/user
+     * @description Get the authenticated user.
+     */
+    userList: (params?: RequestParams) => Promise<any>;
+    /**
+     * @name userPartialUpdate
+     * @request PATCH:/user
+     * @description Update the authenticated user.
+     */
+    userPartialUpdate: (body: UserUpdate, params?: RequestParams) => Promise<any>;
+    /**
+     * @name emailsDelete
+     * @request DELETE:/user/emails
+     * @description Delete email address(es). You can include a single email address or an array of addresses.
+     */
+    emailsDelete: (body: UserEmails, params?: RequestParams) => Promise<any>;
+    /**
+     * @name emailsList
+     * @request GET:/user/emails
+     * @description List email addresses for a user. In the final version of the API, this method will return an array of hashes with extended information for each email address indicating if the address has been verified and if it's primary email address for GitHub. Until API v3 is finalized, use the application/vnd.github.v3 media type to get other response format.
+     */
+    emailsList: (params?: RequestParams) => Promise<UserEmails>;
+    /**
+     * @name emailsCreate
+     * @request POST:/user/emails
+     * @description Add email address(es). You can post a single email address or an array of addresses.
+     */
+    emailsCreate: (body: EmailsPost, params?: RequestParams) => Promise<any>;
+    /**
+     * @name followersList
+     * @request GET:/user/followers
+     * @description List the authenticated user's followers
+     */
+    followersList: (params?: RequestParams) => Promise<Users>;
+    /**
+     * @name followingList
+     * @request GET:/user/following
+     * @description List who the authenticated user is following.
+     */
+    followingList: (params?: RequestParams) => Promise<Users>;
+    /**
+     * @name followingDelete
+     * @request DELETE:/user/following/{username}
+     * @description Unfollow a user. Unfollowing a user requires the user to be logged in and authenticated with basic auth or OAuth with the user:follow scope.
+     */
+    followingDelete: (username: string, params?: RequestParams) => Promise<any>;
+    /**
+     * @name followingDetail
+     * @request GET:/user/following/{username}
+     * @description Check if you are following a user.
+     */
+    followingDetail: (username: string, params?: RequestParams) => Promise<any>;
+    /**
+     * @name followingUpdate
+     * @request PUT:/user/following/{username}
+     * @description Follow a user. Following a user requires the user to be logged in and authenticated with basic auth or OAuth with the user:follow scope.
+     */
+    followingUpdate: (username: string, params?: RequestParams) => Promise<any>;
+    /**
+     * @name issuesList
+     * @request GET:/user/issues
+     * @description List issues. List all issues across owned and member repositories for the authenticated user.
+     */
+    issuesList: (
+      query: {
+        filter: "assigned" | "created" | "mentioned" | "subscribed" | "all";
+        state: "open" | "closed";
+        labels: string;
+        sort: "created" | "updated" | "comments";
+        direction: "asc" | "desc";
+        since?: string;
+      },
+      params?: RequestParams,
+    ) => Promise<Issues>;
+    /**
+     * @name keysList
+     * @request GET:/user/keys
+     * @description List your public keys. Lists the current user's keys. Management of public keys via the API requires that you are authenticated through basic auth, or OAuth with the 'user', 'write:public_key' scopes.
+     */
+    keysList: (params?: RequestParams) => Promise<Gitignore>;
+    /**
+     * @name keysCreate
+     * @request POST:/user/keys
+     * @description Create a public key.
+     */
+    keysCreate: (body: UserKeysPost, params?: RequestParams) => Promise<UserKeysKeyId>;
+    /**
+     * @name keysDelete
+     * @request DELETE:/user/keys/{keyId}
+     * @description Delete a public key. Removes a public key. Requires that you are authenticated via Basic Auth or via OAuth with at least admin:public_key scope.
+     */
+    keysDelete: (keyId: number, params?: RequestParams) => Promise<any>;
+    /**
+     * @name keysDetail
+     * @request GET:/user/keys/{keyId}
+     * @description Get a single public key.
+     */
+    keysDetail: (keyId: number, params?: RequestParams) => Promise<UserKeysKeyId>;
+    /**
+     * @name orgsList
+     * @request GET:/user/orgs
+     * @description List public and private organizations for the authenticated user.
+     */
+    orgsList: (params?: RequestParams) => Promise<Gitignore>;
+    /**
+     * @name reposList
+     * @request GET:/user/repos
+     * @description List repositories for the authenticated user. Note that this does not include repositories owned by organizations which the user can access. You can lis user organizations and list organization repositories separately.
+     */
+    reposList: (
+      query?: {
+        type?: "all" | "public" | "private" | "forks" | "sources" | "member";
+      },
+      params?: RequestParams,
+    ) => Promise<Repos>;
+    /**
+     * @name reposCreate
+     * @request POST:/user/repos
+     * @description Create a new repository for the authenticated user. OAuth users must supply repo scope.
+     */
+    reposCreate: (body: PostRepo, params?: RequestParams) => Promise<Repos>;
+    /**
+     * @name starredList
+     * @request GET:/user/starred
+     * @description List repositories being starred by the authenticated user.
+     */
+    starredList: (
+      query?: {
+        direction?: string;
+        sort?: "created" | "updated";
+      },
+      params?: RequestParams,
+    ) => Promise<Gitignore>;
+    /**
+     * @name starredDelete
+     * @request DELETE:/user/starred/{owner}/{repo}
+     * @description Unstar a repository
+     */
+    starredDelete: (owner: string, repo: string, params?: RequestParams) => Promise<any>;
+    /**
+     * @name starredDetail
+     * @request GET:/user/starred/{owner}/{repo}
+     * @description Check if you are starring a repository.
+     */
+    starredDetail: (owner: string, repo: string, params?: RequestParams) => Promise<any>;
+    /**
+     * @name starredUpdate
+     * @request PUT:/user/starred/{owner}/{repo}
+     * @description Star a repository.
+     */
+    starredUpdate: (owner: string, repo: string, params?: RequestParams) => Promise<any>;
+    /**
+     * @name subscriptionsList
+     * @request GET:/user/subscriptions
+     * @description List repositories being watched by the authenticated user.
+     */
+    subscriptionsList: (params?: RequestParams) => Promise<Repos>;
+    /**
+     * @name subscriptionsDelete
+     * @request DELETE:/user/subscriptions/{owner}/{repo}
+     * @description Stop watching a repository
+     */
+    subscriptionsDelete: (owner: string, repo: string, params?: RequestParams) => Promise<any>;
+    /**
+     * @name subscriptionsDetail
+     * @request GET:/user/subscriptions/{owner}/{repo}
+     * @description Check if you are watching a repository.
+     */
+    subscriptionsDetail: (owner: string, repo: string, params?: RequestParams) => Promise<any>;
+    /**
+     * @name subscriptionsUpdate
+     * @request PUT:/user/subscriptions/{owner}/{repo}
+     * @description Watch a repository.
+     */
+    subscriptionsUpdate: (owner: string, repo: string, params?: RequestParams) => Promise<any>;
+    /**
+     * @name teamsList
+     * @request GET:/user/teams
+     * @description List all of the teams across all of the organizations to which the authenticated user belongs. This method requires user or repo scope when authenticating via OAuth.
+     */
+    teamsList: (params?: RequestParams) => Promise<TeamsList>;
+  };
+  users: {
+    /**
+     * @name usersList
+     * @request GET:/users
+     * @description Get all users. This provides a dump of every user, in the order that they signed up for GitHub. Note: Pagination is powered exclusively by the since parameter. Use the Link header to get the URL for the next page of users.
+     */
+    usersList: (
+      query?: {
+        since?: number;
+      },
+      params?: RequestParams,
+    ) => Promise<Users>;
+    /**
+     * @name usersDetail
+     * @request GET:/users/{username}
+     * @description Get a single user.
+     */
+    usersDetail: (username: string, params?: RequestParams) => Promise<any>;
+    /**
+     * @name eventsDetail
+     * @request GET:/users/{username}/events
+     * @description If you are authenticated as the given user, you will see your private events. Otherwise, you'll only see public events.
+     */
+    eventsDetail: (username: string, params?: RequestParams) => Promise<any>;
+    /**
+     * @name eventsOrgsDetail
+     * @request GET:/users/{username}/events/orgs/{org}
+     * @description This is the user's organization dashboard. You must be authenticated as the user to view this.
+     */
+    eventsOrgsDetail: (username: string, org: string, params?: RequestParams) => Promise<any>;
+    /**
+     * @name followersDetail
+     * @request GET:/users/{username}/followers
+     * @description List a user's followers
+     */
+    followersDetail: (username: string, params?: RequestParams) => Promise<Users>;
+    /**
+     * @name followingDetail
+     * @request GET:/users/{username}/following/{targetUser}
+     * @description Check if one user follows another.
+     */
+    followingDetail: (username: string, targetUser: string, params?: RequestParams) => Promise<any>;
+    /**
+     * @name gistsDetail
+     * @request GET:/users/{username}/gists
+     * @description List a users gists.
+     */
+    gistsDetail: (
+      username: string,
+      query?: {
+        since?: string;
+      },
+      params?: RequestParams,
+    ) => Promise<Gists>;
+    /**
+     * @name keysDetail
+     * @request GET:/users/{username}/keys
+     * @description List public keys for a user. Lists the verified public keys for a user. This is accessible by anyone.
+     */
+    keysDetail: (username: string, params?: RequestParams) => Promise<Gitignore>;
+    /**
+     * @name orgsDetail
+     * @request GET:/users/{username}/orgs
+     * @description List all public organizations for a user.
+     */
+    orgsDetail: (username: string, params?: RequestParams) => Promise<Gitignore>;
+    /**
+     * @name receivedEventsDetail
+     * @request GET:/users/{username}/received_events
+     * @description These are events that you'll only see public events.
+     */
+    receivedEventsDetail: (username: string, params?: RequestParams) => Promise<any>;
+    /**
+     * @name receivedEventsPublicDetail
+     * @request GET:/users/{username}/received_events/public
+     * @description List public events that a user has received
+     */
+    receivedEventsPublicDetail: (username: string, params?: RequestParams) => Promise<any>;
+    /**
+     * @name reposDetail
+     * @request GET:/users/{username}/repos
+     * @description List public repositories for the specified user.
+     */
+    reposDetail: (
+      username: string,
+      query?: {
+        type?: "all" | "public" | "private" | "forks" | "sources" | "member";
+      },
+      params?: RequestParams,
+    ) => Promise<Repos>;
+    /**
+     * @name starredDetail
+     * @request GET:/users/{username}/starred
+     * @description List repositories being starred by a user.
+     */
+    starredDetail: (username: string, params?: RequestParams) => Promise<any>;
+    /**
+     * @name subscriptionsDetail
+     * @request GET:/users/{username}/subscriptions
+     * @description List repositories being watched by a user.
+     */
+    subscriptionsDetail: (username: string, params?: RequestParams) => Promise<any>;
+  };
 }
 export {};

--- a/tests/spec/js/schema.js
+++ b/tests/spec/js/schema.js
@@ -31,11 +31,25 @@ class HttpClient {
     this.bodyFormatters = {
       [BodyType.Json]: JSON.stringify,
     };
-    this.safeParseResponse = (response) =>
-      response
+    this.safeParseResponse = (response) => {
+      const r = response.clone();
+      r.data = null;
+      r.error = null;
+      return response
         .json()
-        .then((data) => data)
-        .catch((e) => response.text);
+        .then((data) => {
+          if (r.ok) {
+            r.data = data;
+          } else {
+            r.error = data;
+          }
+          return r;
+        })
+        .catch((e) => {
+          r.error = e;
+          return r;
+        });
+    };
     this.request = (path, method, { secure, ...params } = {}, body, bodyType, secureByDefault) =>
       fetch(`${this.baseUrl}${path}`, {
         // @ts-ignore

--- a/tests/spec/js/schema.js
+++ b/tests/spec/js/schema.js
@@ -1,5 +1,13 @@
 /* tslint:disable */
 /* eslint-disable */
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
 var BodyType;
 (function (BodyType) {
   BodyType[(BodyType["Json"] = 0)] = "Json";
@@ -31,10 +39,7 @@ class HttpClient {
     this.request = (path, method, { secure, ...params } = {}, body, bodyType, secureByDefault) =>
       fetch(`${this.baseUrl}${path}`, {
         // @ts-ignore
-        ...this.mergeRequestOptions(
-          params,
-          (secureByDefault || secure) && this.securityWorker(this.securityData),
-        ),
+        ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
         method,
         body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
       }).then(async (response) => {
@@ -48,9 +53,7 @@ class HttpClient {
   }
   addQueryParam(query, key) {
     return (
-      encodeURIComponent(key) +
-      "=" +
-      encodeURIComponent(Array.isArray(query[key]) ? query[key].join(",") : query[key])
+      encodeURIComponent(key) + "=" + encodeURIComponent(Array.isArray(query[key]) ? query[key].join(",") : query[key])
     );
   }
   addQueryParams(rawQuery) {
@@ -118,8 +121,7 @@ export class Api extends HttpClient {
        * @request GET:/gists
        * @description List the authenticated user's gists or if called anonymously, this will return all public gists.
        */
-      gistsList: (query, params) =>
-        this.request(`/gists${this.addQueryParams(query)}`, "GET", params),
+      gistsList: (query, params) => this.request(`/gists${this.addQueryParams(query)}`, "GET", params),
       /**
        * @name gistsCreate
        * @request POST:/gists
@@ -131,15 +133,13 @@ export class Api extends HttpClient {
        * @request GET:/gists/public
        * @description List all public gists.
        */
-      publicList: (query, params) =>
-        this.request(`/gists/public${this.addQueryParams(query)}`, "GET", params),
+      publicList: (query, params) => this.request(`/gists/public${this.addQueryParams(query)}`, "GET", params),
       /**
        * @name starredList
        * @request GET:/gists/starred
        * @description List the authenticated user's starred gists.
        */
-      starredList: (query, params) =>
-        this.request(`/gists/starred${this.addQueryParams(query)}`, "GET", params),
+      starredList: (query, params) => this.request(`/gists/starred${this.addQueryParams(query)}`, "GET", params),
       /**
        * @name gistsDelete
        * @request DELETE:/gists/{id}
@@ -169,15 +169,13 @@ export class Api extends HttpClient {
        * @request POST:/gists/{id}/comments
        * @description Create a commen
        */
-      commentsCreate: (id, body, params) =>
-        this.request(`/gists/${id}/comments`, "POST", params, body),
+      commentsCreate: (id, body, params) => this.request(`/gists/${id}/comments`, "POST", params, body),
       /**
        * @name commentsDelete
        * @request DELETE:/gists/{id}/comments/{commentId}
        * @description Delete a comment.
        */
-      commentsDelete: (id, commentId, params) =>
-        this.request(`/gists/${id}/comments/${commentId}`, "DELETE", params),
+      commentsDelete: (id, commentId, params) => this.request(`/gists/${id}/comments/${commentId}`, "DELETE", params),
       /**
        * @name commentsDetail
        * @request GET:/gists/{id}/comments/{commentId}
@@ -185,8 +183,7 @@ export class Api extends HttpClient {
        * @originalName commentsDetail
        * @duplicate
        */
-      commentsDetail2: (id, commentId, params) =>
-        this.request(`/gists/${id}/comments/${commentId}`, "GET", params),
+      commentsDetail2: (id, commentId, params) => this.request(`/gists/${id}/comments/${commentId}`, "GET", params),
       /**
        * @name commentsPartialUpdate
        * @request PATCH:/gists/{id}/comments/{commentId}
@@ -231,8 +228,7 @@ export class Api extends HttpClient {
        * @request GET:/gitignore/templates/{language}
        * @description Get a single template.
        */
-      templatesDetail: (language, params) =>
-        this.request(`/gitignore/templates/${language}`, "GET", params),
+      templatesDetail: (language, params) => this.request(`/gitignore/templates/${language}`, "GET", params),
     };
     this.issues = {
       /**
@@ -240,8 +236,7 @@ export class Api extends HttpClient {
        * @request GET:/issues
        * @description List issues. List all issues across all the authenticated user's visible repositories.
        */
-      issuesList: (query, params) =>
-        this.request(`/issues${this.addQueryParams(query)}`, "GET", params),
+      issuesList: (query, params) => this.request(`/issues${this.addQueryParams(query)}`, "GET", params),
     };
     this.legacy = {
       /**
@@ -250,11 +245,7 @@ export class Api extends HttpClient {
        * @description Find issues by state and keyword.
        */
       issuesSearchDetail: (keyword, state, owner, repository, params) =>
-        this.request(
-          `/legacy/issues/search/${owner}/${repository}/${state}/${keyword}`,
-          "GET",
-          params,
-        ),
+        this.request(`/legacy/issues/search/${owner}/${repository}/${state}/${keyword}`, "GET", params),
       /**
        * @name reposSearchDetail
        * @request GET:/legacy/repos/search/{keyword}
@@ -267,8 +258,7 @@ export class Api extends HttpClient {
        * @request GET:/legacy/user/email/{email}
        * @description This API call is added for compatibility reasons only.
        */
-      userEmailDetail: (email, params) =>
-        this.request(`/legacy/user/email/${email}`, "GET", params),
+      userEmailDetail: (email, params) => this.request(`/legacy/user/email/${email}`, "GET", params),
       /**
        * @name userSearchDetail
        * @request GET:/legacy/user/search/{keyword}
@@ -305,8 +295,7 @@ export class Api extends HttpClient {
        * @request GET:/networks/{owner}/{repo}/events
        * @description List public events for a network of repositories.
        */
-      eventsDetail: (owner, repo, params) =>
-        this.request(`/networks/${owner}/${repo}/events`, "GET", params),
+      eventsDetail: (owner, repo, params) => this.request(`/networks/${owner}/${repo}/events`, "GET", params),
     };
     this.notifications = {
       /**
@@ -314,8 +303,7 @@ export class Api extends HttpClient {
        * @request GET:/notifications
        * @description List your notifications. List all notifications for the current user, grouped by repository.
        */
-      notificationsList: (query, params) =>
-        this.request(`/notifications${this.addQueryParams(query)}`, "GET", params),
+      notificationsList: (query, params) => this.request(`/notifications${this.addQueryParams(query)}`, "GET", params),
       /**
        * @name notificationsUpdate
        * @request PUT:/notifications
@@ -333,8 +321,7 @@ export class Api extends HttpClient {
        * @request PATCH:/notifications/threads/{id}
        * @description Mark a thread as read
        */
-      threadsPartialUpdate: (id, params) =>
-        this.request(`/notifications/threads/${id}`, "PATCH", params),
+      threadsPartialUpdate: (id, params) => this.request(`/notifications/threads/${id}`, "PATCH", params),
       /**
        * @name threadsSubscriptionDelete
        * @request DELETE:/notifications/threads/{id}/subscription
@@ -394,8 +381,7 @@ export class Api extends HttpClient {
        * @request DELETE:/orgs/{org}/members/{username}
        * @description Remove a member. Removing a user from this list will remove them from all teams and they will no longer have any access to the organization's repositories.
        */
-      membersDelete: (org, username, params) =>
-        this.request(`/orgs/${org}/members/${username}`, "DELETE", params),
+      membersDelete: (org, username, params) => this.request(`/orgs/${org}/members/${username}`, "DELETE", params),
       /**
        * @name membersDetail
        * @request GET:/orgs/{org}/members/{username}
@@ -403,15 +389,13 @@ export class Api extends HttpClient {
        * @originalName membersDetail
        * @duplicate
        */
-      membersDetail2: (org, username, params) =>
-        this.request(`/orgs/${org}/members/${username}`, "GET", params),
+      membersDetail2: (org, username, params) => this.request(`/orgs/${org}/members/${username}`, "GET", params),
       /**
        * @name publicMembersDetail
        * @request GET:/orgs/{org}/public_members
        * @description Public members list. Members of an organization can choose to have their membership publicized or not.
        */
-      publicMembersDetail: (org, params) =>
-        this.request(`/orgs/${org}/public_members`, "GET", params),
+      publicMembersDetail: (org, params) => this.request(`/orgs/${org}/public_members`, "GET", params),
       /**
        * @name publicMembersDelete
        * @request DELETE:/orgs/{org}/public_members/{username}
@@ -475,8 +459,7 @@ export class Api extends HttpClient {
        * @request DELETE:/repos/{owner}/{repo}
        * @description Delete a Repository. Deleting a repository requires admin access. If OAuth is used, the delete_repo scope is required.
        */
-      reposDelete: (owner, repo, params) =>
-        this.request(`/repos/${owner}/${repo}`, "DELETE", params),
+      reposDelete: (owner, repo, params) => this.request(`/repos/${owner}/${repo}`, "DELETE", params),
       /**
        * @name reposDetail
        * @request GET:/repos/{owner}/{repo}
@@ -488,15 +471,13 @@ export class Api extends HttpClient {
        * @request PATCH:/repos/{owner}/{repo}
        * @description Edit repository.
        */
-      reposPartialUpdate: (owner, repo, body, params) =>
-        this.request(`/repos/${owner}/${repo}`, "PATCH", params, body),
+      reposPartialUpdate: (owner, repo, body, params) => this.request(`/repos/${owner}/${repo}`, "PATCH", params, body),
       /**
        * @name assigneesDetail
        * @request GET:/repos/{owner}/{repo}/assignees
        * @description List assignees. This call lists all the available assignees (owner + collaborators) to which issues may be assigned.
        */
-      assigneesDetail: (owner, repo, params) =>
-        this.request(`/repos/${owner}/${repo}/assignees`, "GET", params),
+      assigneesDetail: (owner, repo, params) => this.request(`/repos/${owner}/${repo}/assignees`, "GET", params),
       /**
        * @name assigneesDetail
        * @request GET:/repos/{owner}/{repo}/assignees/{assignee}
@@ -511,8 +492,7 @@ export class Api extends HttpClient {
        * @request GET:/repos/{owner}/{repo}/branches
        * @description Get list of branches
        */
-      branchesDetail: (owner, repo, params) =>
-        this.request(`/repos/${owner}/${repo}/branches`, "GET", params),
+      branchesDetail: (owner, repo, params) => this.request(`/repos/${owner}/${repo}/branches`, "GET", params),
       /**
        * @name branchesDetail
        * @request GET:/repos/{owner}/{repo}/branches/{branch}
@@ -557,8 +537,7 @@ export class Api extends HttpClient {
        * @request GET:/repos/{owner}/{repo}/comments
        * @description List commit comments for a repository. Comments are ordered by ascending ID.
        */
-      commentsDetail: (owner, repo, params) =>
-        this.request(`/repos/${owner}/${repo}/comments`, "GET", params),
+      commentsDetail: (owner, repo, params) => this.request(`/repos/${owner}/${repo}/comments`, "GET", params),
       /**
        * @name commentsDelete
        * @request DELETE:/repos/{owner}/{repo}/comments/{commentId}
@@ -639,11 +618,7 @@ export class Api extends HttpClient {
        * @description Get contents. This method returns the contents of a file or directory in a repository. Files and symlinks support a custom media type for getting the raw content. Directories and submodules do not support custom media types. Note: This API supports files up to 1 megabyte in size. Here can be many outcomes. For details see "http://developer.github.com/v3/repos/contents/"
        */
       contentsDetail: (owner, repo, path, query, params) =>
-        this.request(
-          `/repos/${owner}/${repo}/contents/${path}${this.addQueryParams(query)}`,
-          "GET",
-          params,
-        ),
+        this.request(`/repos/${owner}/${repo}/contents/${path}${this.addQueryParams(query)}`, "GET", params),
       /**
        * @name contentsUpdate
        * @request PUT:/repos/{owner}/{repo}/contents/{path}
@@ -657,18 +632,13 @@ export class Api extends HttpClient {
        * @description Get list of contributors.
        */
       contributorsDetail: (owner, repo, query, params) =>
-        this.request(
-          `/repos/${owner}/${repo}/contributors${this.addQueryParams(query)}`,
-          "GET",
-          params,
-        ),
+        this.request(`/repos/${owner}/${repo}/contributors${this.addQueryParams(query)}`, "GET", params),
       /**
        * @name deploymentsDetail
        * @request GET:/repos/{owner}/{repo}/deployments
        * @description Users with pull access can view deployments for a repository
        */
-      deploymentsDetail: (owner, repo, params) =>
-        this.request(`/repos/${owner}/${repo}/deployments`, "GET", params),
+      deploymentsDetail: (owner, repo, params) => this.request(`/repos/${owner}/${repo}/deployments`, "GET", params),
       /**
        * @name deploymentsCreate
        * @request POST:/repos/{owner}/{repo}/deployments
@@ -695,8 +665,7 @@ export class Api extends HttpClient {
        * @request GET:/repos/{owner}/{repo}/downloads
        * @description Deprecated. List downloads for a repository.
        */
-      downloadsDetail: (owner, repo, params) =>
-        this.request(`/repos/${owner}/${repo}/downloads`, "GET", params),
+      downloadsDetail: (owner, repo, params) => this.request(`/repos/${owner}/${repo}/downloads`, "GET", params),
       /**
        * @name downloadsDelete
        * @request DELETE:/repos/{owner}/{repo}/downloads/{downloadId}
@@ -718,8 +687,7 @@ export class Api extends HttpClient {
        * @request GET:/repos/{owner}/{repo}/events
        * @description Get list of repository events.
        */
-      eventsDetail: (owner, repo, params) =>
-        this.request(`/repos/${owner}/${repo}/events`, "GET", params),
+      eventsDetail: (owner, repo, params) => this.request(`/repos/${owner}/${repo}/events`, "GET", params),
       /**
        * @name forksDetail
        * @request GET:/repos/{owner}/{repo}/forks
@@ -732,8 +700,7 @@ export class Api extends HttpClient {
        * @request POST:/repos/{owner}/{repo}/forks
        * @description Create a fork. Forking a Repository happens asynchronously. Therefore, you may have to wai a short period before accessing the git objects. If this takes longer than 5 minutes, be sure to contact Support.
        */
-      forksCreate: (owner, repo, body, params) =>
-        this.request(`/repos/${owner}/${repo}/forks`, "POST", params, body),
+      forksCreate: (owner, repo, body, params) => this.request(`/repos/${owner}/${repo}/forks`, "POST", params, body),
       /**
        * @name gitBlobsCreate
        * @request POST:/repos/{owner}/{repo}/git/blobs
@@ -767,8 +734,7 @@ export class Api extends HttpClient {
        * @request GET:/repos/{owner}/{repo}/git/refs
        * @description Get all References
        */
-      gitRefsDetail: (owner, repo, params) =>
-        this.request(`/repos/${owner}/${repo}/git/refs`, "GET", params),
+      gitRefsDetail: (owner, repo, params) => this.request(`/repos/${owner}/${repo}/git/refs`, "GET", params),
       /**
        * @name gitRefsCreate
        * @request POST:/repos/{owner}/{repo}/git/refs
@@ -826,25 +792,19 @@ export class Api extends HttpClient {
        * @description Get a Tree.
        */
       gitTreesDetail: (owner, repo, shaCode, query, params) =>
-        this.request(
-          `/repos/${owner}/${repo}/git/trees/${shaCode}${this.addQueryParams(query)}`,
-          "GET",
-          params,
-        ),
+        this.request(`/repos/${owner}/${repo}/git/trees/${shaCode}${this.addQueryParams(query)}`, "GET", params),
       /**
        * @name hooksDetail
        * @request GET:/repos/{owner}/{repo}/hooks
        * @description Get list of hooks.
        */
-      hooksDetail: (owner, repo, params) =>
-        this.request(`/repos/${owner}/${repo}/hooks`, "GET", params),
+      hooksDetail: (owner, repo, params) => this.request(`/repos/${owner}/${repo}/hooks`, "GET", params),
       /**
        * @name hooksCreate
        * @request POST:/repos/{owner}/{repo}/hooks
        * @description Create a hook.
        */
-      hooksCreate: (owner, repo, body, params) =>
-        this.request(`/repos/${owner}/${repo}/hooks`, "POST", params, body),
+      hooksCreate: (owner, repo, body, params) => this.request(`/repos/${owner}/${repo}/hooks`, "POST", params, body),
       /**
        * @name hooksDelete
        * @request DELETE:/repos/{owner}/{repo}/hooks/{hookId}
@@ -887,19 +847,14 @@ export class Api extends HttpClient {
        * @request POST:/repos/{owner}/{repo}/issues
        * @description Create an issue. Any user with pull access to a repository can create an issue.
        */
-      issuesCreate: (owner, repo, body, params) =>
-        this.request(`/repos/${owner}/${repo}/issues`, "POST", params, body),
+      issuesCreate: (owner, repo, body, params) => this.request(`/repos/${owner}/${repo}/issues`, "POST", params, body),
       /**
        * @name issuesCommentsDetail
        * @request GET:/repos/{owner}/{repo}/issues/comments
        * @description List comments in a repository.
        */
       issuesCommentsDetail: (owner, repo, query, params) =>
-        this.request(
-          `/repos/${owner}/${repo}/issues/comments${this.addQueryParams(query)}`,
-          "GET",
-          params,
-        ),
+        this.request(`/repos/${owner}/${repo}/issues/comments${this.addQueryParams(query)}`, "GET", params),
       /**
        * @name issuesCommentsDelete
        * @request DELETE:/repos/{owner}/{repo}/issues/comments/{commentId}
@@ -928,8 +883,7 @@ export class Api extends HttpClient {
        * @request GET:/repos/{owner}/{repo}/issues/events
        * @description List issue events for a repository.
        */
-      issuesEventsDetail: (owner, repo, params) =>
-        this.request(`/repos/${owner}/${repo}/issues/events`, "GET", params),
+      issuesEventsDetail: (owner, repo, params) => this.request(`/repos/${owner}/${repo}/issues/events`, "GET", params),
       /**
        * @name issuesEventsDetail
        * @request GET:/repos/{owner}/{repo}/issues/events/{eventId}
@@ -1022,15 +976,13 @@ export class Api extends HttpClient {
        * @request GET:/repos/{owner}/{repo}/keys
        * @description Get list of keys.
        */
-      keysDetail: (owner, repo, params) =>
-        this.request(`/repos/${owner}/${repo}/keys`, "GET", params),
+      keysDetail: (owner, repo, params) => this.request(`/repos/${owner}/${repo}/keys`, "GET", params),
       /**
        * @name keysCreate
        * @request POST:/repos/{owner}/{repo}/keys
        * @description Create a key.
        */
-      keysCreate: (owner, repo, body, params) =>
-        this.request(`/repos/${owner}/${repo}/keys`, "POST", params, body),
+      keysCreate: (owner, repo, body, params) => this.request(`/repos/${owner}/${repo}/keys`, "POST", params, body),
       /**
        * @name keysDelete
        * @request DELETE:/repos/{owner}/{repo}/keys/{keyId}
@@ -1045,22 +997,19 @@ export class Api extends HttpClient {
        * @originalName keysDetail
        * @duplicate
        */
-      keysDetail2: (owner, repo, keyId, params) =>
-        this.request(`/repos/${owner}/${repo}/keys/${keyId}`, "GET", params),
+      keysDetail2: (owner, repo, keyId, params) => this.request(`/repos/${owner}/${repo}/keys/${keyId}`, "GET", params),
       /**
        * @name labelsDetail
        * @request GET:/repos/{owner}/{repo}/labels
        * @description List all labels for this repository.
        */
-      labelsDetail: (owner, repo, params) =>
-        this.request(`/repos/${owner}/${repo}/labels`, "GET", params),
+      labelsDetail: (owner, repo, params) => this.request(`/repos/${owner}/${repo}/labels`, "GET", params),
       /**
        * @name labelsCreate
        * @request POST:/repos/{owner}/{repo}/labels
        * @description Create a label.
        */
-      labelsCreate: (owner, repo, body, params) =>
-        this.request(`/repos/${owner}/${repo}/labels`, "POST", params, body),
+      labelsCreate: (owner, repo, body, params) => this.request(`/repos/${owner}/${repo}/labels`, "POST", params, body),
       /**
        * @name labelsDelete
        * @request DELETE:/repos/{owner}/{repo}/labels/{name}
@@ -1089,26 +1038,20 @@ export class Api extends HttpClient {
        * @request GET:/repos/{owner}/{repo}/languages
        * @description List languages. List languages for the specified repository. The value on the right of a language is the number of bytes of code written in that language.
        */
-      languagesDetail: (owner, repo, params) =>
-        this.request(`/repos/${owner}/${repo}/languages`, "GET", params),
+      languagesDetail: (owner, repo, params) => this.request(`/repos/${owner}/${repo}/languages`, "GET", params),
       /**
        * @name mergesCreate
        * @request POST:/repos/{owner}/{repo}/merges
        * @description Perform a merge.
        */
-      mergesCreate: (owner, repo, body, params) =>
-        this.request(`/repos/${owner}/${repo}/merges`, "POST", params, body),
+      mergesCreate: (owner, repo, body, params) => this.request(`/repos/${owner}/${repo}/merges`, "POST", params, body),
       /**
        * @name milestonesDetail
        * @request GET:/repos/{owner}/{repo}/milestones
        * @description List milestones for a repository.
        */
       milestonesDetail: (owner, repo, query, params) =>
-        this.request(
-          `/repos/${owner}/${repo}/milestones${this.addQueryParams(query)}`,
-          "GET",
-          params,
-        ),
+        this.request(`/repos/${owner}/${repo}/milestones${this.addQueryParams(query)}`, "GET", params),
       /**
        * @name milestonesCreate
        * @request POST:/repos/{owner}/{repo}/milestones
@@ -1152,11 +1095,7 @@ export class Api extends HttpClient {
        * @description List your notifications in a repository List all notifications for the current user.
        */
       notificationsDetail: (owner, repo, query, params) =>
-        this.request(
-          `/repos/${owner}/${repo}/notifications${this.addQueryParams(query)}`,
-          "GET",
-          params,
-        ),
+        this.request(`/repos/${owner}/${repo}/notifications${this.addQueryParams(query)}`, "GET", params),
       /**
        * @name notificationsUpdate
        * @request PUT:/repos/{owner}/{repo}/notifications
@@ -1176,19 +1115,14 @@ export class Api extends HttpClient {
        * @request POST:/repos/{owner}/{repo}/pulls
        * @description Create a pull request.
        */
-      pullsCreate: (owner, repo, body, params) =>
-        this.request(`/repos/${owner}/${repo}/pulls`, "POST", params, body),
+      pullsCreate: (owner, repo, body, params) => this.request(`/repos/${owner}/${repo}/pulls`, "POST", params, body),
       /**
        * @name pullsCommentsDetail
        * @request GET:/repos/{owner}/{repo}/pulls/comments
        * @description List comments in a repository. By default, Review Comments are ordered by ascending ID.
        */
       pullsCommentsDetail: (owner, repo, query, params) =>
-        this.request(
-          `/repos/${owner}/${repo}/pulls/comments${this.addQueryParams(query)}`,
-          "GET",
-          params,
-        ),
+        this.request(`/repos/${owner}/${repo}/pulls/comments${this.addQueryParams(query)}`, "GET", params),
       /**
        * @name pullsCommentsDelete
        * @request DELETE:/repos/{owner}/{repo}/pulls/comments/{commentId}
@@ -1284,8 +1218,7 @@ export class Api extends HttpClient {
        * @request GET:/repos/{owner}/{repo}/releases
        * @description Users with push access to the repository will receive all releases (i.e., published releases and draft releases). Users with pull access will receive published releases only
        */
-      releasesDetail: (owner, repo, params) =>
-        this.request(`/repos/${owner}/${repo}/releases`, "GET", params),
+      releasesDetail: (owner, repo, params) => this.request(`/repos/${owner}/${repo}/releases`, "GET", params),
       /**
        * @name releasesCreate
        * @request POST:/repos/{owner}/{repo}/releases
@@ -1351,8 +1284,7 @@ export class Api extends HttpClient {
        * @request GET:/repos/{owner}/{repo}/stargazers
        * @description List Stargazers.
        */
-      stargazersDetail: (owner, repo, params) =>
-        this.request(`/repos/${owner}/${repo}/stargazers`, "GET", params),
+      stargazersDetail: (owner, repo, params) => this.request(`/repos/${owner}/${repo}/stargazers`, "GET", params),
       /**
        * @name statsCodeFrequencyDetail
        * @request GET:/repos/{owner}/{repo}/stats/code_frequency
@@ -1407,8 +1339,7 @@ export class Api extends HttpClient {
        * @request GET:/repos/{owner}/{repo}/subscribers
        * @description List watchers.
        */
-      subscribersDetail: (owner, repo, params) =>
-        this.request(`/repos/${owner}/${repo}/subscribers`, "GET", params),
+      subscribersDetail: (owner, repo, params) => this.request(`/repos/${owner}/${repo}/subscribers`, "GET", params),
       /**
        * @name subscriptionDelete
        * @request DELETE:/repos/{owner}/{repo}/subscription
@@ -1421,8 +1352,7 @@ export class Api extends HttpClient {
        * @request GET:/repos/{owner}/{repo}/subscription
        * @description Get a Repository Subscription.
        */
-      subscriptionDetail: (owner, repo, params) =>
-        this.request(`/repos/${owner}/${repo}/subscription`, "GET", params),
+      subscriptionDetail: (owner, repo, params) => this.request(`/repos/${owner}/${repo}/subscription`, "GET", params),
       /**
        * @name subscriptionUpdate
        * @request PUT:/repos/{owner}/{repo}/subscription
@@ -1435,22 +1365,19 @@ export class Api extends HttpClient {
        * @request GET:/repos/{owner}/{repo}/tags
        * @description Get list of tags.
        */
-      tagsDetail: (owner, repo, params) =>
-        this.request(`/repos/${owner}/${repo}/tags`, "GET", params),
+      tagsDetail: (owner, repo, params) => this.request(`/repos/${owner}/${repo}/tags`, "GET", params),
       /**
        * @name teamsDetail
        * @request GET:/repos/{owner}/{repo}/teams
        * @description Get list of teams
        */
-      teamsDetail: (owner, repo, params) =>
-        this.request(`/repos/${owner}/${repo}/teams`, "GET", params),
+      teamsDetail: (owner, repo, params) => this.request(`/repos/${owner}/${repo}/teams`, "GET", params),
       /**
        * @name watchersDetail
        * @request GET:/repos/{owner}/{repo}/watchers
        * @description List Stargazers. New implementation.
        */
-      watchersDetail: (owner, repo, params) =>
-        this.request(`/repos/${owner}/${repo}/watchers`, "GET", params),
+      watchersDetail: (owner, repo, params) => this.request(`/repos/${owner}/${repo}/watchers`, "GET", params),
       /**
        * @name reposDetail
        * @request GET:/repos/{owner}/{repo}/{archive_format}/{path}
@@ -1467,8 +1394,7 @@ export class Api extends HttpClient {
        * @request GET:/repositories
        * @description List all public repositories. This provides a dump of every public repository, in the order that they were created. Note: Pagination is powered exclusively by the since parameter. is the Link header to get the URL for the next page of repositories.
        */
-      repositoriesList: (query, params) =>
-        this.request(`/repositories${this.addQueryParams(query)}`, "GET", params),
+      repositoriesList: (query, params) => this.request(`/repositories${this.addQueryParams(query)}`, "GET", params),
     };
     this.search = {
       /**
@@ -1476,15 +1402,13 @@ export class Api extends HttpClient {
        * @request GET:/search/code
        * @description Search code.
        */
-      codeList: (query, params) =>
-        this.request(`/search/code${this.addQueryParams(query)}`, "GET", params),
+      codeList: (query, params) => this.request(`/search/code${this.addQueryParams(query)}`, "GET", params),
       /**
        * @name issuesList
        * @request GET:/search/issues
        * @description Find issues by state and keyword. (This method returns up to 100 results per page.)
        */
-      issuesList: (query, params) =>
-        this.request(`/search/issues${this.addQueryParams(query)}`, "GET", params),
+      issuesList: (query, params) => this.request(`/search/issues${this.addQueryParams(query)}`, "GET", params),
       /**
        * @name repositoriesList
        * @request GET:/search/repositories
@@ -1497,8 +1421,7 @@ export class Api extends HttpClient {
        * @request GET:/search/users
        * @description Search users.
        */
-      usersList: (query, params) =>
-        this.request(`/search/users${this.addQueryParams(query)}`, "GET", params),
+      usersList: (query, params) => this.request(`/search/users${this.addQueryParams(query)}`, "GET", params),
     };
     this.teams = {
       /**
@@ -1518,8 +1441,7 @@ export class Api extends HttpClient {
        * @request PATCH:/teams/{teamId}
        * @description Edit team. In order to edit a team, the authenticated user must be an owner of the org that the team is associated with.
        */
-      teamsPartialUpdate: (teamId, body, params) =>
-        this.request(`/teams/${teamId}`, "PATCH", params, body),
+      teamsPartialUpdate: (teamId, body, params) => this.request(`/teams/${teamId}`, "PATCH", params, body),
       /**
        * @name membersDetail
        * @request GET:/teams/{teamId}/members
@@ -1540,15 +1462,13 @@ export class Api extends HttpClient {
        * @originalName membersDetail
        * @duplicate
        */
-      membersDetail2: (teamId, username, params) =>
-        this.request(`/teams/${teamId}/members/${username}`, "GET", params),
+      membersDetail2: (teamId, username, params) => this.request(`/teams/${teamId}/members/${username}`, "GET", params),
       /**
        * @name membersUpdate
        * @request PUT:/teams/{teamId}/members/{username}
        * @description The API (described below) is deprecated and is scheduled for removal in the next major version of the API. We recommend using the Add team membership API instead. It allows you to invite new organization members to your teams. Add team member. In order to add a user to a team, the authenticated user must have 'admin' permissions to the team or be an owner of the org that the team is associated with.
        */
-      membersUpdate: (teamId, username, params) =>
-        this.request(`/teams/${teamId}/members/${username}`, "PUT", params),
+      membersUpdate: (teamId, username, params) => this.request(`/teams/${teamId}/members/${username}`, "PUT", params),
       /**
        * @name membershipsDelete
        * @request DELETE:/teams/{teamId}/memberships/{username}
@@ -1648,29 +1568,25 @@ export class Api extends HttpClient {
        * @request DELETE:/user/following/{username}
        * @description Unfollow a user. Unfollowing a user requires the user to be logged in and authenticated with basic auth or OAuth with the user:follow scope.
        */
-      followingDelete: (username, params) =>
-        this.request(`/user/following/${username}`, "DELETE", params),
+      followingDelete: (username, params) => this.request(`/user/following/${username}`, "DELETE", params),
       /**
        * @name followingDetail
        * @request GET:/user/following/{username}
        * @description Check if you are following a user.
        */
-      followingDetail: (username, params) =>
-        this.request(`/user/following/${username}`, "GET", params),
+      followingDetail: (username, params) => this.request(`/user/following/${username}`, "GET", params),
       /**
        * @name followingUpdate
        * @request PUT:/user/following/{username}
        * @description Follow a user. Following a user requires the user to be logged in and authenticated with basic auth or OAuth with the user:follow scope.
        */
-      followingUpdate: (username, params) =>
-        this.request(`/user/following/${username}`, "PUT", params),
+      followingUpdate: (username, params) => this.request(`/user/following/${username}`, "PUT", params),
       /**
        * @name issuesList
        * @request GET:/user/issues
        * @description List issues. List all issues across owned and member repositories for the authenticated user.
        */
-      issuesList: (query, params) =>
-        this.request(`/user/issues${this.addQueryParams(query)}`, "GET", params),
+      issuesList: (query, params) => this.request(`/user/issues${this.addQueryParams(query)}`, "GET", params),
       /**
        * @name keysList
        * @request GET:/user/keys
@@ -1706,8 +1622,7 @@ export class Api extends HttpClient {
        * @request GET:/user/repos
        * @description List repositories for the authenticated user. Note that this does not include repositories owned by organizations which the user can access. You can lis user organizations and list organization repositories separately.
        */
-      reposList: (query, params) =>
-        this.request(`/user/repos${this.addQueryParams(query)}`, "GET", params),
+      reposList: (query, params) => this.request(`/user/repos${this.addQueryParams(query)}`, "GET", params),
       /**
        * @name reposCreate
        * @request POST:/user/repos
@@ -1719,29 +1634,25 @@ export class Api extends HttpClient {
        * @request GET:/user/starred
        * @description List repositories being starred by the authenticated user.
        */
-      starredList: (query, params) =>
-        this.request(`/user/starred${this.addQueryParams(query)}`, "GET", params),
+      starredList: (query, params) => this.request(`/user/starred${this.addQueryParams(query)}`, "GET", params),
       /**
        * @name starredDelete
        * @request DELETE:/user/starred/{owner}/{repo}
        * @description Unstar a repository
        */
-      starredDelete: (owner, repo, params) =>
-        this.request(`/user/starred/${owner}/${repo}`, "DELETE", params),
+      starredDelete: (owner, repo, params) => this.request(`/user/starred/${owner}/${repo}`, "DELETE", params),
       /**
        * @name starredDetail
        * @request GET:/user/starred/{owner}/{repo}
        * @description Check if you are starring a repository.
        */
-      starredDetail: (owner, repo, params) =>
-        this.request(`/user/starred/${owner}/${repo}`, "GET", params),
+      starredDetail: (owner, repo, params) => this.request(`/user/starred/${owner}/${repo}`, "GET", params),
       /**
        * @name starredUpdate
        * @request PUT:/user/starred/{owner}/{repo}
        * @description Star a repository.
        */
-      starredUpdate: (owner, repo, params) =>
-        this.request(`/user/starred/${owner}/${repo}`, "PUT", params),
+      starredUpdate: (owner, repo, params) => this.request(`/user/starred/${owner}/${repo}`, "PUT", params),
       /**
        * @name subscriptionsList
        * @request GET:/user/subscriptions
@@ -1760,15 +1671,13 @@ export class Api extends HttpClient {
        * @request GET:/user/subscriptions/{owner}/{repo}
        * @description Check if you are watching a repository.
        */
-      subscriptionsDetail: (owner, repo, params) =>
-        this.request(`/user/subscriptions/${owner}/${repo}`, "GET", params),
+      subscriptionsDetail: (owner, repo, params) => this.request(`/user/subscriptions/${owner}/${repo}`, "GET", params),
       /**
        * @name subscriptionsUpdate
        * @request PUT:/user/subscriptions/{owner}/{repo}
        * @description Watch a repository.
        */
-      subscriptionsUpdate: (owner, repo, params) =>
-        this.request(`/user/subscriptions/${owner}/${repo}`, "PUT", params),
+      subscriptionsUpdate: (owner, repo, params) => this.request(`/user/subscriptions/${owner}/${repo}`, "PUT", params),
       /**
        * @name teamsList
        * @request GET:/user/teams
@@ -1782,8 +1691,7 @@ export class Api extends HttpClient {
        * @request GET:/users
        * @description Get all users. This provides a dump of every user, in the order that they signed up for GitHub. Note: Pagination is powered exclusively by the since parameter. Use the Link header to get the URL for the next page of users.
        */
-      usersList: (query, params) =>
-        this.request(`/users${this.addQueryParams(query)}`, "GET", params),
+      usersList: (query, params) => this.request(`/users${this.addQueryParams(query)}`, "GET", params),
       /**
        * @name usersDetail
        * @request GET:/users/{username}
@@ -1801,15 +1709,13 @@ export class Api extends HttpClient {
        * @request GET:/users/{username}/events/orgs/{org}
        * @description This is the user's organization dashboard. You must be authenticated as the user to view this.
        */
-      eventsOrgsDetail: (username, org, params) =>
-        this.request(`/users/${username}/events/orgs/${org}`, "GET", params),
+      eventsOrgsDetail: (username, org, params) => this.request(`/users/${username}/events/orgs/${org}`, "GET", params),
       /**
        * @name followersDetail
        * @request GET:/users/{username}/followers
        * @description List a user's followers
        */
-      followersDetail: (username, params) =>
-        this.request(`/users/${username}/followers`, "GET", params),
+      followersDetail: (username, params) => this.request(`/users/${username}/followers`, "GET", params),
       /**
        * @name followingDetail
        * @request GET:/users/{username}/following/{targetUser}
@@ -1841,8 +1747,7 @@ export class Api extends HttpClient {
        * @request GET:/users/{username}/received_events
        * @description These are events that you'll only see public events.
        */
-      receivedEventsDetail: (username, params) =>
-        this.request(`/users/${username}/received_events`, "GET", params),
+      receivedEventsDetail: (username, params) => this.request(`/users/${username}/received_events`, "GET", params),
       /**
        * @name receivedEventsPublicDetail
        * @request GET:/users/{username}/received_events/public
@@ -1862,15 +1767,13 @@ export class Api extends HttpClient {
        * @request GET:/users/{username}/starred
        * @description List repositories being starred by a user.
        */
-      starredDetail: (username, params) =>
-        this.request(`/users/${username}/starred`, "GET", params),
+      starredDetail: (username, params) => this.request(`/users/${username}/starred`, "GET", params),
       /**
        * @name subscriptionsDetail
        * @request GET:/users/{username}/subscriptions
        * @description List repositories being watched by a user.
        */
-      subscriptionsDetail: (username, params) =>
-        this.request(`/users/${username}/subscriptions`, "GET", params),
+      subscriptionsDetail: (username, params) => this.request(`/users/${username}/subscriptions`, "GET", params),
     };
   }
 }

--- a/tests/spec/js/schema.js
+++ b/tests/spec/js/schema.js
@@ -1,0 +1,1876 @@
+/* tslint:disable */
+/* eslint-disable */
+var BodyType;
+(function (BodyType) {
+  BodyType[(BodyType["Json"] = 0)] = "Json";
+})(BodyType || (BodyType = {}));
+class HttpClient {
+  constructor({ baseUrl, baseApiParams, securityWorker } = {}) {
+    this.baseUrl = "https://api.github.com/";
+    this.securityData = null;
+    this.securityWorker = () => {};
+    this.baseApiParams = {
+      credentials: "same-origin",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      redirect: "follow",
+      referrerPolicy: "no-referrer",
+    };
+    this.setSecurityData = (data) => {
+      this.securityData = data;
+    };
+    this.bodyFormatters = {
+      [BodyType.Json]: JSON.stringify,
+    };
+    this.safeParseResponse = (response) =>
+      response
+        .json()
+        .then((data) => data)
+        .catch((e) => response.text);
+    this.request = (path, method, { secure, ...params } = {}, body, bodyType, secureByDefault) =>
+      fetch(`${this.baseUrl}${path}`, {
+        // @ts-ignore
+        ...this.mergeRequestOptions(
+          params,
+          (secureByDefault || secure) && this.securityWorker(this.securityData),
+        ),
+        method,
+        body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
+      }).then(async (response) => {
+        const data = await this.safeParseResponse(response);
+        if (!response.ok) throw data;
+        return data;
+      });
+    this.baseUrl = baseUrl || this.baseUrl;
+    this.baseApiParams = baseApiParams || this.baseApiParams;
+    this.securityWorker = securityWorker || this.securityWorker;
+  }
+  addQueryParam(query, key) {
+    return (
+      encodeURIComponent(key) +
+      "=" +
+      encodeURIComponent(Array.isArray(query[key]) ? query[key].join(",") : query[key])
+    );
+  }
+  addQueryParams(rawQuery) {
+    const query = rawQuery || {};
+    const keys = Object.keys(query).filter((key) => "undefined" !== typeof query[key]);
+    return keys.length
+      ? `?${keys
+          .map((key) =>
+            typeof query[key] === "object" && !Array.isArray(query[key])
+              ? this.addQueryParams(query[key]).substring(1)
+              : this.addQueryParam(query, key),
+          )
+          .join("&")}`
+      : "";
+  }
+  mergeRequestOptions(params, securityParams) {
+    return {
+      ...this.baseApiParams,
+      ...params,
+      ...(securityParams || {}),
+      headers: {
+        ...(this.baseApiParams.headers || {}),
+        ...(params.headers || {}),
+        ...((securityParams && securityParams.headers) || {}),
+      },
+    };
+  }
+}
+/**
+ * @title GitHub
+ * @version v3
+ * @baseUrl https://api.github.com/
+ * Powerful collaboration, code review, and code management for open source and private projects.
+ */
+export class Api extends HttpClient {
+  constructor() {
+    super(...arguments);
+    this.emojis = {
+      /**
+       * @name emojisList
+       * @request GET:/emojis
+       * @description Lists all the emojis available to use on GitHub.
+       */
+      emojisList: (params) => this.request(`/emojis`, "GET", params),
+    };
+    this.events = {
+      /**
+       * @name eventsList
+       * @request GET:/events
+       * @description List public events.
+       */
+      eventsList: (params) => this.request(`/events`, "GET", params),
+    };
+    this.feeds = {
+      /**
+       * @name feedsList
+       * @request GET:/feeds
+       * @description List Feeds. GitHub provides several timeline resources in Atom format. The Feeds API lists all the feeds available to the authenticating user.
+       */
+      feedsList: (params) => this.request(`/feeds`, "GET", params),
+    };
+    this.gists = {
+      /**
+       * @name gistsList
+       * @request GET:/gists
+       * @description List the authenticated user's gists or if called anonymously, this will return all public gists.
+       */
+      gistsList: (query, params) =>
+        this.request(`/gists${this.addQueryParams(query)}`, "GET", params),
+      /**
+       * @name gistsCreate
+       * @request POST:/gists
+       * @description Create a gist.
+       */
+      gistsCreate: (body, params) => this.request(`/gists`, "POST", params, body),
+      /**
+       * @name publicList
+       * @request GET:/gists/public
+       * @description List all public gists.
+       */
+      publicList: (query, params) =>
+        this.request(`/gists/public${this.addQueryParams(query)}`, "GET", params),
+      /**
+       * @name starredList
+       * @request GET:/gists/starred
+       * @description List the authenticated user's starred gists.
+       */
+      starredList: (query, params) =>
+        this.request(`/gists/starred${this.addQueryParams(query)}`, "GET", params),
+      /**
+       * @name gistsDelete
+       * @request DELETE:/gists/{id}
+       * @description Delete a gist.
+       */
+      gistsDelete: (id, params) => this.request(`/gists/${id}`, "DELETE", params),
+      /**
+       * @name gistsDetail
+       * @request GET:/gists/{id}
+       * @description Get a single gist.
+       */
+      gistsDetail: (id, params) => this.request(`/gists/${id}`, "GET", params),
+      /**
+       * @name gistsPartialUpdate
+       * @request PATCH:/gists/{id}
+       * @description Edit a gist.
+       */
+      gistsPartialUpdate: (id, body, params) => this.request(`/gists/${id}`, "PATCH", params, body),
+      /**
+       * @name commentsDetail
+       * @request GET:/gists/{id}/comments
+       * @description List comments on a gist.
+       */
+      commentsDetail: (id, params) => this.request(`/gists/${id}/comments`, "GET", params),
+      /**
+       * @name commentsCreate
+       * @request POST:/gists/{id}/comments
+       * @description Create a commen
+       */
+      commentsCreate: (id, body, params) =>
+        this.request(`/gists/${id}/comments`, "POST", params, body),
+      /**
+       * @name commentsDelete
+       * @request DELETE:/gists/{id}/comments/{commentId}
+       * @description Delete a comment.
+       */
+      commentsDelete: (id, commentId, params) =>
+        this.request(`/gists/${id}/comments/${commentId}`, "DELETE", params),
+      /**
+       * @name commentsDetail
+       * @request GET:/gists/{id}/comments/{commentId}
+       * @description Get a single comment.
+       * @originalName commentsDetail
+       * @duplicate
+       */
+      commentsDetail2: (id, commentId, params) =>
+        this.request(`/gists/${id}/comments/${commentId}`, "GET", params),
+      /**
+       * @name commentsPartialUpdate
+       * @request PATCH:/gists/{id}/comments/{commentId}
+       * @description Edit a comment.
+       */
+      commentsPartialUpdate: (id, commentId, body, params) =>
+        this.request(`/gists/${id}/comments/${commentId}`, "PATCH", params, body),
+      /**
+       * @name forksCreate
+       * @request POST:/gists/{id}/forks
+       * @description Fork a gist.
+       */
+      forksCreate: (id, params) => this.request(`/gists/${id}/forks`, "POST", params),
+      /**
+       * @name starDelete
+       * @request DELETE:/gists/{id}/star
+       * @description Unstar a gist.
+       */
+      starDelete: (id, params) => this.request(`/gists/${id}/star`, "DELETE", params),
+      /**
+       * @name starDetail
+       * @request GET:/gists/{id}/star
+       * @description Check if a gist is starred.
+       */
+      starDetail: (id, params) => this.request(`/gists/${id}/star`, "GET", params),
+      /**
+       * @name starUpdate
+       * @request PUT:/gists/{id}/star
+       * @description Star a gist.
+       */
+      starUpdate: (id, params) => this.request(`/gists/${id}/star`, "PUT", params),
+    };
+    this.gitignore = {
+      /**
+       * @name templatesList
+       * @request GET:/gitignore/templates
+       * @description Listing available templates. List all templates available to pass as an option when creating a repository.
+       */
+      templatesList: (params) => this.request(`/gitignore/templates`, "GET", params),
+      /**
+       * @name templatesDetail
+       * @request GET:/gitignore/templates/{language}
+       * @description Get a single template.
+       */
+      templatesDetail: (language, params) =>
+        this.request(`/gitignore/templates/${language}`, "GET", params),
+    };
+    this.issues = {
+      /**
+       * @name issuesList
+       * @request GET:/issues
+       * @description List issues. List all issues across all the authenticated user's visible repositories.
+       */
+      issuesList: (query, params) =>
+        this.request(`/issues${this.addQueryParams(query)}`, "GET", params),
+    };
+    this.legacy = {
+      /**
+       * @name issuesSearchDetail
+       * @request GET:/legacy/issues/search/{owner}/{repository}/{state}/{keyword}
+       * @description Find issues by state and keyword.
+       */
+      issuesSearchDetail: (keyword, state, owner, repository, params) =>
+        this.request(
+          `/legacy/issues/search/${owner}/${repository}/${state}/${keyword}`,
+          "GET",
+          params,
+        ),
+      /**
+       * @name reposSearchDetail
+       * @request GET:/legacy/repos/search/{keyword}
+       * @description Find repositories by keyword. Note, this legacy method does not follow the v3 pagination pattern. This method returns up to 100 results per page and pages can be fetched using the start_page parameter.
+       */
+      reposSearchDetail: (keyword, query, params) =>
+        this.request(`/legacy/repos/search/${keyword}${this.addQueryParams(query)}`, "GET", params),
+      /**
+       * @name userEmailDetail
+       * @request GET:/legacy/user/email/{email}
+       * @description This API call is added for compatibility reasons only.
+       */
+      userEmailDetail: (email, params) =>
+        this.request(`/legacy/user/email/${email}`, "GET", params),
+      /**
+       * @name userSearchDetail
+       * @request GET:/legacy/user/search/{keyword}
+       * @description Find users by keyword.
+       */
+      userSearchDetail: (keyword, query, params) =>
+        this.request(`/legacy/user/search/${keyword}${this.addQueryParams(query)}`, "GET", params),
+    };
+    this.markdown = {
+      /**
+       * @name markdownCreate
+       * @request POST:/markdown
+       * @description Render an arbitrary Markdown document
+       */
+      markdownCreate: (body, params) => this.request(`/markdown`, "POST", params, body),
+      /**
+       * @name postMarkdown
+       * @request POST:/markdown/raw
+       * @description Render a Markdown document in raw mode
+       */
+      postMarkdown: (params) => this.request(`/markdown/raw`, "POST", params),
+    };
+    this.meta = {
+      /**
+       * @name metaList
+       * @request GET:/meta
+       * @description This gives some information about GitHub.com, the service.
+       */
+      metaList: (params) => this.request(`/meta`, "GET", params),
+    };
+    this.networks = {
+      /**
+       * @name eventsDetail
+       * @request GET:/networks/{owner}/{repo}/events
+       * @description List public events for a network of repositories.
+       */
+      eventsDetail: (owner, repo, params) =>
+        this.request(`/networks/${owner}/${repo}/events`, "GET", params),
+    };
+    this.notifications = {
+      /**
+       * @name notificationsList
+       * @request GET:/notifications
+       * @description List your notifications. List all notifications for the current user, grouped by repository.
+       */
+      notificationsList: (query, params) =>
+        this.request(`/notifications${this.addQueryParams(query)}`, "GET", params),
+      /**
+       * @name notificationsUpdate
+       * @request PUT:/notifications
+       * @description Mark as read. Marking a notification as "read" removes it from the default view on GitHub.com.
+       */
+      notificationsUpdate: (body, params) => this.request(`/notifications`, "PUT", params, body),
+      /**
+       * @name threadsDetail
+       * @request GET:/notifications/threads/{id}
+       * @description View a single thread.
+       */
+      threadsDetail: (id, params) => this.request(`/notifications/threads/${id}`, "GET", params),
+      /**
+       * @name threadsPartialUpdate
+       * @request PATCH:/notifications/threads/{id}
+       * @description Mark a thread as read
+       */
+      threadsPartialUpdate: (id, params) =>
+        this.request(`/notifications/threads/${id}`, "PATCH", params),
+      /**
+       * @name threadsSubscriptionDelete
+       * @request DELETE:/notifications/threads/{id}/subscription
+       * @description Delete a Thread Subscription.
+       */
+      threadsSubscriptionDelete: (id, params) =>
+        this.request(`/notifications/threads/${id}/subscription`, "DELETE", params),
+      /**
+       * @name threadsSubscriptionDetail
+       * @request GET:/notifications/threads/{id}/subscription
+       * @description Get a Thread Subscription.
+       */
+      threadsSubscriptionDetail: (id, params) =>
+        this.request(`/notifications/threads/${id}/subscription`, "GET", params),
+      /**
+       * @name threadsSubscriptionUpdate
+       * @request PUT:/notifications/threads/{id}/subscription
+       * @description Set a Thread Subscription. This lets you subscribe to a thread, or ignore it. Subscribing to a thread is unnecessary if the user is already subscribed to the repository. Ignoring a thread will mute all future notifications (until you comment or get @mentioned).
+       */
+      threadsSubscriptionUpdate: (id, body, params) =>
+        this.request(`/notifications/threads/${id}/subscription`, "PUT", params, body),
+    };
+    this.orgs = {
+      /**
+       * @name orgsDetail
+       * @request GET:/orgs/{org}
+       * @description Get an Organization.
+       */
+      orgsDetail: (org, params) => this.request(`/orgs/${org}`, "GET", params),
+      /**
+       * @name orgsPartialUpdate
+       * @request PATCH:/orgs/{org}
+       * @description Edit an Organization.
+       */
+      orgsPartialUpdate: (org, body, params) => this.request(`/orgs/${org}`, "PATCH", params, body),
+      /**
+       * @name eventsDetail
+       * @request GET:/orgs/{org}/events
+       * @description List public events for an organization.
+       */
+      eventsDetail: (org, params) => this.request(`/orgs/${org}/events`, "GET", params),
+      /**
+       * @name issuesDetail
+       * @request GET:/orgs/{org}/issues
+       * @description List issues. List all issues for a given organization for the authenticated user.
+       */
+      issuesDetail: (org, query, params) =>
+        this.request(`/orgs/${org}/issues${this.addQueryParams(query)}`, "GET", params),
+      /**
+       * @name membersDetail
+       * @request GET:/orgs/{org}/members
+       * @description Members list. List all users who are members of an organization. A member is a user tha belongs to at least 1 team in the organization. If the authenticated user is also an owner of this organization then both concealed and public members will be returned. If the requester is not an owner of the organization the query will be redirected to the public members list.
+       */
+      membersDetail: (org, params) => this.request(`/orgs/${org}/members`, "GET", params),
+      /**
+       * @name membersDelete
+       * @request DELETE:/orgs/{org}/members/{username}
+       * @description Remove a member. Removing a user from this list will remove them from all teams and they will no longer have any access to the organization's repositories.
+       */
+      membersDelete: (org, username, params) =>
+        this.request(`/orgs/${org}/members/${username}`, "DELETE", params),
+      /**
+       * @name membersDetail
+       * @request GET:/orgs/{org}/members/{username}
+       * @description Check if a user is, publicly or privately, a member of the organization.
+       * @originalName membersDetail
+       * @duplicate
+       */
+      membersDetail2: (org, username, params) =>
+        this.request(`/orgs/${org}/members/${username}`, "GET", params),
+      /**
+       * @name publicMembersDetail
+       * @request GET:/orgs/{org}/public_members
+       * @description Public members list. Members of an organization can choose to have their membership publicized or not.
+       */
+      publicMembersDetail: (org, params) =>
+        this.request(`/orgs/${org}/public_members`, "GET", params),
+      /**
+       * @name publicMembersDelete
+       * @request DELETE:/orgs/{org}/public_members/{username}
+       * @description Conceal a user's membership.
+       */
+      publicMembersDelete: (org, username, params) =>
+        this.request(`/orgs/${org}/public_members/${username}`, "DELETE", params),
+      /**
+       * @name publicMembersDetail
+       * @request GET:/orgs/{org}/public_members/{username}
+       * @description Check public membership.
+       * @originalName publicMembersDetail
+       * @duplicate
+       */
+      publicMembersDetail2: (org, username, params) =>
+        this.request(`/orgs/${org}/public_members/${username}`, "GET", params),
+      /**
+       * @name publicMembersUpdate
+       * @request PUT:/orgs/{org}/public_members/{username}
+       * @description Publicize a user's membership.
+       */
+      publicMembersUpdate: (org, username, params) =>
+        this.request(`/orgs/${org}/public_members/${username}`, "PUT", params),
+      /**
+       * @name reposDetail
+       * @request GET:/orgs/{org}/repos
+       * @description List repositories for the specified org.
+       */
+      reposDetail: (org, query, params) =>
+        this.request(`/orgs/${org}/repos${this.addQueryParams(query)}`, "GET", params),
+      /**
+       * @name reposCreate
+       * @request POST:/orgs/{org}/repos
+       * @description Create a new repository for the authenticated user. OAuth users must supply repo scope.
+       */
+      reposCreate: (org, body, params) => this.request(`/orgs/${org}/repos`, "POST", params, body),
+      /**
+       * @name teamsDetail
+       * @request GET:/orgs/{org}/teams
+       * @description List teams.
+       */
+      teamsDetail: (org, params) => this.request(`/orgs/${org}/teams`, "GET", params),
+      /**
+       * @name teamsCreate
+       * @request POST:/orgs/{org}/teams
+       * @description Create team. In order to create a team, the authenticated user must be an owner of organization.
+       */
+      teamsCreate: (org, body, params) => this.request(`/orgs/${org}/teams`, "POST", params, body),
+    };
+    this.rateLimit = {
+      /**
+       * @name rateLimitList
+       * @request GET:/rate_limit
+       * @description Get your current rate limit status Note: Accessing this endpoint does not count against your rate limit.
+       */
+      rateLimitList: (params) => this.request(`/rate_limit`, "GET", params),
+    };
+    this.repos = {
+      /**
+       * @name reposDelete
+       * @request DELETE:/repos/{owner}/{repo}
+       * @description Delete a Repository. Deleting a repository requires admin access. If OAuth is used, the delete_repo scope is required.
+       */
+      reposDelete: (owner, repo, params) =>
+        this.request(`/repos/${owner}/${repo}`, "DELETE", params),
+      /**
+       * @name reposDetail
+       * @request GET:/repos/{owner}/{repo}
+       * @description Get repository.
+       */
+      reposDetail: (owner, repo, params) => this.request(`/repos/${owner}/${repo}`, "GET", params),
+      /**
+       * @name reposPartialUpdate
+       * @request PATCH:/repos/{owner}/{repo}
+       * @description Edit repository.
+       */
+      reposPartialUpdate: (owner, repo, body, params) =>
+        this.request(`/repos/${owner}/${repo}`, "PATCH", params, body),
+      /**
+       * @name assigneesDetail
+       * @request GET:/repos/{owner}/{repo}/assignees
+       * @description List assignees. This call lists all the available assignees (owner + collaborators) to which issues may be assigned.
+       */
+      assigneesDetail: (owner, repo, params) =>
+        this.request(`/repos/${owner}/${repo}/assignees`, "GET", params),
+      /**
+       * @name assigneesDetail
+       * @request GET:/repos/{owner}/{repo}/assignees/{assignee}
+       * @description Check assignee. You may also check to see if a particular user is an assignee for a repository.
+       * @originalName assigneesDetail
+       * @duplicate
+       */
+      assigneesDetail2: (owner, repo, assignee, params) =>
+        this.request(`/repos/${owner}/${repo}/assignees/${assignee}`, "GET", params),
+      /**
+       * @name branchesDetail
+       * @request GET:/repos/{owner}/{repo}/branches
+       * @description Get list of branches
+       */
+      branchesDetail: (owner, repo, params) =>
+        this.request(`/repos/${owner}/${repo}/branches`, "GET", params),
+      /**
+       * @name branchesDetail
+       * @request GET:/repos/{owner}/{repo}/branches/{branch}
+       * @description Get Branch
+       * @originalName branchesDetail
+       * @duplicate
+       */
+      branchesDetail2: (owner, repo, branch, params) =>
+        this.request(`/repos/${owner}/${repo}/branches/${branch}`, "GET", params),
+      /**
+       * @name collaboratorsDetail
+       * @request GET:/repos/{owner}/{repo}/collaborators
+       * @description List. When authenticating as an organization owner of an organization-owned repository, all organization owners are included in the list of collaborators. Otherwise, only users with access to the repository are returned in the collaborators list.
+       */
+      collaboratorsDetail: (owner, repo, params) =>
+        this.request(`/repos/${owner}/${repo}/collaborators`, "GET", params),
+      /**
+       * @name collaboratorsDelete
+       * @request DELETE:/repos/{owner}/{repo}/collaborators/{user}
+       * @description Remove collaborator.
+       */
+      collaboratorsDelete: (owner, repo, user, params) =>
+        this.request(`/repos/${owner}/${repo}/collaborators/${user}`, "DELETE", params),
+      /**
+       * @name collaboratorsDetail
+       * @request GET:/repos/{owner}/{repo}/collaborators/{user}
+       * @description Check if user is a collaborator
+       * @originalName collaboratorsDetail
+       * @duplicate
+       */
+      collaboratorsDetail2: (owner, repo, user, params) =>
+        this.request(`/repos/${owner}/${repo}/collaborators/${user}`, "GET", params),
+      /**
+       * @name collaboratorsUpdate
+       * @request PUT:/repos/{owner}/{repo}/collaborators/{user}
+       * @description Add collaborator.
+       */
+      collaboratorsUpdate: (owner, repo, user, params) =>
+        this.request(`/repos/${owner}/${repo}/collaborators/${user}`, "PUT", params),
+      /**
+       * @name commentsDetail
+       * @request GET:/repos/{owner}/{repo}/comments
+       * @description List commit comments for a repository. Comments are ordered by ascending ID.
+       */
+      commentsDetail: (owner, repo, params) =>
+        this.request(`/repos/${owner}/${repo}/comments`, "GET", params),
+      /**
+       * @name commentsDelete
+       * @request DELETE:/repos/{owner}/{repo}/comments/{commentId}
+       * @description Delete a commit comment
+       */
+      commentsDelete: (owner, repo, commentId, params) =>
+        this.request(`/repos/${owner}/${repo}/comments/${commentId}`, "DELETE", params),
+      /**
+       * @name commentsDetail
+       * @request GET:/repos/{owner}/{repo}/comments/{commentId}
+       * @description Get a single commit comment.
+       * @originalName commentsDetail
+       * @duplicate
+       */
+      commentsDetail2: (owner, repo, commentId, params) =>
+        this.request(`/repos/${owner}/${repo}/comments/${commentId}`, "GET", params),
+      /**
+       * @name commentsPartialUpdate
+       * @request PATCH:/repos/{owner}/{repo}/comments/{commentId}
+       * @description Update a commit comment.
+       */
+      commentsPartialUpdate: (owner, repo, commentId, body, params) =>
+        this.request(`/repos/${owner}/${repo}/comments/${commentId}`, "PATCH", params, body),
+      /**
+       * @name commitsDetail
+       * @request GET:/repos/{owner}/{repo}/commits
+       * @description List commits on a repository.
+       */
+      commitsDetail: (owner, repo, query, params) =>
+        this.request(`/repos/${owner}/${repo}/commits${this.addQueryParams(query)}`, "GET", params),
+      /**
+       * @name commitsStatusDetail
+       * @request GET:/repos/{owner}/{repo}/commits/{ref}/status
+       * @description Get the combined Status for a specific Ref The Combined status endpoint is currently available for developers to preview. During the preview period, the API may change without advance notice. Please see the blog post for full details. To access this endpoint during the preview period, you must provide a custom media type in the Accept header: application/vnd.github.she-hulk-preview+json
+       */
+      commitsStatusDetail: (owner, repo, ref, params) =>
+        this.request(`/repos/${owner}/${repo}/commits/${ref}/status`, "GET", params),
+      /**
+       * @name commitsDetail
+       * @request GET:/repos/{owner}/{repo}/commits/{shaCode}
+       * @description Get a single commit.
+       * @originalName commitsDetail
+       * @duplicate
+       */
+      commitsDetail2: (owner, repo, shaCode, params) =>
+        this.request(`/repos/${owner}/${repo}/commits/${shaCode}`, "GET", params),
+      /**
+       * @name commitsCommentsDetail
+       * @request GET:/repos/{owner}/{repo}/commits/{shaCode}/comments
+       * @description List comments for a single commitList comments for a single commit.
+       */
+      commitsCommentsDetail: (owner, repo, shaCode, params) =>
+        this.request(`/repos/${owner}/${repo}/commits/${shaCode}/comments`, "GET", params),
+      /**
+       * @name commitsCommentsCreate
+       * @request POST:/repos/{owner}/{repo}/commits/{shaCode}/comments
+       * @description Create a commit comment.
+       */
+      commitsCommentsCreate: (owner, repo, shaCode, body, params) =>
+        this.request(`/repos/${owner}/${repo}/commits/${shaCode}/comments`, "POST", params, body),
+      /**
+       * @name compareDetail
+       * @request GET:/repos/{owner}/{repo}/compare/{baseId}...{headId}
+       * @description Compare two commits
+       */
+      compareDetail: (owner, repo, baseId, headId, params) =>
+        this.request(`/repos/${owner}/${repo}/compare/${baseId}...${headId}`, "GET", params),
+      /**
+       * @name contentsDelete
+       * @request DELETE:/repos/{owner}/{repo}/contents/{path}
+       * @description Delete a file. This method deletes a file in a repository.
+       */
+      contentsDelete: (owner, repo, path, body, params) =>
+        this.request(`/repos/${owner}/${repo}/contents/${path}`, "DELETE", params, body),
+      /**
+       * @name contentsDetail
+       * @request GET:/repos/{owner}/{repo}/contents/{path}
+       * @description Get contents. This method returns the contents of a file or directory in a repository. Files and symlinks support a custom media type for getting the raw content. Directories and submodules do not support custom media types. Note: This API supports files up to 1 megabyte in size. Here can be many outcomes. For details see "http://developer.github.com/v3/repos/contents/"
+       */
+      contentsDetail: (owner, repo, path, query, params) =>
+        this.request(
+          `/repos/${owner}/${repo}/contents/${path}${this.addQueryParams(query)}`,
+          "GET",
+          params,
+        ),
+      /**
+       * @name contentsUpdate
+       * @request PUT:/repos/{owner}/{repo}/contents/{path}
+       * @description Create a file.
+       */
+      contentsUpdate: (owner, repo, path, body, params) =>
+        this.request(`/repos/${owner}/${repo}/contents/${path}`, "PUT", params, body),
+      /**
+       * @name contributorsDetail
+       * @request GET:/repos/{owner}/{repo}/contributors
+       * @description Get list of contributors.
+       */
+      contributorsDetail: (owner, repo, query, params) =>
+        this.request(
+          `/repos/${owner}/${repo}/contributors${this.addQueryParams(query)}`,
+          "GET",
+          params,
+        ),
+      /**
+       * @name deploymentsDetail
+       * @request GET:/repos/{owner}/{repo}/deployments
+       * @description Users with pull access can view deployments for a repository
+       */
+      deploymentsDetail: (owner, repo, params) =>
+        this.request(`/repos/${owner}/${repo}/deployments`, "GET", params),
+      /**
+       * @name deploymentsCreate
+       * @request POST:/repos/{owner}/{repo}/deployments
+       * @description Users with push access can create a deployment for a given ref
+       */
+      deploymentsCreate: (owner, repo, body, params) =>
+        this.request(`/repos/${owner}/${repo}/deployments`, "POST", params, body),
+      /**
+       * @name deploymentsStatusesDetail
+       * @request GET:/repos/{owner}/{repo}/deployments/{id}/statuses
+       * @description Users with pull access can view deployment statuses for a deployment
+       */
+      deploymentsStatusesDetail: (owner, repo, id, params) =>
+        this.request(`/repos/${owner}/${repo}/deployments/${id}/statuses`, "GET", params),
+      /**
+       * @name deploymentsStatusesCreate
+       * @request POST:/repos/{owner}/{repo}/deployments/{id}/statuses
+       * @description Create a Deployment Status Users with push access can create deployment statuses for a given deployment:
+       */
+      deploymentsStatusesCreate: (owner, repo, id, body, params) =>
+        this.request(`/repos/${owner}/${repo}/deployments/${id}/statuses`, "POST", params, body),
+      /**
+       * @name downloadsDetail
+       * @request GET:/repos/{owner}/{repo}/downloads
+       * @description Deprecated. List downloads for a repository.
+       */
+      downloadsDetail: (owner, repo, params) =>
+        this.request(`/repos/${owner}/${repo}/downloads`, "GET", params),
+      /**
+       * @name downloadsDelete
+       * @request DELETE:/repos/{owner}/{repo}/downloads/{downloadId}
+       * @description Deprecated. Delete a download.
+       */
+      downloadsDelete: (owner, repo, downloadId, params) =>
+        this.request(`/repos/${owner}/${repo}/downloads/${downloadId}`, "DELETE", params),
+      /**
+       * @name downloadsDetail
+       * @request GET:/repos/{owner}/{repo}/downloads/{downloadId}
+       * @description Deprecated. Get a single download.
+       * @originalName downloadsDetail
+       * @duplicate
+       */
+      downloadsDetail2: (owner, repo, downloadId, params) =>
+        this.request(`/repos/${owner}/${repo}/downloads/${downloadId}`, "GET", params),
+      /**
+       * @name eventsDetail
+       * @request GET:/repos/{owner}/{repo}/events
+       * @description Get list of repository events.
+       */
+      eventsDetail: (owner, repo, params) =>
+        this.request(`/repos/${owner}/${repo}/events`, "GET", params),
+      /**
+       * @name forksDetail
+       * @request GET:/repos/{owner}/{repo}/forks
+       * @description List forks.
+       */
+      forksDetail: (owner, repo, query, params) =>
+        this.request(`/repos/${owner}/${repo}/forks${this.addQueryParams(query)}`, "GET", params),
+      /**
+       * @name forksCreate
+       * @request POST:/repos/{owner}/{repo}/forks
+       * @description Create a fork. Forking a Repository happens asynchronously. Therefore, you may have to wai a short period before accessing the git objects. If this takes longer than 5 minutes, be sure to contact Support.
+       */
+      forksCreate: (owner, repo, body, params) =>
+        this.request(`/repos/${owner}/${repo}/forks`, "POST", params, body),
+      /**
+       * @name gitBlobsCreate
+       * @request POST:/repos/{owner}/{repo}/git/blobs
+       * @description Create a Blob.
+       */
+      gitBlobsCreate: (owner, repo, body, params) =>
+        this.request(`/repos/${owner}/${repo}/git/blobs`, "POST", params, body),
+      /**
+       * @name gitBlobsDetail
+       * @request GET:/repos/{owner}/{repo}/git/blobs/{shaCode}
+       * @description Get a Blob. Since blobs can be any arbitrary binary data, the input and responses for the blob API takes an encoding parameter that can be either utf-8 or base64. If your data cannot be losslessly sent as a UTF-8 string, you can base64 encode it.
+       */
+      gitBlobsDetail: (owner, repo, shaCode, params) =>
+        this.request(`/repos/${owner}/${repo}/git/blobs/${shaCode}`, "GET", params),
+      /**
+       * @name gitCommitsCreate
+       * @request POST:/repos/{owner}/{repo}/git/commits
+       * @description Create a Commit.
+       */
+      gitCommitsCreate: (owner, repo, body, params) =>
+        this.request(`/repos/${owner}/${repo}/git/commits`, "POST", params, body),
+      /**
+       * @name gitCommitsDetail
+       * @request GET:/repos/{owner}/{repo}/git/commits/{shaCode}
+       * @description Get a Commit.
+       */
+      gitCommitsDetail: (owner, repo, shaCode, params) =>
+        this.request(`/repos/${owner}/${repo}/git/commits/${shaCode}`, "GET", params),
+      /**
+       * @name gitRefsDetail
+       * @request GET:/repos/{owner}/{repo}/git/refs
+       * @description Get all References
+       */
+      gitRefsDetail: (owner, repo, params) =>
+        this.request(`/repos/${owner}/${repo}/git/refs`, "GET", params),
+      /**
+       * @name gitRefsCreate
+       * @request POST:/repos/{owner}/{repo}/git/refs
+       * @description Create a Reference
+       */
+      gitRefsCreate: (owner, repo, body, params) =>
+        this.request(`/repos/${owner}/${repo}/git/refs`, "POST", params, body),
+      /**
+       * @name gitRefsDelete
+       * @request DELETE:/repos/{owner}/{repo}/git/refs/{ref}
+       * @description Delete a Reference Example: Deleting a branch: DELETE /repos/octocat/Hello-World/git/refs/heads/feature-a Example: Deleting a tag:        DELETE /repos/octocat/Hello-World/git/refs/tags/v1.0
+       */
+      gitRefsDelete: (owner, repo, ref, params) =>
+        this.request(`/repos/${owner}/${repo}/git/refs/${ref}`, "DELETE", params),
+      /**
+       * @name gitRefsDetail
+       * @request GET:/repos/{owner}/{repo}/git/refs/{ref}
+       * @description Get a Reference
+       * @originalName gitRefsDetail
+       * @duplicate
+       */
+      gitRefsDetail2: (owner, repo, ref, params) =>
+        this.request(`/repos/${owner}/${repo}/git/refs/${ref}`, "GET", params),
+      /**
+       * @name gitRefsPartialUpdate
+       * @request PATCH:/repos/{owner}/{repo}/git/refs/{ref}
+       * @description Update a Reference
+       */
+      gitRefsPartialUpdate: (owner, repo, ref, body, params) =>
+        this.request(`/repos/${owner}/${repo}/git/refs/${ref}`, "PATCH", params, body),
+      /**
+       * @name gitTagsCreate
+       * @request POST:/repos/{owner}/{repo}/git/tags
+       * @description Create a Tag Object. Note that creating a tag object does not create the reference that makes a tag in Git. If you want to create an annotated tag in Git, you have to do this call to create the tag object, and then create the refs/tags/[tag] reference. If you want to create a lightweight tag, you only have to create the tag reference - this call would be unnecessary.
+       */
+      gitTagsCreate: (owner, repo, body, params) =>
+        this.request(`/repos/${owner}/${repo}/git/tags`, "POST", params, body),
+      /**
+       * @name gitTagsDetail
+       * @request GET:/repos/{owner}/{repo}/git/tags/{shaCode}
+       * @description Get a Tag.
+       */
+      gitTagsDetail: (owner, repo, shaCode, params) =>
+        this.request(`/repos/${owner}/${repo}/git/tags/${shaCode}`, "GET", params),
+      /**
+       * @name gitTreesCreate
+       * @request POST:/repos/{owner}/{repo}/git/trees
+       * @description Create a Tree. The tree creation API will take nested entries as well. If both a tree and a nested path modifying that tree are specified, it will overwrite the contents of that tree with the new path contents and write a new tree out.
+       */
+      gitTreesCreate: (owner, repo, body, params) =>
+        this.request(`/repos/${owner}/${repo}/git/trees`, "POST", params, body),
+      /**
+       * @name gitTreesDetail
+       * @request GET:/repos/{owner}/{repo}/git/trees/{shaCode}
+       * @description Get a Tree.
+       */
+      gitTreesDetail: (owner, repo, shaCode, query, params) =>
+        this.request(
+          `/repos/${owner}/${repo}/git/trees/${shaCode}${this.addQueryParams(query)}`,
+          "GET",
+          params,
+        ),
+      /**
+       * @name hooksDetail
+       * @request GET:/repos/{owner}/{repo}/hooks
+       * @description Get list of hooks.
+       */
+      hooksDetail: (owner, repo, params) =>
+        this.request(`/repos/${owner}/${repo}/hooks`, "GET", params),
+      /**
+       * @name hooksCreate
+       * @request POST:/repos/{owner}/{repo}/hooks
+       * @description Create a hook.
+       */
+      hooksCreate: (owner, repo, body, params) =>
+        this.request(`/repos/${owner}/${repo}/hooks`, "POST", params, body),
+      /**
+       * @name hooksDelete
+       * @request DELETE:/repos/{owner}/{repo}/hooks/{hookId}
+       * @description Delete a hook.
+       */
+      hooksDelete: (owner, repo, hookId, params) =>
+        this.request(`/repos/${owner}/${repo}/hooks/${hookId}`, "DELETE", params),
+      /**
+       * @name hooksDetail
+       * @request GET:/repos/{owner}/{repo}/hooks/{hookId}
+       * @description Get single hook.
+       * @originalName hooksDetail
+       * @duplicate
+       */
+      hooksDetail2: (owner, repo, hookId, params) =>
+        this.request(`/repos/${owner}/${repo}/hooks/${hookId}`, "GET", params),
+      /**
+       * @name hooksPartialUpdate
+       * @request PATCH:/repos/{owner}/{repo}/hooks/{hookId}
+       * @description Edit a hook.
+       */
+      hooksPartialUpdate: (owner, repo, hookId, body, params) =>
+        this.request(`/repos/${owner}/${repo}/hooks/${hookId}`, "PATCH", params, body),
+      /**
+       * @name hooksTestsCreate
+       * @request POST:/repos/{owner}/{repo}/hooks/{hookId}/tests
+       * @description Test a push hook. This will trigger the hook with the latest push to the current repository if the hook is subscribed to push events. If the hook is not subscribed to push events, the server will respond with 204 but no test POST will be generated. Note: Previously /repos/:owner/:repo/hooks/:id/tes
+       */
+      hooksTestsCreate: (owner, repo, hookId, params) =>
+        this.request(`/repos/${owner}/${repo}/hooks/${hookId}/tests`, "POST", params),
+      /**
+       * @name issuesDetail
+       * @request GET:/repos/{owner}/{repo}/issues
+       * @description List issues for a repository.
+       */
+      issuesDetail: (owner, repo, query, params) =>
+        this.request(`/repos/${owner}/${repo}/issues${this.addQueryParams(query)}`, "GET", params),
+      /**
+       * @name issuesCreate
+       * @request POST:/repos/{owner}/{repo}/issues
+       * @description Create an issue. Any user with pull access to a repository can create an issue.
+       */
+      issuesCreate: (owner, repo, body, params) =>
+        this.request(`/repos/${owner}/${repo}/issues`, "POST", params, body),
+      /**
+       * @name issuesCommentsDetail
+       * @request GET:/repos/{owner}/{repo}/issues/comments
+       * @description List comments in a repository.
+       */
+      issuesCommentsDetail: (owner, repo, query, params) =>
+        this.request(
+          `/repos/${owner}/${repo}/issues/comments${this.addQueryParams(query)}`,
+          "GET",
+          params,
+        ),
+      /**
+       * @name issuesCommentsDelete
+       * @request DELETE:/repos/{owner}/{repo}/issues/comments/{commentId}
+       * @description Delete a comment.
+       */
+      issuesCommentsDelete: (owner, repo, commentId, params) =>
+        this.request(`/repos/${owner}/${repo}/issues/comments/${commentId}`, "DELETE", params),
+      /**
+       * @name issuesCommentsDetail
+       * @request GET:/repos/{owner}/{repo}/issues/comments/{commentId}
+       * @description Get a single comment.
+       * @originalName issuesCommentsDetail
+       * @duplicate
+       */
+      issuesCommentsDetail2: (owner, repo, commentId, params) =>
+        this.request(`/repos/${owner}/${repo}/issues/comments/${commentId}`, "GET", params),
+      /**
+       * @name issuesCommentsPartialUpdate
+       * @request PATCH:/repos/{owner}/{repo}/issues/comments/{commentId}
+       * @description Edit a comment.
+       */
+      issuesCommentsPartialUpdate: (owner, repo, commentId, body, params) =>
+        this.request(`/repos/${owner}/${repo}/issues/comments/${commentId}`, "PATCH", params, body),
+      /**
+       * @name issuesEventsDetail
+       * @request GET:/repos/{owner}/{repo}/issues/events
+       * @description List issue events for a repository.
+       */
+      issuesEventsDetail: (owner, repo, params) =>
+        this.request(`/repos/${owner}/${repo}/issues/events`, "GET", params),
+      /**
+       * @name issuesEventsDetail
+       * @request GET:/repos/{owner}/{repo}/issues/events/{eventId}
+       * @description Get a single event.
+       * @originalName issuesEventsDetail
+       * @duplicate
+       */
+      issuesEventsDetail2: (owner, repo, eventId, params) =>
+        this.request(`/repos/${owner}/${repo}/issues/events/${eventId}`, "GET", params),
+      /**
+       * @name issuesDetail
+       * @request GET:/repos/{owner}/{repo}/issues/{number}
+       * @description Get a single issue
+       * @originalName issuesDetail
+       * @duplicate
+       */
+      issuesDetail2: (owner, repo, number, params) =>
+        this.request(`/repos/${owner}/${repo}/issues/${number}`, "GET", params),
+      /**
+       * @name issuesPartialUpdate
+       * @request PATCH:/repos/{owner}/{repo}/issues/{number}
+       * @description Edit an issue. Issue owners and users with push access can edit an issue.
+       */
+      issuesPartialUpdate: (owner, repo, number, body, params) =>
+        this.request(`/repos/${owner}/${repo}/issues/${number}`, "PATCH", params, body),
+      /**
+       * @name issuesCommentsDetail
+       * @request GET:/repos/{owner}/{repo}/issues/{number}/comments
+       * @description List comments on an issue.
+       * @originalName issuesCommentsDetail
+       * @duplicate
+       */
+      issuesCommentsDetail3: (owner, repo, number, params) =>
+        this.request(`/repos/${owner}/${repo}/issues/${number}/comments`, "GET", params),
+      /**
+       * @name issuesCommentsCreate
+       * @request POST:/repos/{owner}/{repo}/issues/{number}/comments
+       * @description Create a comment.
+       */
+      issuesCommentsCreate: (owner, repo, number, body, params) =>
+        this.request(`/repos/${owner}/${repo}/issues/${number}/comments`, "POST", params, body),
+      /**
+       * @name issuesEventsDetail
+       * @request GET:/repos/{owner}/{repo}/issues/{number}/events
+       * @description List events for an issue.
+       * @originalName issuesEventsDetail
+       * @duplicate
+       */
+      issuesEventsDetail3: (owner, repo, number, params) =>
+        this.request(`/repos/${owner}/${repo}/issues/${number}/events`, "GET", params),
+      /**
+       * @name issuesLabelsDelete
+       * @request DELETE:/repos/{owner}/{repo}/issues/{number}/labels
+       * @description Remove all labels from an issue.
+       */
+      issuesLabelsDelete: (owner, repo, number, params) =>
+        this.request(`/repos/${owner}/${repo}/issues/${number}/labels`, "DELETE", params),
+      /**
+       * @name issuesLabelsDetail
+       * @request GET:/repos/{owner}/{repo}/issues/{number}/labels
+       * @description List labels on an issue.
+       */
+      issuesLabelsDetail: (owner, repo, number, params) =>
+        this.request(`/repos/${owner}/${repo}/issues/${number}/labels`, "GET", params),
+      /**
+       * @name issuesLabelsCreate
+       * @request POST:/repos/{owner}/{repo}/issues/{number}/labels
+       * @description Add labels to an issue.
+       */
+      issuesLabelsCreate: (owner, repo, number, body, params) =>
+        this.request(`/repos/${owner}/${repo}/issues/${number}/labels`, "POST", params, body),
+      /**
+       * @name issuesLabelsUpdate
+       * @request PUT:/repos/{owner}/{repo}/issues/{number}/labels
+       * @description Replace all labels for an issue. Sending an empty array ([]) will remove all Labels from the Issue.
+       */
+      issuesLabelsUpdate: (owner, repo, number, body, params) =>
+        this.request(`/repos/${owner}/${repo}/issues/${number}/labels`, "PUT", params, body),
+      /**
+       * @name issuesLabelsDelete
+       * @request DELETE:/repos/{owner}/{repo}/issues/{number}/labels/{name}
+       * @description Remove a label from an issue.
+       * @originalName issuesLabelsDelete
+       * @duplicate
+       */
+      issuesLabelsDelete2: (owner, repo, number, name, params) =>
+        this.request(`/repos/${owner}/${repo}/issues/${number}/labels/${name}`, "DELETE", params),
+      /**
+       * @name keysDetail
+       * @request GET:/repos/{owner}/{repo}/keys
+       * @description Get list of keys.
+       */
+      keysDetail: (owner, repo, params) =>
+        this.request(`/repos/${owner}/${repo}/keys`, "GET", params),
+      /**
+       * @name keysCreate
+       * @request POST:/repos/{owner}/{repo}/keys
+       * @description Create a key.
+       */
+      keysCreate: (owner, repo, body, params) =>
+        this.request(`/repos/${owner}/${repo}/keys`, "POST", params, body),
+      /**
+       * @name keysDelete
+       * @request DELETE:/repos/{owner}/{repo}/keys/{keyId}
+       * @description Delete a key.
+       */
+      keysDelete: (owner, repo, keyId, params) =>
+        this.request(`/repos/${owner}/${repo}/keys/${keyId}`, "DELETE", params),
+      /**
+       * @name keysDetail
+       * @request GET:/repos/{owner}/{repo}/keys/{keyId}
+       * @description Get a key
+       * @originalName keysDetail
+       * @duplicate
+       */
+      keysDetail2: (owner, repo, keyId, params) =>
+        this.request(`/repos/${owner}/${repo}/keys/${keyId}`, "GET", params),
+      /**
+       * @name labelsDetail
+       * @request GET:/repos/{owner}/{repo}/labels
+       * @description List all labels for this repository.
+       */
+      labelsDetail: (owner, repo, params) =>
+        this.request(`/repos/${owner}/${repo}/labels`, "GET", params),
+      /**
+       * @name labelsCreate
+       * @request POST:/repos/{owner}/{repo}/labels
+       * @description Create a label.
+       */
+      labelsCreate: (owner, repo, body, params) =>
+        this.request(`/repos/${owner}/${repo}/labels`, "POST", params, body),
+      /**
+       * @name labelsDelete
+       * @request DELETE:/repos/{owner}/{repo}/labels/{name}
+       * @description Delete a label.
+       */
+      labelsDelete: (owner, repo, name, params) =>
+        this.request(`/repos/${owner}/${repo}/labels/${name}`, "DELETE", params),
+      /**
+       * @name labelsDetail
+       * @request GET:/repos/{owner}/{repo}/labels/{name}
+       * @description Get a single label.
+       * @originalName labelsDetail
+       * @duplicate
+       */
+      labelsDetail2: (owner, repo, name, params) =>
+        this.request(`/repos/${owner}/${repo}/labels/${name}`, "GET", params),
+      /**
+       * @name labelsPartialUpdate
+       * @request PATCH:/repos/{owner}/{repo}/labels/{name}
+       * @description Update a label.
+       */
+      labelsPartialUpdate: (owner, repo, name, body, params) =>
+        this.request(`/repos/${owner}/${repo}/labels/${name}`, "PATCH", params, body),
+      /**
+       * @name languagesDetail
+       * @request GET:/repos/{owner}/{repo}/languages
+       * @description List languages. List languages for the specified repository. The value on the right of a language is the number of bytes of code written in that language.
+       */
+      languagesDetail: (owner, repo, params) =>
+        this.request(`/repos/${owner}/${repo}/languages`, "GET", params),
+      /**
+       * @name mergesCreate
+       * @request POST:/repos/{owner}/{repo}/merges
+       * @description Perform a merge.
+       */
+      mergesCreate: (owner, repo, body, params) =>
+        this.request(`/repos/${owner}/${repo}/merges`, "POST", params, body),
+      /**
+       * @name milestonesDetail
+       * @request GET:/repos/{owner}/{repo}/milestones
+       * @description List milestones for a repository.
+       */
+      milestonesDetail: (owner, repo, query, params) =>
+        this.request(
+          `/repos/${owner}/${repo}/milestones${this.addQueryParams(query)}`,
+          "GET",
+          params,
+        ),
+      /**
+       * @name milestonesCreate
+       * @request POST:/repos/{owner}/{repo}/milestones
+       * @description Create a milestone.
+       */
+      milestonesCreate: (owner, repo, body, params) =>
+        this.request(`/repos/${owner}/${repo}/milestones`, "POST", params, body),
+      /**
+       * @name milestonesDelete
+       * @request DELETE:/repos/{owner}/{repo}/milestones/{number}
+       * @description Delete a milestone.
+       */
+      milestonesDelete: (owner, repo, number, params) =>
+        this.request(`/repos/${owner}/${repo}/milestones/${number}`, "DELETE", params),
+      /**
+       * @name milestonesDetail
+       * @request GET:/repos/{owner}/{repo}/milestones/{number}
+       * @description Get a single milestone.
+       * @originalName milestonesDetail
+       * @duplicate
+       */
+      milestonesDetail2: (owner, repo, number, params) =>
+        this.request(`/repos/${owner}/${repo}/milestones/${number}`, "GET", params),
+      /**
+       * @name milestonesPartialUpdate
+       * @request PATCH:/repos/{owner}/{repo}/milestones/{number}
+       * @description Update a milestone.
+       */
+      milestonesPartialUpdate: (owner, repo, number, body, params) =>
+        this.request(`/repos/${owner}/${repo}/milestones/${number}`, "PATCH", params, body),
+      /**
+       * @name milestonesLabelsDetail
+       * @request GET:/repos/{owner}/{repo}/milestones/{number}/labels
+       * @description Get labels for every issue in a milestone.
+       */
+      milestonesLabelsDetail: (owner, repo, number, params) =>
+        this.request(`/repos/${owner}/${repo}/milestones/${number}/labels`, "GET", params),
+      /**
+       * @name notificationsDetail
+       * @request GET:/repos/{owner}/{repo}/notifications
+       * @description List your notifications in a repository List all notifications for the current user.
+       */
+      notificationsDetail: (owner, repo, query, params) =>
+        this.request(
+          `/repos/${owner}/${repo}/notifications${this.addQueryParams(query)}`,
+          "GET",
+          params,
+        ),
+      /**
+       * @name notificationsUpdate
+       * @request PUT:/repos/{owner}/{repo}/notifications
+       * @description Mark notifications as read in a repository. Marking all notifications in a repository as "read" removes them from the default view on GitHub.com.
+       */
+      notificationsUpdate: (owner, repo, body, params) =>
+        this.request(`/repos/${owner}/${repo}/notifications`, "PUT", params, body),
+      /**
+       * @name pullsDetail
+       * @request GET:/repos/{owner}/{repo}/pulls
+       * @description List pull requests.
+       */
+      pullsDetail: (owner, repo, query, params) =>
+        this.request(`/repos/${owner}/${repo}/pulls${this.addQueryParams(query)}`, "GET", params),
+      /**
+       * @name pullsCreate
+       * @request POST:/repos/{owner}/{repo}/pulls
+       * @description Create a pull request.
+       */
+      pullsCreate: (owner, repo, body, params) =>
+        this.request(`/repos/${owner}/${repo}/pulls`, "POST", params, body),
+      /**
+       * @name pullsCommentsDetail
+       * @request GET:/repos/{owner}/{repo}/pulls/comments
+       * @description List comments in a repository. By default, Review Comments are ordered by ascending ID.
+       */
+      pullsCommentsDetail: (owner, repo, query, params) =>
+        this.request(
+          `/repos/${owner}/${repo}/pulls/comments${this.addQueryParams(query)}`,
+          "GET",
+          params,
+        ),
+      /**
+       * @name pullsCommentsDelete
+       * @request DELETE:/repos/{owner}/{repo}/pulls/comments/{commentId}
+       * @description Delete a comment.
+       */
+      pullsCommentsDelete: (owner, repo, commentId, params) =>
+        this.request(`/repos/${owner}/${repo}/pulls/comments/${commentId}`, "DELETE", params),
+      /**
+       * @name pullsCommentsDetail
+       * @request GET:/repos/{owner}/{repo}/pulls/comments/{commentId}
+       * @description Get a single comment.
+       * @originalName pullsCommentsDetail
+       * @duplicate
+       */
+      pullsCommentsDetail2: (owner, repo, commentId, params) =>
+        this.request(`/repos/${owner}/${repo}/pulls/comments/${commentId}`, "GET", params),
+      /**
+       * @name pullsCommentsPartialUpdate
+       * @request PATCH:/repos/{owner}/{repo}/pulls/comments/{commentId}
+       * @description Edit a comment.
+       */
+      pullsCommentsPartialUpdate: (owner, repo, commentId, body, params) =>
+        this.request(`/repos/${owner}/${repo}/pulls/comments/${commentId}`, "PATCH", params, body),
+      /**
+       * @name pullsDetail
+       * @request GET:/repos/{owner}/{repo}/pulls/{number}
+       * @description Get a single pull request.
+       * @originalName pullsDetail
+       * @duplicate
+       */
+      pullsDetail2: (owner, repo, number, params) =>
+        this.request(`/repos/${owner}/${repo}/pulls/${number}`, "GET", params),
+      /**
+       * @name pullsPartialUpdate
+       * @request PATCH:/repos/{owner}/{repo}/pulls/{number}
+       * @description Update a pull request.
+       */
+      pullsPartialUpdate: (owner, repo, number, body, params) =>
+        this.request(`/repos/${owner}/${repo}/pulls/${number}`, "PATCH", params, body),
+      /**
+       * @name pullsCommentsDetail
+       * @request GET:/repos/{owner}/{repo}/pulls/{number}/comments
+       * @description List comments on a pull request.
+       * @originalName pullsCommentsDetail
+       * @duplicate
+       */
+      pullsCommentsDetail3: (owner, repo, number, params) =>
+        this.request(`/repos/${owner}/${repo}/pulls/${number}/comments`, "GET", params),
+      /**
+       * @name pullsCommentsCreate
+       * @request POST:/repos/{owner}/{repo}/pulls/{number}/comments
+       * @description Create a comment. #TODO Alternative input ( http://developer.github.com/v3/pulls/comments/ ) description: | Alternative Input. Instead of passing commit_id, path, and position you can reply to an existing Pull Request Comment like this: body Required string in_reply_to Required number - Comment id to reply to.
+       */
+      pullsCommentsCreate: (owner, repo, number, body, params) =>
+        this.request(`/repos/${owner}/${repo}/pulls/${number}/comments`, "POST", params, body),
+      /**
+       * @name pullsCommitsDetail
+       * @request GET:/repos/{owner}/{repo}/pulls/{number}/commits
+       * @description List commits on a pull request.
+       */
+      pullsCommitsDetail: (owner, repo, number, params) =>
+        this.request(`/repos/${owner}/${repo}/pulls/${number}/commits`, "GET", params),
+      /**
+       * @name pullsFilesDetail
+       * @request GET:/repos/{owner}/{repo}/pulls/{number}/files
+       * @description List pull requests files.
+       */
+      pullsFilesDetail: (owner, repo, number, params) =>
+        this.request(`/repos/${owner}/${repo}/pulls/${number}/files`, "GET", params),
+      /**
+       * @name pullsMergeDetail
+       * @request GET:/repos/{owner}/{repo}/pulls/{number}/merge
+       * @description Get if a pull request has been merged.
+       */
+      pullsMergeDetail: (owner, repo, number, params) =>
+        this.request(`/repos/${owner}/${repo}/pulls/${number}/merge`, "GET", params),
+      /**
+       * @name pullsMergeUpdate
+       * @request PUT:/repos/{owner}/{repo}/pulls/{number}/merge
+       * @description Merge a pull request (Merge Button's)
+       */
+      pullsMergeUpdate: (owner, repo, number, body, params) =>
+        this.request(`/repos/${owner}/${repo}/pulls/${number}/merge`, "PUT", params, body),
+      /**
+       * @name readmeDetail
+       * @request GET:/repos/{owner}/{repo}/readme
+       * @description Get the README. This method returns the preferred README for a repository.
+       */
+      readmeDetail: (owner, repo, query, params) =>
+        this.request(`/repos/${owner}/${repo}/readme${this.addQueryParams(query)}`, "GET", params),
+      /**
+       * @name releasesDetail
+       * @request GET:/repos/{owner}/{repo}/releases
+       * @description Users with push access to the repository will receive all releases (i.e., published releases and draft releases). Users with pull access will receive published releases only
+       */
+      releasesDetail: (owner, repo, params) =>
+        this.request(`/repos/${owner}/${repo}/releases`, "GET", params),
+      /**
+       * @name releasesCreate
+       * @request POST:/repos/{owner}/{repo}/releases
+       * @description Create a release Users with push access to the repository can create a release.
+       */
+      releasesCreate: (owner, repo, body, params) =>
+        this.request(`/repos/${owner}/${repo}/releases`, "POST", params, body),
+      /**
+       * @name releasesAssetsDelete
+       * @request DELETE:/repos/{owner}/{repo}/releases/assets/{id}
+       * @description Delete a release asset
+       */
+      releasesAssetsDelete: (owner, repo, id, params) =>
+        this.request(`/repos/${owner}/${repo}/releases/assets/${id}`, "DELETE", params),
+      /**
+       * @name releasesAssetsDetail
+       * @request GET:/repos/{owner}/{repo}/releases/assets/{id}
+       * @description Get a single release asset
+       */
+      releasesAssetsDetail: (owner, repo, id, params) =>
+        this.request(`/repos/${owner}/${repo}/releases/assets/${id}`, "GET", params),
+      /**
+       * @name releasesAssetsPartialUpdate
+       * @request PATCH:/repos/{owner}/{repo}/releases/assets/{id}
+       * @description Edit a release asset Users with push access to the repository can edit a release asset.
+       */
+      releasesAssetsPartialUpdate: (owner, repo, id, body, params) =>
+        this.request(`/repos/${owner}/${repo}/releases/assets/${id}`, "PATCH", params, body),
+      /**
+       * @name releasesDelete
+       * @request DELETE:/repos/{owner}/{repo}/releases/{id}
+       * @description Users with push access to the repository can delete a release.
+       */
+      releasesDelete: (owner, repo, id, params) =>
+        this.request(`/repos/${owner}/${repo}/releases/${id}`, "DELETE", params),
+      /**
+       * @name releasesDetail
+       * @request GET:/repos/{owner}/{repo}/releases/{id}
+       * @description Get a single release
+       * @originalName releasesDetail
+       * @duplicate
+       */
+      releasesDetail2: (owner, repo, id, params) =>
+        this.request(`/repos/${owner}/${repo}/releases/${id}`, "GET", params),
+      /**
+       * @name releasesPartialUpdate
+       * @request PATCH:/repos/{owner}/{repo}/releases/{id}
+       * @description Users with push access to the repository can edit a release
+       */
+      releasesPartialUpdate: (owner, repo, id, body, params) =>
+        this.request(`/repos/${owner}/${repo}/releases/${id}`, "PATCH", params, body),
+      /**
+       * @name releasesAssetsDetail
+       * @request GET:/repos/{owner}/{repo}/releases/{id}/assets
+       * @description List assets for a release
+       * @originalName releasesAssetsDetail
+       * @duplicate
+       */
+      releasesAssetsDetail2: (owner, repo, id, params) =>
+        this.request(`/repos/${owner}/${repo}/releases/${id}/assets`, "GET", params),
+      /**
+       * @name stargazersDetail
+       * @request GET:/repos/{owner}/{repo}/stargazers
+       * @description List Stargazers.
+       */
+      stargazersDetail: (owner, repo, params) =>
+        this.request(`/repos/${owner}/${repo}/stargazers`, "GET", params),
+      /**
+       * @name statsCodeFrequencyDetail
+       * @request GET:/repos/{owner}/{repo}/stats/code_frequency
+       * @description Get the number of additions and deletions per week. Returns a weekly aggregate of the number of additions and deletions pushed to a repository.
+       */
+      statsCodeFrequencyDetail: (owner, repo, params) =>
+        this.request(`/repos/${owner}/${repo}/stats/code_frequency`, "GET", params),
+      /**
+       * @name statsCommitActivityDetail
+       * @request GET:/repos/{owner}/{repo}/stats/commit_activity
+       * @description Get the last year of commit activity data. Returns the last year of commit activity grouped by week. The days array is a group of commits per day, starting on Sunday.
+       */
+      statsCommitActivityDetail: (owner, repo, params) =>
+        this.request(`/repos/${owner}/${repo}/stats/commit_activity`, "GET", params),
+      /**
+       * @name statsContributorsDetail
+       * @request GET:/repos/{owner}/{repo}/stats/contributors
+       * @description Get contributors list with additions, deletions, and commit counts.
+       */
+      statsContributorsDetail: (owner, repo, params) =>
+        this.request(`/repos/${owner}/${repo}/stats/contributors`, "GET", params),
+      /**
+       * @name statsParticipationDetail
+       * @request GET:/repos/{owner}/{repo}/stats/participation
+       * @description Get the weekly commit count for the repo owner and everyone else.
+       */
+      statsParticipationDetail: (owner, repo, params) =>
+        this.request(`/repos/${owner}/${repo}/stats/participation`, "GET", params),
+      /**
+       * @name statsPunchCardDetail
+       * @request GET:/repos/{owner}/{repo}/stats/punch_card
+       * @description Get the number of commits per hour in each day. Each array contains the day number, hour number, and number of commits 0-6 Sunday - Saturday 0-23 Hour of day Number of commits For example, [2, 14, 25] indicates that there were 25 total commits, during the 2.00pm hour on Tuesdays. All times are based on the time zone of individual commits.
+       */
+      statsPunchCardDetail: (owner, repo, params) =>
+        this.request(`/repos/${owner}/${repo}/stats/punch_card`, "GET", params),
+      /**
+       * @name statusesDetail
+       * @request GET:/repos/{owner}/{repo}/statuses/{ref}
+       * @description List Statuses for a specific Ref.
+       */
+      statusesDetail: (owner, repo, ref, params) =>
+        this.request(`/repos/${owner}/${repo}/statuses/${ref}`, "GET", params),
+      /**
+       * @name statusesCreate
+       * @request POST:/repos/{owner}/{repo}/statuses/{ref}
+       * @description Create a Status.
+       */
+      statusesCreate: (owner, repo, ref, body, params) =>
+        this.request(`/repos/${owner}/${repo}/statuses/${ref}`, "POST", params, body),
+      /**
+       * @name subscribersDetail
+       * @request GET:/repos/{owner}/{repo}/subscribers
+       * @description List watchers.
+       */
+      subscribersDetail: (owner, repo, params) =>
+        this.request(`/repos/${owner}/${repo}/subscribers`, "GET", params),
+      /**
+       * @name subscriptionDelete
+       * @request DELETE:/repos/{owner}/{repo}/subscription
+       * @description Delete a Repository Subscription.
+       */
+      subscriptionDelete: (owner, repo, params) =>
+        this.request(`/repos/${owner}/${repo}/subscription`, "DELETE", params),
+      /**
+       * @name subscriptionDetail
+       * @request GET:/repos/{owner}/{repo}/subscription
+       * @description Get a Repository Subscription.
+       */
+      subscriptionDetail: (owner, repo, params) =>
+        this.request(`/repos/${owner}/${repo}/subscription`, "GET", params),
+      /**
+       * @name subscriptionUpdate
+       * @request PUT:/repos/{owner}/{repo}/subscription
+       * @description Set a Repository Subscription
+       */
+      subscriptionUpdate: (owner, repo, body, params) =>
+        this.request(`/repos/${owner}/${repo}/subscription`, "PUT", params, body),
+      /**
+       * @name tagsDetail
+       * @request GET:/repos/{owner}/{repo}/tags
+       * @description Get list of tags.
+       */
+      tagsDetail: (owner, repo, params) =>
+        this.request(`/repos/${owner}/${repo}/tags`, "GET", params),
+      /**
+       * @name teamsDetail
+       * @request GET:/repos/{owner}/{repo}/teams
+       * @description Get list of teams
+       */
+      teamsDetail: (owner, repo, params) =>
+        this.request(`/repos/${owner}/${repo}/teams`, "GET", params),
+      /**
+       * @name watchersDetail
+       * @request GET:/repos/{owner}/{repo}/watchers
+       * @description List Stargazers. New implementation.
+       */
+      watchersDetail: (owner, repo, params) =>
+        this.request(`/repos/${owner}/${repo}/watchers`, "GET", params),
+      /**
+       * @name reposDetail
+       * @request GET:/repos/{owner}/{repo}/{archive_format}/{path}
+       * @description Get archive link. This method will return a 302 to a URL to download a tarball or zipball archive for a repository. Please make sure your HTTP framework is configured to follow redirects or you will need to use the Location header to make a second GET request. Note: For private repositories, these links are temporary and expire quickly.
+       * @originalName reposDetail
+       * @duplicate
+       */
+      reposDetail2: (owner, repo, archive_format, path, params) =>
+        this.request(`/repos/${owner}/${repo}/${archive_format}/${path}`, "GET", params),
+    };
+    this.repositories = {
+      /**
+       * @name repositoriesList
+       * @request GET:/repositories
+       * @description List all public repositories. This provides a dump of every public repository, in the order that they were created. Note: Pagination is powered exclusively by the since parameter. is the Link header to get the URL for the next page of repositories.
+       */
+      repositoriesList: (query, params) =>
+        this.request(`/repositories${this.addQueryParams(query)}`, "GET", params),
+    };
+    this.search = {
+      /**
+       * @name codeList
+       * @request GET:/search/code
+       * @description Search code.
+       */
+      codeList: (query, params) =>
+        this.request(`/search/code${this.addQueryParams(query)}`, "GET", params),
+      /**
+       * @name issuesList
+       * @request GET:/search/issues
+       * @description Find issues by state and keyword. (This method returns up to 100 results per page.)
+       */
+      issuesList: (query, params) =>
+        this.request(`/search/issues${this.addQueryParams(query)}`, "GET", params),
+      /**
+       * @name repositoriesList
+       * @request GET:/search/repositories
+       * @description Search repositories.
+       */
+      repositoriesList: (query, params) =>
+        this.request(`/search/repositories${this.addQueryParams(query)}`, "GET", params),
+      /**
+       * @name usersList
+       * @request GET:/search/users
+       * @description Search users.
+       */
+      usersList: (query, params) =>
+        this.request(`/search/users${this.addQueryParams(query)}`, "GET", params),
+    };
+    this.teams = {
+      /**
+       * @name teamsDelete
+       * @request DELETE:/teams/{teamId}
+       * @description Delete team. In order to delete a team, the authenticated user must be an owner of the org that the team is associated with.
+       */
+      teamsDelete: (teamId, params) => this.request(`/teams/${teamId}`, "DELETE", params),
+      /**
+       * @name teamsDetail
+       * @request GET:/teams/{teamId}
+       * @description Get team.
+       */
+      teamsDetail: (teamId, params) => this.request(`/teams/${teamId}`, "GET", params),
+      /**
+       * @name teamsPartialUpdate
+       * @request PATCH:/teams/{teamId}
+       * @description Edit team. In order to edit a team, the authenticated user must be an owner of the org that the team is associated with.
+       */
+      teamsPartialUpdate: (teamId, body, params) =>
+        this.request(`/teams/${teamId}`, "PATCH", params, body),
+      /**
+       * @name membersDetail
+       * @request GET:/teams/{teamId}/members
+       * @description List team members. In order to list members in a team, the authenticated user must be a member of the team.
+       */
+      membersDetail: (teamId, params) => this.request(`/teams/${teamId}/members`, "GET", params),
+      /**
+       * @name membersDelete
+       * @request DELETE:/teams/{teamId}/members/{username}
+       * @description The "Remove team member" API is deprecated and is scheduled for removal in the next major version of the API. We recommend using the Remove team membership API instead. It allows you to remove both active and pending memberships. Remove team member. In order to remove a user from a team, the authenticated user must have 'admin' permissions to the team or be an owner of the org that the team is associated with. NOTE This does not delete the user, it just remove them from the team.
+       */
+      membersDelete: (teamId, username, params) =>
+        this.request(`/teams/${teamId}/members/${username}`, "DELETE", params),
+      /**
+       * @name membersDetail
+       * @request GET:/teams/{teamId}/members/{username}
+       * @description The "Get team member" API is deprecated and is scheduled for removal in the next major version of the API. We recommend using the Get team membership API instead. It allows you to get both active and pending memberships. Get team member. In order to get if a user is a member of a team, the authenticated user mus be a member of the team.
+       * @originalName membersDetail
+       * @duplicate
+       */
+      membersDetail2: (teamId, username, params) =>
+        this.request(`/teams/${teamId}/members/${username}`, "GET", params),
+      /**
+       * @name membersUpdate
+       * @request PUT:/teams/{teamId}/members/{username}
+       * @description The API (described below) is deprecated and is scheduled for removal in the next major version of the API. We recommend using the Add team membership API instead. It allows you to invite new organization members to your teams. Add team member. In order to add a user to a team, the authenticated user must have 'admin' permissions to the team or be an owner of the org that the team is associated with.
+       */
+      membersUpdate: (teamId, username, params) =>
+        this.request(`/teams/${teamId}/members/${username}`, "PUT", params),
+      /**
+       * @name membershipsDelete
+       * @request DELETE:/teams/{teamId}/memberships/{username}
+       * @description Remove team membership. In order to remove a membership between a user and a team, the authenticated user must have 'admin' permissions to the team or be an owner of the organization that the team is associated with. NOTE: This does not delete the user, it just removes their membership from the team.
+       */
+      membershipsDelete: (teamId, username, params) =>
+        this.request(`/teams/${teamId}/memberships/${username}`, "DELETE", params),
+      /**
+       * @name membershipsDetail
+       * @request GET:/teams/{teamId}/memberships/{username}
+       * @description Get team membership. In order to get a user's membership with a team, the authenticated user must be a member of the team or an owner of the team's organization.
+       */
+      membershipsDetail: (teamId, username, params) =>
+        this.request(`/teams/${teamId}/memberships/${username}`, "GET", params),
+      /**
+       * @name membershipsUpdate
+       * @request PUT:/teams/{teamId}/memberships/{username}
+       * @description Add team membership. In order to add a membership between a user and a team, the authenticated user must have 'admin' permissions to the team or be an owner of the organization that the team is associated with. If the user is already a part of the team's organization (meaning they're on at least one other team in the organization), this endpoint will add the user to the team. If the user is completely unaffiliated with the team's organization (meaning they're on none of the organization's teams), this endpoint will send an invitation to the user via email. This newly-created membership will be in the 'pending' state until the user accepts the invitation, at which point the membership will transition to the 'active' state and the user will be added as a member of the team.
+       */
+      membershipsUpdate: (teamId, username, params) =>
+        this.request(`/teams/${teamId}/memberships/${username}`, "PUT", params),
+      /**
+       * @name reposDetail
+       * @request GET:/teams/{teamId}/repos
+       * @description List team repos
+       */
+      reposDetail: (teamId, params) => this.request(`/teams/${teamId}/repos`, "GET", params),
+      /**
+       * @name reposDelete
+       * @request DELETE:/teams/{teamId}/repos/{owner}/{repo}
+       * @description In order to remove a repository from a team, the authenticated user must be an owner of the org that the team is associated with. NOTE: This does not delete the repository, it just removes it from the team.
+       */
+      reposDelete: (teamId, owner, repo, params) =>
+        this.request(`/teams/${teamId}/repos/${owner}/${repo}`, "DELETE", params),
+      /**
+       * @name reposDetail
+       * @request GET:/teams/{teamId}/repos/{owner}/{repo}
+       * @description Check if a team manages a repository
+       * @originalName reposDetail
+       * @duplicate
+       */
+      reposDetail2: (teamId, owner, repo, params) =>
+        this.request(`/teams/${teamId}/repos/${owner}/${repo}`, "GET", params),
+      /**
+       * @name reposUpdate
+       * @request PUT:/teams/{teamId}/repos/{owner}/{repo}
+       * @description In order to add a repository to a team, the authenticated user must be an owner of the org that the team is associated with. Also, the repository must be owned by the organization, or a direct fork of a repository owned by the organization.
+       */
+      reposUpdate: (teamId, owner, repo, params) =>
+        this.request(`/teams/${teamId}/repos/${owner}/${repo}`, "PUT", params),
+    };
+    this.user = {
+      /**
+       * @name userList
+       * @request GET:/user
+       * @description Get the authenticated user.
+       */
+      userList: (params) => this.request(`/user`, "GET", params),
+      /**
+       * @name userPartialUpdate
+       * @request PATCH:/user
+       * @description Update the authenticated user.
+       */
+      userPartialUpdate: (body, params) => this.request(`/user`, "PATCH", params, body),
+      /**
+       * @name emailsDelete
+       * @request DELETE:/user/emails
+       * @description Delete email address(es). You can include a single email address or an array of addresses.
+       */
+      emailsDelete: (body, params) => this.request(`/user/emails`, "DELETE", params, body),
+      /**
+       * @name emailsList
+       * @request GET:/user/emails
+       * @description List email addresses for a user. In the final version of the API, this method will return an array of hashes with extended information for each email address indicating if the address has been verified and if it's primary email address for GitHub. Until API v3 is finalized, use the application/vnd.github.v3 media type to get other response format.
+       */
+      emailsList: (params) => this.request(`/user/emails`, "GET", params),
+      /**
+       * @name emailsCreate
+       * @request POST:/user/emails
+       * @description Add email address(es). You can post a single email address or an array of addresses.
+       */
+      emailsCreate: (body, params) => this.request(`/user/emails`, "POST", params, body),
+      /**
+       * @name followersList
+       * @request GET:/user/followers
+       * @description List the authenticated user's followers
+       */
+      followersList: (params) => this.request(`/user/followers`, "GET", params),
+      /**
+       * @name followingList
+       * @request GET:/user/following
+       * @description List who the authenticated user is following.
+       */
+      followingList: (params) => this.request(`/user/following`, "GET", params),
+      /**
+       * @name followingDelete
+       * @request DELETE:/user/following/{username}
+       * @description Unfollow a user. Unfollowing a user requires the user to be logged in and authenticated with basic auth or OAuth with the user:follow scope.
+       */
+      followingDelete: (username, params) =>
+        this.request(`/user/following/${username}`, "DELETE", params),
+      /**
+       * @name followingDetail
+       * @request GET:/user/following/{username}
+       * @description Check if you are following a user.
+       */
+      followingDetail: (username, params) =>
+        this.request(`/user/following/${username}`, "GET", params),
+      /**
+       * @name followingUpdate
+       * @request PUT:/user/following/{username}
+       * @description Follow a user. Following a user requires the user to be logged in and authenticated with basic auth or OAuth with the user:follow scope.
+       */
+      followingUpdate: (username, params) =>
+        this.request(`/user/following/${username}`, "PUT", params),
+      /**
+       * @name issuesList
+       * @request GET:/user/issues
+       * @description List issues. List all issues across owned and member repositories for the authenticated user.
+       */
+      issuesList: (query, params) =>
+        this.request(`/user/issues${this.addQueryParams(query)}`, "GET", params),
+      /**
+       * @name keysList
+       * @request GET:/user/keys
+       * @description List your public keys. Lists the current user's keys. Management of public keys via the API requires that you are authenticated through basic auth, or OAuth with the 'user', 'write:public_key' scopes.
+       */
+      keysList: (params) => this.request(`/user/keys`, "GET", params),
+      /**
+       * @name keysCreate
+       * @request POST:/user/keys
+       * @description Create a public key.
+       */
+      keysCreate: (body, params) => this.request(`/user/keys`, "POST", params, body),
+      /**
+       * @name keysDelete
+       * @request DELETE:/user/keys/{keyId}
+       * @description Delete a public key. Removes a public key. Requires that you are authenticated via Basic Auth or via OAuth with at least admin:public_key scope.
+       */
+      keysDelete: (keyId, params) => this.request(`/user/keys/${keyId}`, "DELETE", params),
+      /**
+       * @name keysDetail
+       * @request GET:/user/keys/{keyId}
+       * @description Get a single public key.
+       */
+      keysDetail: (keyId, params) => this.request(`/user/keys/${keyId}`, "GET", params),
+      /**
+       * @name orgsList
+       * @request GET:/user/orgs
+       * @description List public and private organizations for the authenticated user.
+       */
+      orgsList: (params) => this.request(`/user/orgs`, "GET", params),
+      /**
+       * @name reposList
+       * @request GET:/user/repos
+       * @description List repositories for the authenticated user. Note that this does not include repositories owned by organizations which the user can access. You can lis user organizations and list organization repositories separately.
+       */
+      reposList: (query, params) =>
+        this.request(`/user/repos${this.addQueryParams(query)}`, "GET", params),
+      /**
+       * @name reposCreate
+       * @request POST:/user/repos
+       * @description Create a new repository for the authenticated user. OAuth users must supply repo scope.
+       */
+      reposCreate: (body, params) => this.request(`/user/repos`, "POST", params, body),
+      /**
+       * @name starredList
+       * @request GET:/user/starred
+       * @description List repositories being starred by the authenticated user.
+       */
+      starredList: (query, params) =>
+        this.request(`/user/starred${this.addQueryParams(query)}`, "GET", params),
+      /**
+       * @name starredDelete
+       * @request DELETE:/user/starred/{owner}/{repo}
+       * @description Unstar a repository
+       */
+      starredDelete: (owner, repo, params) =>
+        this.request(`/user/starred/${owner}/${repo}`, "DELETE", params),
+      /**
+       * @name starredDetail
+       * @request GET:/user/starred/{owner}/{repo}
+       * @description Check if you are starring a repository.
+       */
+      starredDetail: (owner, repo, params) =>
+        this.request(`/user/starred/${owner}/${repo}`, "GET", params),
+      /**
+       * @name starredUpdate
+       * @request PUT:/user/starred/{owner}/{repo}
+       * @description Star a repository.
+       */
+      starredUpdate: (owner, repo, params) =>
+        this.request(`/user/starred/${owner}/${repo}`, "PUT", params),
+      /**
+       * @name subscriptionsList
+       * @request GET:/user/subscriptions
+       * @description List repositories being watched by the authenticated user.
+       */
+      subscriptionsList: (params) => this.request(`/user/subscriptions`, "GET", params),
+      /**
+       * @name subscriptionsDelete
+       * @request DELETE:/user/subscriptions/{owner}/{repo}
+       * @description Stop watching a repository
+       */
+      subscriptionsDelete: (owner, repo, params) =>
+        this.request(`/user/subscriptions/${owner}/${repo}`, "DELETE", params),
+      /**
+       * @name subscriptionsDetail
+       * @request GET:/user/subscriptions/{owner}/{repo}
+       * @description Check if you are watching a repository.
+       */
+      subscriptionsDetail: (owner, repo, params) =>
+        this.request(`/user/subscriptions/${owner}/${repo}`, "GET", params),
+      /**
+       * @name subscriptionsUpdate
+       * @request PUT:/user/subscriptions/{owner}/{repo}
+       * @description Watch a repository.
+       */
+      subscriptionsUpdate: (owner, repo, params) =>
+        this.request(`/user/subscriptions/${owner}/${repo}`, "PUT", params),
+      /**
+       * @name teamsList
+       * @request GET:/user/teams
+       * @description List all of the teams across all of the organizations to which the authenticated user belongs. This method requires user or repo scope when authenticating via OAuth.
+       */
+      teamsList: (params) => this.request(`/user/teams`, "GET", params),
+    };
+    this.users = {
+      /**
+       * @name usersList
+       * @request GET:/users
+       * @description Get all users. This provides a dump of every user, in the order that they signed up for GitHub. Note: Pagination is powered exclusively by the since parameter. Use the Link header to get the URL for the next page of users.
+       */
+      usersList: (query, params) =>
+        this.request(`/users${this.addQueryParams(query)}`, "GET", params),
+      /**
+       * @name usersDetail
+       * @request GET:/users/{username}
+       * @description Get a single user.
+       */
+      usersDetail: (username, params) => this.request(`/users/${username}`, "GET", params),
+      /**
+       * @name eventsDetail
+       * @request GET:/users/{username}/events
+       * @description If you are authenticated as the given user, you will see your private events. Otherwise, you'll only see public events.
+       */
+      eventsDetail: (username, params) => this.request(`/users/${username}/events`, "GET", params),
+      /**
+       * @name eventsOrgsDetail
+       * @request GET:/users/{username}/events/orgs/{org}
+       * @description This is the user's organization dashboard. You must be authenticated as the user to view this.
+       */
+      eventsOrgsDetail: (username, org, params) =>
+        this.request(`/users/${username}/events/orgs/${org}`, "GET", params),
+      /**
+       * @name followersDetail
+       * @request GET:/users/{username}/followers
+       * @description List a user's followers
+       */
+      followersDetail: (username, params) =>
+        this.request(`/users/${username}/followers`, "GET", params),
+      /**
+       * @name followingDetail
+       * @request GET:/users/{username}/following/{targetUser}
+       * @description Check if one user follows another.
+       */
+      followingDetail: (username, targetUser, params) =>
+        this.request(`/users/${username}/following/${targetUser}`, "GET", params),
+      /**
+       * @name gistsDetail
+       * @request GET:/users/{username}/gists
+       * @description List a users gists.
+       */
+      gistsDetail: (username, query, params) =>
+        this.request(`/users/${username}/gists${this.addQueryParams(query)}`, "GET", params),
+      /**
+       * @name keysDetail
+       * @request GET:/users/{username}/keys
+       * @description List public keys for a user. Lists the verified public keys for a user. This is accessible by anyone.
+       */
+      keysDetail: (username, params) => this.request(`/users/${username}/keys`, "GET", params),
+      /**
+       * @name orgsDetail
+       * @request GET:/users/{username}/orgs
+       * @description List all public organizations for a user.
+       */
+      orgsDetail: (username, params) => this.request(`/users/${username}/orgs`, "GET", params),
+      /**
+       * @name receivedEventsDetail
+       * @request GET:/users/{username}/received_events
+       * @description These are events that you'll only see public events.
+       */
+      receivedEventsDetail: (username, params) =>
+        this.request(`/users/${username}/received_events`, "GET", params),
+      /**
+       * @name receivedEventsPublicDetail
+       * @request GET:/users/{username}/received_events/public
+       * @description List public events that a user has received
+       */
+      receivedEventsPublicDetail: (username, params) =>
+        this.request(`/users/${username}/received_events/public`, "GET", params),
+      /**
+       * @name reposDetail
+       * @request GET:/users/{username}/repos
+       * @description List public repositories for the specified user.
+       */
+      reposDetail: (username, query, params) =>
+        this.request(`/users/${username}/repos${this.addQueryParams(query)}`, "GET", params),
+      /**
+       * @name starredDetail
+       * @request GET:/users/{username}/starred
+       * @description List repositories being starred by a user.
+       */
+      starredDetail: (username, params) =>
+        this.request(`/users/${username}/starred`, "GET", params),
+      /**
+       * @name subscriptionsDetail
+       * @request GET:/users/{username}/subscriptions
+       * @description List repositories being watched by a user.
+       */
+      subscriptionsDetail: (username, params) =>
+        this.request(`/users/${username}/subscriptions`, "GET", params),
+    };
+  }
+}

--- a/tests/spec/js/schema.json
+++ b/tests/spec/js/schema.json
@@ -1,0 +1,23683 @@
+{
+  "swagger": "2.0",
+  "schemes": ["https"],
+  "host": "api.github.com",
+  "basePath": "/",
+  "info": {
+    "description": "Powerful collaboration, code review, and code management for open source and private projects.\n",
+    "termsOfService": "https://help.github.com/articles/github-terms-of-service/#b-api-terms",
+    "title": "GitHub",
+    "version": "v3",
+    "x-apisguru-categories": ["collaboration", "developer_tools"],
+    "x-logo": {
+      "url": "https://api.apis.guru/v2/cache/logo/https_twitter.com_github_profile_image.jpeg"
+    },
+    "x-origin": [
+      {
+        "format": "swagger",
+        "url": "https://raw.githubusercontent.com/APIs-guru/unofficial_openapi_specs/master/github.com/v3/swagger.yaml",
+        "version": "2.0"
+      }
+    ],
+    "x-preferred": false,
+    "x-providerName": "github.com",
+    "x-unofficialSpec": true
+  },
+  "externalDocs": {
+    "url": "https://developer.github.com/v3/"
+  },
+  "consumes": ["application/json"],
+  "produces": ["application/json"],
+  "securityDefinitions": {
+    "oauth_2_0": {
+      "authorizationUrl": "https://github.com/login/oauth/authorize",
+      "description": "OAuth2 is a protocol that lets external apps request authorization to private\ndetails in a user's GitHub account without getting their password. This is\npreferred over Basic Authentication because tokens can be limited to specific\ntypes of data, and can be revoked by users at any time.\n",
+      "flow": "accessCode",
+      "scopes": {
+        "admin:org": "",
+        "admin:org_hook": "",
+        "admin:public_key": "",
+        "admin:repo_hook": "",
+        "delete_repo": "",
+        "gist": "",
+        "notifications": "",
+        "public_repo": "",
+        "read:org": "",
+        "read:public_key": "",
+        "read:repo_hook": "",
+        "repo": "",
+        "repo:status": "",
+        "repo_deployment": "",
+        "user": "",
+        "user:email": "",
+        "user:follow": "",
+        "write:org": "",
+        "write:public_key": "",
+        "write:repo_hook": ""
+      },
+      "tokenUrl": "https://github.com/login/oauth/access_token",
+      "type": "oauth2"
+    }
+  },
+  "paths": {
+    "/emojis": {
+      "get": {
+        "description": "Lists all the emojis available to use on GitHub.",
+        "parameters": [
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/emojis"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/events": {
+      "get": {
+        "description": "List public events.",
+        "parameters": [
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/events"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/feeds": {
+      "get": {
+        "description": "List Feeds.\nGitHub provides several timeline resources in Atom format. The Feeds API\n lists all the feeds available to the authenticating user.\n",
+        "parameters": [
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/feeds"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/gists": {
+      "get": {
+        "description": "List the authenticated user's gists or if called anonymously, this will\nreturn all public gists.\n",
+        "parameters": [
+          {
+            "description": "Timestamp in ISO 8601 format YYYY-MM-DDTHH:MM:SSZ.\nOnly gists updated at or after this time are returned.\n",
+            "in": "query",
+            "name": "since",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/gists"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Create a gist.",
+        "parameters": [
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/postGist"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/gist"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/gists/public": {
+      "get": {
+        "description": "List all public gists.",
+        "parameters": [
+          {
+            "description": "Timestamp in ISO 8601 format YYYY-MM-DDTHH:MM:SSZ.\nOnly gists updated at or after this time are returned.\n",
+            "in": "query",
+            "name": "since",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/gists"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/gists/starred": {
+      "get": {
+        "description": "List the authenticated user's starred gists.",
+        "parameters": [
+          {
+            "description": "Timestamp in ISO 8601 format YYYY-MM-DDTHH:MM:SSZ.\nOnly gists updated at or after this time are returned.\n",
+            "in": "query",
+            "name": "since",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/gists"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/gists/{id}": {
+      "delete": {
+        "description": "Delete a gist.",
+        "parameters": [
+          {
+            "description": "Id of gist.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No content.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "description": "Get a single gist.",
+        "parameters": [
+          {
+            "description": "Id of gist.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/gist"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "description": "Edit a gist.",
+        "parameters": [
+          {
+            "description": "Id of gist.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/patchGist"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/gist"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/gists/{id}/comments": {
+      "get": {
+        "description": "List comments on a gist.",
+        "parameters": [
+          {
+            "description": "Id of gist.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/comments"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Create a commen",
+        "parameters": [
+          {
+            "description": "Id of gist.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/commentBody"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/comment"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/gists/{id}/comments/{commentId}": {
+      "delete": {
+        "description": "Delete a comment.",
+        "parameters": [
+          {
+            "description": "Id of gist.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Id of comment.",
+            "in": "path",
+            "name": "commentId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No content.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "description": "Get a single comment.",
+        "parameters": [
+          {
+            "description": "Id of gist.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Id of comment.",
+            "in": "path",
+            "name": "commentId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/comment"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "description": "Edit a comment.",
+        "parameters": [
+          {
+            "description": "Id of gist.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Id of comment.",
+            "in": "path",
+            "name": "commentId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/comment"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/comment"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/gists/{id}/forks": {
+      "post": {
+        "description": "Fork a gist.",
+        "parameters": [
+          {
+            "description": "Id of gist.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Exists.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "404": {
+            "description": "Not exists.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/gists/{id}/star": {
+      "delete": {
+        "description": "Unstar a gist.",
+        "parameters": [
+          {
+            "description": "Id of gist.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Item removed.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "description": "Check if a gist is starred.",
+        "parameters": [
+          {
+            "description": "Id of gist.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Exists.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "404": {
+            "description": "Not exists.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "Star a gist.",
+        "parameters": [
+          {
+            "description": "Id of gist.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Starred.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/gitignore/templates": {
+      "get": {
+        "description": "Listing available templates.\nList all templates available to pass as an option when creating a repository.\n",
+        "parameters": [
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/gitignore"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/gitignore/templates/{language}": {
+      "get": {
+        "description": "Get a single template.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "language",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/gitignore-lang"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/issues": {
+      "get": {
+        "description": "List issues.\nList all issues across all the authenticated user's visible repositories.\n",
+        "parameters": [
+          {
+            "default": "all",
+            "description": "Issues assigned to you / created by you / mentioning you / you're\nsubscribed to updates for / All issues the authenticated user can see\n",
+            "enum": ["assigned", "created", "mentioned", "subscribed", "all"],
+            "in": "query",
+            "name": "filter",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "default": "open",
+            "enum": ["open", "closed"],
+            "in": "query",
+            "name": "state",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "String list of comma separated Label names. Example - bug,ui,@high.",
+            "in": "query",
+            "name": "labels",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "default": "created",
+            "enum": ["created", "updated", "comments"],
+            "in": "query",
+            "name": "sort",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "default": "desc",
+            "enum": ["asc", "desc"],
+            "in": "query",
+            "name": "direction",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Optional string of a timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ.\nOnly issues updated at or after this time are returned.\n",
+            "in": "query",
+            "name": "since",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/issues"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/legacy/issues/search/{owner}/{repository}/{state}/{keyword}": {
+      "get": {
+        "deprecated": true,
+        "description": "Find issues by state and keyword.",
+        "parameters": [
+          {
+            "description": "The search term.",
+            "in": "path",
+            "name": "keyword",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Indicates the state of the issues to return. Can be either open or closed.",
+            "enum": ["open", "closed"],
+            "in": "path",
+            "name": "state",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "repository",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/search-issues-by-keyword"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/legacy/repos/search/{keyword}": {
+      "get": {
+        "deprecated": true,
+        "description": "Find repositories by keyword. Note, this legacy method does not follow the v3 pagination pattern. This method returns up to 100 results per page and pages can be fetched using the start_page parameter.",
+        "parameters": [
+          {
+            "description": "The search term",
+            "in": "path",
+            "name": "keyword",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "default": "desc",
+            "description": "The sort field. if sort param is provided. Can be either asc or desc.",
+            "enum": ["desc", "asc"],
+            "in": "query",
+            "name": "order",
+            "type": "string"
+          },
+          {
+            "description": "Filter results by language",
+            "in": "query",
+            "name": "language",
+            "type": "string"
+          },
+          {
+            "description": "The page number to fetch",
+            "in": "query",
+            "name": "start_page",
+            "type": "string"
+          },
+          {
+            "description": "The sort field. One of stars, forks, or updated. Default: results are sorted by best match.",
+            "enum": ["updated", "stars", "forks"],
+            "in": "query",
+            "name": "sort",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/search-repositories-by-keyword"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/legacy/user/email/{email}": {
+      "get": {
+        "deprecated": true,
+        "description": "This API call is added for compatibility reasons only.",
+        "parameters": [
+          {
+            "description": "The email address",
+            "in": "path",
+            "name": "email",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/search-user-by-email"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/legacy/user/search/{keyword}": {
+      "get": {
+        "deprecated": true,
+        "description": "Find users by keyword.",
+        "parameters": [
+          {
+            "description": "The search term",
+            "in": "path",
+            "name": "keyword",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "default": "desc",
+            "description": "The sort field. if sort param is provided. Can be either asc or desc.",
+            "enum": ["desc", "asc"],
+            "in": "query",
+            "name": "order",
+            "type": "string"
+          },
+          {
+            "description": "The page number to fetch",
+            "in": "query",
+            "name": "start_page",
+            "type": "string"
+          },
+          {
+            "description": "The sort field. One of stars, forks, or updated. Default: results are sorted by best match.",
+            "enum": ["updated", "stars", "forks"],
+            "in": "query",
+            "name": "sort",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/search-users-by-keyword"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/markdown": {
+      "post": {
+        "description": "Render an arbitrary Markdown document",
+        "parameters": [
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/markdown"
+            }
+          }
+        ],
+        "produces": ["text/html"],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/markdown/raw": {
+      "post": {
+        "consumes": ["text/plain"],
+        "description": "Render a Markdown document in raw mode",
+        "parameters": [
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "produces": ["text/html"],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/meta": {
+      "get": {
+        "description": "This gives some information about GitHub.com, the service.",
+        "parameters": [
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/meta"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/networks/{owner}/{repo}/events": {
+      "get": {
+        "description": "List public events for a network of repositories.",
+        "parameters": [
+          {
+            "description": "Name of the owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/events"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/notifications": {
+      "get": {
+        "description": "List your notifications.\nList all notifications for the current user, grouped by repository.\n",
+        "parameters": [
+          {
+            "description": "True to show notifications marked as read.",
+            "in": "query",
+            "name": "all",
+            "type": "boolean"
+          },
+          {
+            "description": "True to show only notifications in which the user is directly participating\nor mentioned.\n",
+            "in": "query",
+            "name": "participating",
+            "type": "boolean"
+          },
+          {
+            "description": "The time should be passed in as UTC in the ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ.\nExample: \"2012-10-09T23:39:01Z\".\n",
+            "in": "query",
+            "name": "since",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/notifications"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "Mark as read.\nMarking a notification as \"read\" removes it from the default view on GitHub.com.\n",
+        "parameters": [
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/notificationMarkRead"
+            }
+          }
+        ],
+        "responses": {
+          "205": {
+            "description": "Marked as read.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/notifications/threads/{id}": {
+      "get": {
+        "description": "View a single thread.",
+        "parameters": [
+          {
+            "description": "Id of thread.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/notifications"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "description": "Mark a thread as read",
+        "parameters": [
+          {
+            "description": "Id of thread.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "205": {
+            "description": "Thread marked as read.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/notifications/threads/{id}/subscription": {
+      "delete": {
+        "description": "Delete a Thread Subscription.",
+        "parameters": [
+          {
+            "description": "Id of thread.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "description": "Get a Thread Subscription.",
+        "parameters": [
+          {
+            "description": "Id of thread.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/subscription"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "Set a Thread Subscription.\nThis lets you subscribe to a thread, or ignore it. Subscribing to a thread\nis unnecessary if the user is already subscribed to the repository. Ignoring\na thread will mute all future notifications (until you comment or get @mentioned).\n",
+        "parameters": [
+          {
+            "description": "Id of thread.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/putSubscription"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/subscription"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/orgs/{org}": {
+      "get": {
+        "description": "Get an Organization.",
+        "parameters": [
+          {
+            "description": "Name of organisation.",
+            "in": "path",
+            "name": "org",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/organization"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "description": "Edit an Organization.",
+        "parameters": [
+          {
+            "description": "Name of organisation.",
+            "in": "path",
+            "name": "org",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/patchOrg"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/organization"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/orgs/{org}/events": {
+      "get": {
+        "description": "List public events for an organization.",
+        "parameters": [
+          {
+            "description": "Name of organisation.",
+            "in": "path",
+            "name": "org",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/events"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/orgs/{org}/issues": {
+      "get": {
+        "description": "List issues.\nList all issues for a given organization for the authenticated user.\n",
+        "parameters": [
+          {
+            "description": "Name of organisation.",
+            "in": "path",
+            "name": "org",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "default": "all",
+            "description": "Issues assigned to you / created by you / mentioning you / you're\nsubscribed to updates for / All issues the authenticated user can see\n",
+            "enum": ["assigned", "created", "mentioned", "subscribed", "all"],
+            "in": "query",
+            "name": "filter",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "default": "open",
+            "enum": ["open", "closed"],
+            "in": "query",
+            "name": "state",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "String list of comma separated Label names. Example - bug,ui,@high.",
+            "in": "query",
+            "name": "labels",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "default": "created",
+            "enum": ["created", "updated", "comments"],
+            "in": "query",
+            "name": "sort",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "default": "desc",
+            "enum": ["asc", "desc"],
+            "in": "query",
+            "name": "direction",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Optional string of a timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ.\nOnly issues updated at or after this time are returned.\n",
+            "in": "query",
+            "name": "since",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/issues"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/orgs/{org}/members": {
+      "get": {
+        "description": "Members list.\nList all users who are members of an organization. A member is a user tha\nbelongs to at least 1 team in the organization. If the authenticated user\nis also an owner of this organization then both concealed and public members\nwill be returned. If the requester is not an owner of the organization the\nquery will be redirected to the public members list.\n",
+        "parameters": [
+          {
+            "description": "Name of organisation.",
+            "in": "path",
+            "name": "org",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/users"
+            }
+          },
+          "302": {
+            "description": "Response if requester is not an organization member.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/orgs/{org}/members/{username}": {
+      "delete": {
+        "description": "Remove a member.\nRemoving a user from this list will remove them from all teams and they\nwill no longer have any access to the organization's repositories.\n",
+        "parameters": [
+          {
+            "description": "Name of organisation.",
+            "in": "path",
+            "name": "org",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of the user.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No content.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "description": "Check if a user is, publicly or privately, a member of the organization.",
+        "parameters": [
+          {
+            "description": "Name of organisation.",
+            "in": "path",
+            "name": "org",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of the user.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No content. Response if requester is an organization member and user is a member\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "302": {
+            "description": "Found. Response if requester is not an organization member\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found.\na. Response if requester is an organization member and user is not a member\nb. Response if requester is not an organization member and is inquiring about themselves\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/orgs/{org}/public_members": {
+      "get": {
+        "description": "Public members list.\nMembers of an organization can choose to have their membership publicized\nor not.\n",
+        "parameters": [
+          {
+            "description": "Name of organisation.",
+            "in": "path",
+            "name": "org",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/users"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/orgs/{org}/public_members/{username}": {
+      "delete": {
+        "description": "Conceal a user's membership.",
+        "parameters": [
+          {
+            "description": "Name of organisation.",
+            "in": "path",
+            "name": "org",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of the user.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Concealed.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "description": "Check public membership.",
+        "parameters": [
+          {
+            "description": "Name of organisation.",
+            "in": "path",
+            "name": "org",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of the user.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "User is a public member.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "404": {
+            "description": "User is not a public member.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "Publicize a user's membership.",
+        "parameters": [
+          {
+            "description": "Name of organisation.",
+            "in": "path",
+            "name": "org",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of the user.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Publicized.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/orgs/{org}/repos": {
+      "get": {
+        "description": "List repositories for the specified org.",
+        "parameters": [
+          {
+            "description": "Name of organisation.",
+            "in": "path",
+            "name": "org",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "default": "all",
+            "enum": ["all", "public", "private", "forks", "sources", "member"],
+            "in": "query",
+            "name": "type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/repos"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Create a new repository for the authenticated user. OAuth users must supply\nrepo scope.\n",
+        "parameters": [
+          {
+            "description": "Name of organisation.",
+            "in": "path",
+            "name": "org",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/postRepo"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/repos"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/orgs/{org}/teams": {
+      "get": {
+        "description": "List teams.",
+        "parameters": [
+          {
+            "description": "Name of organisation.",
+            "in": "path",
+            "name": "org",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/teams"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Create team.\nIn order to create a team, the authenticated user must be an owner of organization.\n",
+        "parameters": [
+          {
+            "description": "Name of organisation.",
+            "in": "path",
+            "name": "org",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/orgTeamsPost"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/team"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/rate_limit": {
+      "get": {
+        "description": "Get your current rate limit status\nNote: Accessing this endpoint does not count against your rate limit.\n",
+        "parameters": [
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/rate_limit"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}": {
+      "delete": {
+        "description": "Delete a Repository.\nDeleting a repository requires admin access. If OAuth is used, the delete_repo\nscope is required.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Item removed.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "description": "Get repository.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/repo"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "description": "Edit repository.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/repoEdit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/repo"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/assignees": {
+      "get": {
+        "description": "List assignees.\nThis call lists all the available assignees (owner + collaborators) to which\nissues may be assigned.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/assignees"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/assignees/{assignee}": {
+      "get": {
+        "description": "Check assignee.\nYou may also check to see if a particular user is an assignee for a repository.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Login of the assignee.",
+            "in": "path",
+            "name": "assignee",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "User is an assignee.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "404": {
+            "description": "User isn't an assignee.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/branches": {
+      "get": {
+        "description": "Get list of branches",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/branches"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/branches/{branch}": {
+      "get": {
+        "description": "Get Branch",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of the branch.",
+            "in": "path",
+            "name": "branch",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/branch"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/collaborators": {
+      "get": {
+        "description": "List.\nWhen authenticating as an organization owner of an organization-owned\nrepository, all organization owners are included in the list of\ncollaborators. Otherwise, only users with access to the repository are\nreturned in the collaborators list.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/users"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/collaborators/{user}": {
+      "delete": {
+        "description": "Remove collaborator.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Login of the user.",
+            "in": "path",
+            "name": "user",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Collaborator removed.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "description": "Check if user is a collaborator",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Login of the user.",
+            "in": "path",
+            "name": "user",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "User is a collaborator.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "404": {
+            "description": "User is not a collaborator.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "Add collaborator.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Login of the user.",
+            "in": "path",
+            "name": "user",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Collaborator added.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/comments": {
+      "get": {
+        "description": "List commit comments for a repository.\nComments are ordered by ascending ID.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/repoComments"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/comments/{commentId}": {
+      "delete": {
+        "description": "Delete a commit comment",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Id of comment.",
+            "in": "path",
+            "name": "commentId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No content.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "description": "Get a single commit comment.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Id of comment.",
+            "in": "path",
+            "name": "commentId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/commitComment"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "description": "Update a commit comment.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Id of comment.",
+            "in": "path",
+            "name": "commentId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/commentBody"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/commitComment"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/commits": {
+      "get": {
+        "description": "List commits on a repository.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "The time should be passed in as UTC in the ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ.\nExample: \"2012-10-09T23:39:01Z\".\n",
+            "in": "query",
+            "name": "since",
+            "type": "string"
+          },
+          {
+            "description": "Sha or branch to start listing commits from.",
+            "in": "query",
+            "name": "sha",
+            "type": "string"
+          },
+          {
+            "description": "Only commits containing this file path will be returned.",
+            "in": "query",
+            "name": "path",
+            "type": "string"
+          },
+          {
+            "description": "GitHub login, name, or email by which to filter by commit author.",
+            "in": "query",
+            "name": "author",
+            "type": "string"
+          },
+          {
+            "description": "ISO 8601 Date - Only commits before this date will be returned.",
+            "in": "query",
+            "name": "until",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/commits"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/commits/{ref}/status": {
+      "get": {
+        "description": "Get the combined Status for a specific Ref\nThe Combined status endpoint is currently available for developers to preview. During the preview period, the API may change without advance notice. Please see the blog post for full details.\nTo access this endpoint during the preview period, you must provide a custom media type in the Accept header:\napplication/vnd.github.she-hulk-preview+json\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "ref",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/refStatus"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/commits/{shaCode}": {
+      "get": {
+        "description": "Get a single commit.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "SHA-1 code of the commit.",
+            "in": "path",
+            "name": "shaCode",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/commit"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/commits/{shaCode}/comments": {
+      "get": {
+        "description": "List comments for a single commitList comments for a single commit.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "SHA-1 code of the commit.",
+            "in": "path",
+            "name": "shaCode",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/repoComments"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Create a commit comment.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "SHA-1 code of the commit.",
+            "in": "path",
+            "name": "shaCode",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/commitCommentBody"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/commitComment"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/compare/{baseId}...{headId}": {
+      "get": {
+        "description": "Compare two commits",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "baseId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "headId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/compare-commits"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/contents/{path}": {
+      "delete": {
+        "description": "Delete a file.\nThis method deletes a file in a repository.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/deleteFileBody"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/deleteFile"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "description": "Get contents.\nThis method returns the contents of a file or directory in a repository.\nFiles and symlinks support a custom media type for getting the raw content.\nDirectories and submodules do not support custom media types.\nNote: This API supports files up to 1 megabyte in size.\nHere can be many outcomes. For details see \"http://developer.github.com/v3/repos/contents/\"\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "The content path.",
+            "in": "query",
+            "name": "path",
+            "type": "string"
+          },
+          {
+            "description": "The String name of the Commit/Branch/Tag. Defaults to 'master'.",
+            "in": "query",
+            "name": "ref",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/contents-path"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "Create a file.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/createFileBody"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/createFile"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/contributors": {
+      "get": {
+        "description": "Get list of contributors.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Set to 1 or true to include anonymous contributors in results.",
+            "in": "query",
+            "name": "anon",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/users"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/deployments": {
+      "get": {
+        "description": "Users with pull access can view deployments for a repository",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/repo-deployments"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Users with push access can create a deployment for a given ref",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/deployment"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/deployment-resp"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/deployments/{id}/statuses": {
+      "get": {
+        "description": "Users with pull access can view deployment statuses for a deployment",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "The Deployment ID to list the statuses from.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/deployment-statuses"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Create a Deployment Status\nUsers with push access can create deployment statuses for a given deployment:\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "The Deployment ID to list the statuses from.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/deployment-statuses-create"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "ok",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/downloads": {
+      "get": {
+        "deprecated": true,
+        "description": "Deprecated. List downloads for a repository.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/downloads"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/downloads/{downloadId}": {
+      "delete": {
+        "deprecated": true,
+        "description": "Deprecated. Delete a download.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Id of download.",
+            "in": "path",
+            "name": "downloadId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No content.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "deprecated": true,
+        "description": "Deprecated. Get a single download.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Id of download.",
+            "in": "path",
+            "name": "downloadId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/download"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/events": {
+      "get": {
+        "description": "Get list of repository events.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/events"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/forks": {
+      "get": {
+        "description": "List forks.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "default": "newes",
+            "enum": ["newes", "oldes", "watchers"],
+            "in": "query",
+            "name": "sort",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/forks"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Create a fork.\nForking a Repository happens asynchronously. Therefore, you may have to wai\na short period before accessing the git objects. If this takes longer than 5\nminutes, be sure to contact Support.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/forkBody"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/repo"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/git/blobs": {
+      "post": {
+        "description": "Create a Blob.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/blob"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/blobs"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/git/blobs/{shaCode}": {
+      "get": {
+        "description": "Get a Blob.\nSince blobs can be any arbitrary binary data, the input and responses for\nthe blob API takes an encoding parameter that can be either utf-8 or\nbase64. If your data cannot be losslessly sent as a UTF-8 string, you can\nbase64 encode it.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "SHA-1 code.",
+            "in": "path",
+            "name": "shaCode",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/blob"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/git/commits": {
+      "post": {
+        "description": "Create a Commit.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/repoCommitBody"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/gitCommit"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/git/commits/{shaCode}": {
+      "get": {
+        "description": "Get a Commit.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "SHA-1 code.",
+            "in": "path",
+            "name": "shaCode",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/repoCommit"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/git/refs": {
+      "get": {
+        "description": "Get all References",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/refs"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Create a Reference",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/refsBody"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/headBranch"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/git/refs/{ref}": {
+      "delete": {
+        "description": "Delete a Reference\nExample: Deleting a branch: DELETE /repos/octocat/Hello-World/git/refs/heads/feature-a\nExample: Deleting a tag:        DELETE /repos/octocat/Hello-World/git/refs/tags/v1.0\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "ref",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "description": "Get a Reference",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "ref",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/headBranch"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "description": "Update a Reference",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "ref",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/gitRefPatch"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/headBranch"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/git/tags": {
+      "post": {
+        "description": "Create a Tag Object.\nNote that creating a tag object does not create the reference that makes a\ntag in Git. If you want to create an annotated tag in Git, you have to do\nthis call to create the tag object, and then create the refs/tags/[tag]\nreference. If you want to create a lightweight tag, you only have to create\nthe tag reference - this call would be unnecessary.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/tagBody"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/tag"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/git/tags/{shaCode}": {
+      "get": {
+        "description": "Get a Tag.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "shaCode",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/tag"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/git/trees": {
+      "post": {
+        "description": "Create a Tree.\nThe tree creation API will take nested entries as well. If both a tree and\na nested path modifying that tree are specified, it will overwrite the\ncontents of that tree with the new path contents and write a new tree out.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/tree"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/trees"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/git/trees/{shaCode}": {
+      "get": {
+        "description": "Get a Tree.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Tree SHA.",
+            "in": "path",
+            "name": "shaCode",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Get a Tree Recursively. (0 or 1)",
+            "in": "query",
+            "name": "recursive",
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/tree"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/hooks": {
+      "get": {
+        "description": "Get list of hooks.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/hook"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Create a hook.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/hookBody"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/hook"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/hooks/{hookId}": {
+      "delete": {
+        "description": "Delete a hook.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Id of hook.",
+            "in": "path",
+            "name": "hookId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No content.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "description": "Get single hook.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Id of hook.",
+            "in": "path",
+            "name": "hookId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/hook"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "description": "Edit a hook.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Id of hook.",
+            "in": "path",
+            "name": "hookId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/hookBody"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/hook"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/hooks/{hookId}/tests": {
+      "post": {
+        "description": "Test a push hook.\nThis will trigger the hook with the latest push to the current repository\nif the hook is subscribed to push events. If the hook is not subscribed\nto push events, the server will respond with 204 but no test POST will\nbe generated.\nNote: Previously /repos/:owner/:repo/hooks/:id/tes\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Id of hook.",
+            "in": "path",
+            "name": "hookId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Hook is triggered.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/issues": {
+      "get": {
+        "description": "List issues for a repository.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "default": "all",
+            "description": "Issues assigned to you / created by you / mentioning you / you're\nsubscribed to updates for / All issues the authenticated user can see\n",
+            "enum": ["assigned", "created", "mentioned", "subscribed", "all"],
+            "in": "query",
+            "name": "filter",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "default": "open",
+            "enum": ["open", "closed"],
+            "in": "query",
+            "name": "state",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "String list of comma separated Label names. Example - bug,ui,@high.",
+            "in": "query",
+            "name": "labels",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "default": "created",
+            "enum": ["created", "updated", "comments"],
+            "in": "query",
+            "name": "sort",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "default": "desc",
+            "enum": ["asc", "desc"],
+            "in": "query",
+            "name": "direction",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Optional string of a timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ.\nOnly issues updated at or after this time are returned.\n",
+            "in": "query",
+            "name": "since",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/issues"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Create an issue.\nAny user with pull access to a repository can create an issue.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/issue"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/issue"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/issues/comments": {
+      "get": {
+        "description": "List comments in a repository.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Ignored without 'sort' parameter.",
+            "in": "query",
+            "name": "direction",
+            "type": "string"
+          },
+          {
+            "description": "",
+            "enum": ["created", "updated"],
+            "in": "query",
+            "name": "sort",
+            "type": "string"
+          },
+          {
+            "description": "The time should be passed in as UTC in the ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ.\nExample: \"2012-10-09T23:39:01Z\".\n",
+            "in": "query",
+            "name": "since",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/issuesComments"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/issues/comments/{commentId}": {
+      "delete": {
+        "description": "Delete a comment.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "ID of comment.",
+            "in": "path",
+            "name": "commentId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No content.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "description": "Get a single comment.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "ID of comment.",
+            "in": "path",
+            "name": "commentId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/issuesComment"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "description": "Edit a comment.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "ID of comment.",
+            "in": "path",
+            "name": "commentId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/commentBody"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/issuesComment"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/issues/events": {
+      "get": {
+        "description": "List issue events for a repository.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/issueEvents"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/issues/events/{eventId}": {
+      "get": {
+        "description": "Get a single event.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Id of the event.",
+            "in": "path",
+            "name": "eventId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/issueEvent"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/issues/{number}": {
+      "get": {
+        "description": "Get a single issue",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Number of issue.",
+            "in": "path",
+            "name": "number",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/issue"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "description": "Edit an issue.\nIssue owners and users with push access can edit an issue.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Number of issue.",
+            "in": "path",
+            "name": "number",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/issue"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/issue"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/issues/{number}/comments": {
+      "get": {
+        "description": "List comments on an issue.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Number of issue.",
+            "in": "path",
+            "name": "number",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/issuesComments"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Create a comment.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Number of issue.",
+            "in": "path",
+            "name": "number",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/commentBody"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/issuesComment"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/issues/{number}/events": {
+      "get": {
+        "description": "List events for an issue.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Number of issue.",
+            "in": "path",
+            "name": "number",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/issueEvents"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/issues/{number}/labels": {
+      "delete": {
+        "description": "Remove all labels from an issue.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Number of issue.",
+            "in": "path",
+            "name": "number",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No content.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "description": "List labels on an issue.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Number of issue.",
+            "in": "path",
+            "name": "number",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/labels"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Add labels to an issue.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Number of issue.",
+            "in": "path",
+            "name": "number",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/emailsPost"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/label"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "Replace all labels for an issue.\nSending an empty array ([]) will remove all Labels from the Issue.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Number of issue.",
+            "in": "path",
+            "name": "number",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/emailsPost"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/label"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/issues/{number}/labels/{name}": {
+      "delete": {
+        "description": "Remove a label from an issue.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Number of issue.",
+            "in": "path",
+            "name": "number",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Name of the label.",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Item removed.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/keys": {
+      "get": {
+        "description": "Get list of keys.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/keys"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Create a key.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/user-keys-post"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/user-keys-keyId"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/keys/{keyId}": {
+      "delete": {
+        "description": "Delete a key.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Id of key.",
+            "in": "path",
+            "name": "keyId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No content.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "description": "Get a key",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Id of key.",
+            "in": "path",
+            "name": "keyId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/user-keys-keyId"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/labels": {
+      "get": {
+        "description": "List all labels for this repository.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/labels"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Create a label.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/emailsPost"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/label"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/labels/{name}": {
+      "delete": {
+        "description": "Delete a label.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of the label.",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No content.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "description": "Get a single label.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of the label.",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/label"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "description": "Update a label.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of the label.",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/emailsPost"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/label"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/languages": {
+      "get": {
+        "description": "List languages.\nList languages for the specified repository. The value on the right of a\nlanguage is the number of bytes of code written in that language.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/languages"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/merges": {
+      "post": {
+        "description": "Perform a merge.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/mergesBody"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Successful Response (The resulting merge commit)",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/mergesSuccessful"
+            }
+          },
+          "204": {
+            "description": "No-op response (base already contains the head, nothing to merge)",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "404": {
+            "description": "Missing base response or missing head response",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/mergesConflict"
+            }
+          },
+          "409": {
+            "description": "Merge conflict response.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/mergesConflict"
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/milestones": {
+      "get": {
+        "description": "List milestones for a repository.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "default": "open",
+            "description": "String to filter by state.",
+            "enum": ["open", "closed"],
+            "in": "query",
+            "name": "state",
+            "type": "string"
+          },
+          {
+            "description": "Ignored without 'sort' parameter.",
+            "in": "query",
+            "name": "direction",
+            "type": "string"
+          },
+          {
+            "default": "due_date",
+            "description": "",
+            "enum": ["due_date", "completeness"],
+            "in": "query",
+            "name": "sort",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/milestone"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Create a milestone.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/milestoneUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/milestone"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/milestones/{number}": {
+      "delete": {
+        "description": "Delete a milestone.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Number of milestone.",
+            "in": "path",
+            "name": "number",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No content.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "description": "Get a single milestone.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Number of milestone.",
+            "in": "path",
+            "name": "number",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/milestone"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "description": "Update a milestone.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Number of milestone.",
+            "in": "path",
+            "name": "number",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/milestoneUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/milestone"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/milestones/{number}/labels": {
+      "get": {
+        "description": "Get labels for every issue in a milestone.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Number of milestone.",
+            "in": "path",
+            "name": "number",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/labels"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/notifications": {
+      "get": {
+        "description": "List your notifications in a repository\nList all notifications for the current user.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "True to show notifications marked as read.",
+            "in": "query",
+            "name": "all",
+            "type": "boolean"
+          },
+          {
+            "description": "True to show only notifications in which the user is directly participating\nor mentioned.\n",
+            "in": "query",
+            "name": "participating",
+            "type": "boolean"
+          },
+          {
+            "description": "The time should be passed in as UTC in the ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ.\nExample: \"2012-10-09T23:39:01Z\".\n",
+            "in": "query",
+            "name": "since",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/notifications"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "Mark notifications as read in a repository.\nMarking all notifications in a repository as \"read\" removes them from the\ndefault view on GitHub.com.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/notificationMarkRead"
+            }
+          }
+        ],
+        "responses": {
+          "205": {
+            "description": "Marked as read.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/pulls": {
+      "get": {
+        "description": "List pull requests.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "default": "open",
+            "description": "String to filter by state.",
+            "enum": ["open", "closed"],
+            "in": "query",
+            "name": "state",
+            "type": "string"
+          },
+          {
+            "description": "Filter pulls by head user and branch name in the format of 'user:ref-name'.\nExample: github:new-script-format.\n",
+            "in": "query",
+            "name": "head",
+            "type": "string"
+          },
+          {
+            "description": "Filter pulls by base branch name. Example - gh-pages.",
+            "in": "query",
+            "name": "base",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/pulls"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Create a pull request.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/pullsPost"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/pulls"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/pulls/comments": {
+      "get": {
+        "description": "List comments in a repository.\nBy default, Review Comments are ordered by ascending ID.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Ignored without 'sort' parameter.",
+            "in": "query",
+            "name": "direction",
+            "type": "string"
+          },
+          {
+            "description": "",
+            "enum": ["created", "updated"],
+            "in": "query",
+            "name": "sort",
+            "type": "string"
+          },
+          {
+            "description": "The time should be passed in as UTC in the ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ.\nExample: \"2012-10-09T23:39:01Z\".\n",
+            "in": "query",
+            "name": "since",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/issuesComments"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/pulls/comments/{commentId}": {
+      "delete": {
+        "description": "Delete a comment.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Id of comment.",
+            "in": "path",
+            "name": "commentId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No content.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "description": "Get a single comment.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Id of comment.",
+            "in": "path",
+            "name": "commentId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/pullsComment"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "description": "Edit a comment.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Id of comment.",
+            "in": "path",
+            "name": "commentId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/commentBody"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/pullsComment"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/pulls/{number}": {
+      "get": {
+        "description": "Get a single pull request.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Id of pull.",
+            "in": "path",
+            "name": "number",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/pullRequest"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "description": "Update a pull request.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Id of pull.",
+            "in": "path",
+            "name": "number",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/pullUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/repo"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/pulls/{number}/comments": {
+      "get": {
+        "description": "List comments on a pull request.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Id of pull.",
+            "in": "path",
+            "name": "number",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/pullsComment"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Create a comment.\n  #TODO Alternative input ( http://developer.github.com/v3/pulls/comments/ )\n  description: |\n    Alternative Input.\n    Instead of passing commit_id, path, and position you can reply to an\n    existing Pull Request Comment like this:\n\n        body\n           Required string\n        in_reply_to\n           Required number - Comment id to reply to.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Id of pull.",
+            "in": "path",
+            "name": "number",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/pullsCommentPost"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/pullsComment"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/pulls/{number}/commits": {
+      "get": {
+        "description": "List commits on a pull request.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Id of pull.",
+            "in": "path",
+            "name": "number",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/commits"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/pulls/{number}/files": {
+      "get": {
+        "description": "List pull requests files.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Id of pull.",
+            "in": "path",
+            "name": "number",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/pulls"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/pulls/{number}/merge": {
+      "get": {
+        "description": "Get if a pull request has been merged.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Id of pull.",
+            "in": "path",
+            "name": "number",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Pull request has been merged.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "404": {
+            "description": "Pull request has not been merged.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "Merge a pull request (Merge Button's)",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Id of pull.",
+            "in": "path",
+            "name": "number",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/mergePullBody"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response if merge was successful.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/merge"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "405": {
+            "description": "Response if merge cannot be performed.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/merge"
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/readme": {
+      "get": {
+        "description": "Get the README.\nThis method returns the preferred README for a repository.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "The String name of the Commit/Branch/Tag. Defaults to master.",
+            "in": "query",
+            "name": "ref",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/contents-path"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/releases": {
+      "get": {
+        "description": "Users with push access to the repository will receive all releases (i.e., published releases and draft releases). Users with pull access will receive published releases only",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/releases"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Create a release\nUsers with push access to the repository can create a release.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/release-create"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/release"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/releases/assets/{id}": {
+      "delete": {
+        "description": "Delete a release asset",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "description": "Get a single release asset",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/asset"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "description": "Edit a release asset\nUsers with push access to the repository can edit a release asset.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/assetPatch"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/asset"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/releases/{id}": {
+      "delete": {
+        "description": "Users with push access to the repository can delete a release.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "description": "Get a single release",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/release"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "description": "Users with push access to the repository can edit a release",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/release-create"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/release"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/releases/{id}/assets": {
+      "get": {
+        "description": "List assets for a release",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/assets"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/stargazers": {
+      "get": {
+        "description": "List Stargazers.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/users"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/stats/code_frequency": {
+      "get": {
+        "description": "Get the number of additions and deletions per week.\nReturns a weekly aggregate of the number of additions and deletions pushed\nto a repository.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/codeFrequencyStats"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/stats/commit_activity": {
+      "get": {
+        "description": "Get the last year of commit activity data.\nReturns the last year of commit activity grouped by week. The days array\nis a group of commits per day, starting on Sunday.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/commitActivityStats"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/stats/contributors": {
+      "get": {
+        "description": "Get contributors list with additions, deletions, and commit counts.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/contributorsStats"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/stats/participation": {
+      "get": {
+        "description": "Get the weekly commit count for the repo owner and everyone else.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/participationStats"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/stats/punch_card": {
+      "get": {
+        "description": "Get the number of commits per hour in each day.\nEach array contains the day number, hour number, and number of commits\n0-6 Sunday - Saturday\n0-23 Hour of day\nNumber of commits\n\nFor example, [2, 14, 25] indicates that there were 25 total commits, during\nthe 2.00pm hour on Tuesdays. All times are based on the time zone of\nindividual commits.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/codeFrequencyStats"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/statuses/{ref}": {
+      "get": {
+        "description": "List Statuses for a specific Ref.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Ref to list the statuses from. It can be a SHA, a branch name, or a tag name.\n",
+            "in": "path",
+            "name": "ref",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/ref"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Create a Status.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Ref to list the statuses from. It can be a SHA, a branch name, or a tag name.\n",
+            "in": "path",
+            "name": "ref",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/headBranch"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/ref"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/subscribers": {
+      "get": {
+        "description": "List watchers.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/users"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/subscription": {
+      "delete": {
+        "description": "Delete a Repository Subscription.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No content.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "description": "Get a Repository Subscription.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/subscription"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "Set a Repository Subscription",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/subscriptionBody"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/subscription"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/tags": {
+      "get": {
+        "description": "Get list of tags.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/tags"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/teams": {
+      "get": {
+        "description": "Get list of teams",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/teams"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/watchers": {
+      "get": {
+        "description": "List Stargazers. New implementation.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/users"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/{archive_format}/{path}": {
+      "get": {
+        "description": "Get archive link.\nThis method will return a 302 to a URL to download a tarball or zipball\narchive for a repository. Please make sure your HTTP framework is\nconfigured to follow redirects or you will need to use the Location header\nto make a second GET request.\nNote: For private repositories, these links are temporary and expire quickly.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "enum": ["tarball", "zipball"],
+            "in": "path",
+            "name": "archive_format",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Valid Git reference, defaults to 'master'.",
+            "in": "path",
+            "name": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "302": {
+            "description": "Found.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repositories": {
+      "get": {
+        "description": "List all public repositories.\nThis provides a dump of every public repository, in the order that they\nwere created.\nNote: Pagination is powered exclusively by the since parameter. is the\nLink header to get the URL for the next page of repositories.\n",
+        "parameters": [
+          {
+            "description": "The time should be passed in as UTC in the ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ.\nExample: \"2012-10-09T23:39:01Z\".\n",
+            "in": "query",
+            "name": "since",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/repos"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/search/code": {
+      "get": {
+        "description": "Search code.",
+        "parameters": [
+          {
+            "default": "desc",
+            "description": "The sort field. if sort param is provided. Can be either asc or desc.",
+            "enum": ["desc", "asc"],
+            "in": "query",
+            "name": "order",
+            "type": "string"
+          },
+          {
+            "description": "The search terms. This can be any combination of the supported code\nsearch parameters:\n'Search In' Qualifies which fields are searched. With this qualifier\nyou can restrict the search to just the file contents, the file path,\nor both.\n'Languages' Searches code based on the language it's written in.\n'Forks' Filters repositories based on the number of forks, and/or\nwhether code from forked repositories should be included in the results\nat all.\n'Size' Finds files that match a certain size (in bytes).\n'Path' Specifies the path that the resulting file must be at.\n'Extension' Matches files with a certain extension.\n'Users' or 'Repositories' Limits searches to a specific user or repository.\n",
+            "in": "query",
+            "name": "q",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Can only be 'indexed', which indicates how recently a file has been indexed\nby the GitHub search infrastructure. If not provided, results are sorted\nby best match.\n",
+            "enum": ["indexed"],
+            "in": "query",
+            "name": "sort",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/search-code"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/search/issues": {
+      "get": {
+        "description": "Find issues by state and keyword. (This method returns up to 100 results per page.)",
+        "parameters": [
+          {
+            "default": "desc",
+            "description": "The sort field. if sort param is provided. Can be either asc or desc.",
+            "enum": ["desc", "asc"],
+            "in": "query",
+            "name": "order",
+            "type": "string"
+          },
+          {
+            "description": "The q search term can also contain any combination of the supported issue search qualifiers:",
+            "in": "query",
+            "name": "q",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "The sort field. Can be comments, created, or updated. Default: results are sorted by best match.",
+            "enum": ["updated", "created", "comments"],
+            "in": "query",
+            "name": "sort",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/search-issues"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/search/repositories": {
+      "get": {
+        "description": "Search repositories.",
+        "parameters": [
+          {
+            "default": "desc",
+            "description": "The sort field. if sort param is provided. Can be either asc or desc.",
+            "enum": ["desc", "asc"],
+            "in": "query",
+            "name": "order",
+            "type": "string"
+          },
+          {
+            "description": "The search terms. This can be any combination of the supported repository\nsearch parameters:\n'Search In' Qualifies which fields are searched. With this qualifier you\ncan restrict the search to just the repository name, description, readme,\nor any combination of these.\n'Size' Finds repositories that match a certain size (in kilobytes).\n'Forks' Filters repositories based on the number of forks, and/or whether\nforked repositories should be included in the results at all.\n'Created' and 'Last Updated' Filters repositories based on times of\ncreation, or when they were last updated.\n'Users or Repositories' Limits searches to a specific user or repository.\n'Languages' Searches repositories based on the language they are written in.\n'Stars' Searches repositories based on the number of stars.\n",
+            "in": "query",
+            "name": "q",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "If not provided, results are sorted by best match.",
+            "enum": ["stars", "forks", "updated"],
+            "in": "query",
+            "name": "sort",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/search-repositories"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/search/users": {
+      "get": {
+        "description": "Search users.",
+        "parameters": [
+          {
+            "default": "desc",
+            "description": "The sort field. if sort param is provided. Can be either asc or desc.",
+            "enum": ["desc", "asc"],
+            "in": "query",
+            "name": "order",
+            "type": "string"
+          },
+          {
+            "description": "The search terms. This can be any combination of the supported user\nsearch parameters:\n'Search In' Qualifies which fields are searched. With this qualifier you\ncan restrict the search to just the username, public email, full name,\nlocation, or any combination of these.\n'Repository count' Filters users based on the number of repositories they\nhave.\n'Location' Filter users by the location indicated in their profile.\n'Language' Search for users that have repositories that match a certain\nlanguage.\n'Created' Filter users based on when they joined.\n'Followers' Filter users based on the number of followers they have.\n",
+            "in": "query",
+            "name": "q",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "If not provided, results are sorted by best match.",
+            "enum": ["followers", "repositories", "joined"],
+            "in": "query",
+            "name": "sort",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/search-users"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/teams/{teamId}": {
+      "delete": {
+        "description": "Delete team.\nIn order to delete a team, the authenticated user must be an owner of the\norg that the team is associated with.\n",
+        "parameters": [
+          {
+            "description": "Id of team.",
+            "in": "path",
+            "name": "teamId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No content.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "description": "Get team.",
+        "parameters": [
+          {
+            "description": "Id of team.",
+            "in": "path",
+            "name": "teamId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/team"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "description": "Edit team.\nIn order to edit a team, the authenticated user must be an owner of the org\nthat the team is associated with.\n",
+        "parameters": [
+          {
+            "description": "Id of team.",
+            "in": "path",
+            "name": "teamId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/editTeam"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/team"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/teams/{teamId}/members": {
+      "get": {
+        "description": "List team members.\nIn order to list members in a team, the authenticated user must be a member\nof the team.\n",
+        "parameters": [
+          {
+            "description": "Id of team.",
+            "in": "path",
+            "name": "teamId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/users"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/teams/{teamId}/members/{username}": {
+      "delete": {
+        "deprecated": true,
+        "description": "The \"Remove team member\" API is deprecated and is scheduled for removal in the next major version of the API. We recommend using the Remove team membership API instead. It allows you to remove both active and pending memberships.\n\nRemove team member.\nIn order to remove a user from a team, the authenticated user must have 'admin'\npermissions to the team or be an owner of the org that the team is associated\nwith.\nNOTE This does not delete the user, it just remove them from the team.\n",
+        "parameters": [
+          {
+            "description": "Id of team.",
+            "in": "path",
+            "name": "teamId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Name of a member.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Team member removed.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "deprecated": true,
+        "description": "The \"Get team member\" API is deprecated and is scheduled for removal in the next major version of the API. We recommend using the Get team membership API instead. It allows you to get both active and pending memberships.\n\nGet team member.\nIn order to get if a user is a member of a team, the authenticated user mus\nbe a member of the team.\n",
+        "parameters": [
+          {
+            "description": "Id of team.",
+            "in": "path",
+            "name": "teamId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Name of a member.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "User is a member.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "404": {
+            "description": "User is not a member.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "deprecated": true,
+        "description": "The API (described below) is deprecated and is scheduled for removal in the next major version of the API. We recommend using the Add team membership API instead. It allows you to invite new organization members to your teams.\n\nAdd team member.\nIn order to add a user to a team, the authenticated user must have 'admin'\npermissions to the team or be an owner of the org that the team is associated\nwith.\n",
+        "parameters": [
+          {
+            "description": "Id of team.",
+            "in": "path",
+            "name": "teamId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Name of a member.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Team member added.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "422": {
+            "description": "If you attempt to add an organization to a team, you will get this.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/organizationAsTeamMember"
+            }
+          }
+        }
+      }
+    },
+    "/teams/{teamId}/memberships/{username}": {
+      "delete": {
+        "description": "Remove team membership.\nIn order to remove a membership between a user and a team, the authenticated user must have 'admin' permissions to the team or be an owner of the organization that the team is associated with. NOTE: This does not delete the user, it just removes their membership from the team.\n",
+        "parameters": [
+          {
+            "description": "Id of team.",
+            "in": "path",
+            "name": "teamId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Name of a member.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Team member removed.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "description": "Get team membership.\nIn order to get a user's membership with a team, the authenticated user must be a member of the team or an owner of the team's organization.\n",
+        "parameters": [
+          {
+            "description": "Id of team.",
+            "in": "path",
+            "name": "teamId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Name of a member.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User is a member.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/teamMembership"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "404": {
+            "description": "User has no membership with team",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "Add team membership.\nIn order to add a membership between a user and a team, the authenticated user must have 'admin' permissions to the team or be an owner of the organization that the team is associated with.\n\nIf the user is already a part of the team's organization (meaning they're on at least one other team in the organization), this endpoint will add the user to the team.\n\nIf the user is completely unaffiliated with the team's organization (meaning they're on none of the organization's teams), this endpoint will send an invitation to the user via email. This newly-created membership will be in the 'pending' state until the user accepts the invitation, at which point the membership will transition to the 'active' state and the user will be added as a member of the team.\n",
+        "parameters": [
+          {
+            "description": "Id of team.",
+            "in": "path",
+            "name": "teamId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Name of a member.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Team member added.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/teamMembership"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "422": {
+            "description": "If you attempt to add an organization to a team, you will get this.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/organizationAsTeamMember"
+            }
+          }
+        }
+      }
+    },
+    "/teams/{teamId}/repos": {
+      "get": {
+        "description": "List team repos",
+        "parameters": [
+          {
+            "description": "Id of team.",
+            "in": "path",
+            "name": "teamId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/teamRepos"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/teams/{teamId}/repos/{owner}/{repo}": {
+      "delete": {
+        "description": "In order to remove a repository from a team, the authenticated user must be an owner of the org that the team is associated with. NOTE: This does not delete the repository, it just removes it from the team.",
+        "parameters": [
+          {
+            "description": "Id of team.",
+            "in": "path",
+            "name": "teamId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Name of a repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of a repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No content.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "description": "Check if a team manages a repository",
+        "parameters": [
+          {
+            "description": "Id of team.",
+            "in": "path",
+            "name": "teamId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Name of a repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of a repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "In order to add a repository to a team, the authenticated user must be an owner of the org that the team is associated with. Also, the repository must be owned by the organization, or a direct fork of a repository owned by the organization.",
+        "parameters": [
+          {
+            "description": "Id of team.",
+            "in": "path",
+            "name": "teamId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Name of a organization.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of a repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user": {
+      "get": {
+        "description": "Get the authenticated user.",
+        "parameters": [
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/user"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "description": "Update the authenticated user.",
+        "parameters": [
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/user-update"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/user"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user/emails": {
+      "delete": {
+        "description": "Delete email address(es).\nYou can include a single email address or an array of addresses.\n",
+        "parameters": [
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/user-emails"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No content.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "description": "List email addresses for a user.\nIn the final version of the API, this method will return an array of hashes\nwith extended information for each email address indicating if the address\nhas been verified and if it's primary email address for GitHub.\nUntil API v3 is finalized, use the application/vnd.github.v3 media type to\nget other response format.\n",
+        "parameters": [
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "produces": ["application/vnd.github.v3"],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/user-emails"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Add email address(es).\nYou can post a single email address or an array of addresses.\n",
+        "parameters": [
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/emailsPost"
+            }
+          }
+        ],
+        "responses": {
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user/followers": {
+      "get": {
+        "description": "List the authenticated user's followers",
+        "parameters": [
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/users"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user/following": {
+      "get": {
+        "description": "List who the authenticated user is following.",
+        "parameters": [
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/users"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user/following/{username}": {
+      "delete": {
+        "description": "Unfollow a user.\nUnfollowing a user requires the user to be logged in and authenticated with\nbasic auth or OAuth with the user:follow scope.\n",
+        "parameters": [
+          {
+            "description": "Name of user.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "User unfollowed.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "description": "Check if you are following a user.",
+        "parameters": [
+          {
+            "description": "Name of user.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Response if you are following this user.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "404": {
+            "description": "Response if you are not following this user.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "Follow a user.\nFollowing a user requires the user to be logged in and authenticated with\nbasic auth or OAuth with the user:follow scope.\n",
+        "parameters": [
+          {
+            "description": "Name of user.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "You are now following the user.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user/issues": {
+      "get": {
+        "description": "List issues.\nList all issues across owned and member repositories for the authenticated\nuser.\n",
+        "parameters": [
+          {
+            "default": "all",
+            "description": "Issues assigned to you / created by you / mentioning you / you're\nsubscribed to updates for / All issues the authenticated user can see\n",
+            "enum": ["assigned", "created", "mentioned", "subscribed", "all"],
+            "in": "query",
+            "name": "filter",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "default": "open",
+            "enum": ["open", "closed"],
+            "in": "query",
+            "name": "state",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "String list of comma separated Label names. Example - bug,ui,@high.",
+            "in": "query",
+            "name": "labels",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "default": "created",
+            "enum": ["created", "updated", "comments"],
+            "in": "query",
+            "name": "sort",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "default": "desc",
+            "enum": ["asc", "desc"],
+            "in": "query",
+            "name": "direction",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Optional string of a timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ.\nOnly issues updated at or after this time are returned.\n",
+            "in": "query",
+            "name": "since",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/issues"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user/keys": {
+      "get": {
+        "description": "List your public keys.\nLists the current user's keys. Management of public keys via the API requires\nthat you are authenticated through basic auth, or OAuth with the 'user', 'write:public_key' scopes.\n",
+        "parameters": [
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/gitignore"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Create a public key.",
+        "parameters": [
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/user-keys-post"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/user-keys-keyId"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user/keys/{keyId}": {
+      "delete": {
+        "description": "Delete a public key. Removes a public key. Requires that you are authenticated via Basic Auth or via OAuth with at least admin:public_key scope.",
+        "parameters": [
+          {
+            "description": "ID of key.",
+            "in": "path",
+            "name": "keyId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No content.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "description": "Get a single public key.",
+        "parameters": [
+          {
+            "description": "ID of key.",
+            "in": "path",
+            "name": "keyId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/user-keys-keyId"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user/orgs": {
+      "get": {
+        "description": "List public and private organizations for the authenticated user.",
+        "parameters": [
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/gitignore"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user/repos": {
+      "get": {
+        "description": "List repositories for the authenticated user. Note that this does not include\nrepositories owned by organizations which the user can access. You can lis\nuser organizations and list organization repositories separately.\n",
+        "parameters": [
+          {
+            "default": "all",
+            "enum": ["all", "public", "private", "forks", "sources", "member"],
+            "in": "query",
+            "name": "type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/repos"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Create a new repository for the authenticated user. OAuth users must supply\nrepo scope.\n",
+        "parameters": [
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/postRepo"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/repos"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user/starred": {
+      "get": {
+        "description": "List repositories being starred by the authenticated user.",
+        "parameters": [
+          {
+            "description": "Ignored without 'sort' parameter.",
+            "in": "query",
+            "name": "direction",
+            "type": "string"
+          },
+          {
+            "default": "created",
+            "description": "",
+            "enum": ["created", "updated"],
+            "in": "query",
+            "name": "sort",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/gitignore"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user/starred/{owner}/{repo}": {
+      "delete": {
+        "description": "Unstar a repository",
+        "parameters": [
+          {
+            "description": "Name of a repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of a repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Unstarred.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "description": "Check if you are starring a repository.",
+        "parameters": [
+          {
+            "description": "Name of a repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of a repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "This repository is starred by you.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "404": {
+            "description": "This repository is not starred by you.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "Star a repository.",
+        "parameters": [
+          {
+            "description": "Name of a repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of a repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Repository starred.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user/subscriptions": {
+      "get": {
+        "description": "List repositories being watched by the authenticated user.",
+        "parameters": [
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/repos"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user/subscriptions/{owner}/{repo}": {
+      "delete": {
+        "deprecated": true,
+        "description": "Stop watching a repository",
+        "parameters": [
+          {
+            "description": "Name of the owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Unwatched.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "deprecated": true,
+        "description": "Check if you are watching a repository.",
+        "parameters": [
+          {
+            "description": "Name of the owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Repository is watched by you.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "404": {
+            "description": "Repository is not watched by you.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "deprecated": true,
+        "description": "Watch a repository.",
+        "parameters": [
+          {
+            "description": "Name of the owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Repository is watched.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user/teams": {
+      "get": {
+        "description": "List all of the teams across all of the organizations to which the authenticated user belongs. This method requires user or repo scope when authenticating via OAuth.",
+        "parameters": [
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/teams-list"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users": {
+      "get": {
+        "description": "Get all users.\nThis provides a dump of every user, in the order that they signed up for GitHub.\nNote: Pagination is powered exclusively by the since parameter. Use the Link\nheader to get the URL for the next page of users.\n",
+        "parameters": [
+          {
+            "description": "The integer ID of the last user that you've seen.",
+            "in": "query",
+            "name": "since",
+            "type": "integer"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/users"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/{username}": {
+      "get": {
+        "description": "Get a single user.",
+        "parameters": [
+          {
+            "description": "Name of user.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/user"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/{username}/events": {
+      "get": {
+        "description": "If you are authenticated as the given user, you will see your private events. Otherwise, you'll only see public events.",
+        "parameters": [
+          {
+            "description": "Name of user.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/{username}/events/orgs/{org}": {
+      "get": {
+        "description": "This is the user's organization dashboard. You must be authenticated as the user to view this.",
+        "parameters": [
+          {
+            "description": "Name of user.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "org",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/{username}/followers": {
+      "get": {
+        "description": "List a user's followers",
+        "parameters": [
+          {
+            "description": "Name of user.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/users"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/{username}/following/{targetUser}": {
+      "get": {
+        "description": "Check if one user follows another.",
+        "parameters": [
+          {
+            "description": "Name of user.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of user.",
+            "in": "path",
+            "name": "targetUser",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Response if user follows target user.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          },
+          "404": {
+            "description": "Response if user does not follow target user.",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/{username}/gists": {
+      "get": {
+        "description": "List a users gists.",
+        "parameters": [
+          {
+            "description": "Name of user.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "The time should be passed in as UTC in the ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ.\nExample: \"2012-10-09T23:39:01Z\".\n",
+            "in": "query",
+            "name": "since",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/gists"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/{username}/keys": {
+      "get": {
+        "description": "List public keys for a user.\nLists the verified public keys for a user. This is accessible by anyone.\n",
+        "parameters": [
+          {
+            "description": "Name of user.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/gitignore"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/{username}/orgs": {
+      "get": {
+        "description": "List all public organizations for a user.",
+        "parameters": [
+          {
+            "description": "Name of user.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/gitignore"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/{username}/received_events": {
+      "get": {
+        "description": "These are events that you'll only see public events.",
+        "parameters": [
+          {
+            "description": "Name of user.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/{username}/received_events/public": {
+      "get": {
+        "description": "List public events that a user has received",
+        "parameters": [
+          {
+            "description": "Name of user.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/{username}/repos": {
+      "get": {
+        "description": "List public repositories for the specified user.",
+        "parameters": [
+          {
+            "description": "Name of user.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "default": "all",
+            "enum": ["all", "public", "private", "forks", "sources", "member"],
+            "in": "query",
+            "name": "type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/repos"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/{username}/starred": {
+      "get": {
+        "description": "List repositories being starred by a user.",
+        "parameters": [
+          {
+            "description": "Name of user.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/{username}/subscriptions": {
+      "get": {
+        "description": "List repositories being watched by a user.",
+        "parameters": [
+          {
+            "description": "Name of user.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n",
+            "headers": {
+              "X-GitHub-Media-Type": {
+                "description": "You can check the current version of media type in responses.\n",
+                "type": "string"
+              },
+              "X-GitHub-Request-Id": {
+                "type": "integer"
+              },
+              "X-RateLimit-Limit": {
+                "type": "integer"
+              },
+              "X-RateLimit-Remaining": {
+                "type": "integer"
+              },
+              "X-RateLimit-Reset": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "actor": {
+      "description": "A user or organization",
+      "properties": {
+        "avatar_url": {
+          "type": "string"
+        },
+        "bio": {
+          "type": "string"
+        },
+        "blog": {
+          "description": "The website URL from the profile page",
+          "type": "string"
+        },
+        "collaborators": {
+          "type": "integer"
+        },
+        "company": {
+          "type": "string"
+        },
+        "created_at": {
+          "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+          "type": "string"
+        },
+        "disk_usage": {
+          "type": "integer"
+        },
+        "email": {
+          "description": "Note: The returned email is the user’s publicly visible email address (or null if the user has not specified a public email address in their profile).",
+          "type": "string"
+        },
+        "followers": {
+          "type": "integer"
+        },
+        "followers_url": {
+          "type": "string"
+        },
+        "following": {
+          "type": "integer"
+        },
+        "following_url": {
+          "type": "string"
+        },
+        "gists_url": {
+          "type": "string"
+        },
+        "gravatar_id": {
+          "type": "string"
+        },
+        "hireable": {
+          "type": "boolean"
+        },
+        "html_url": {
+          "type": "string"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "location": {
+          "type": "string"
+        },
+        "login": {
+          "description": "The account username",
+          "type": "string"
+        },
+        "name": {
+          "description": "The full account name",
+          "type": "string"
+        },
+        "organizations_url": {
+          "type": "string"
+        },
+        "owned_private_repos": {
+          "type": "integer"
+        },
+        "plan": {
+          "properties": {
+            "collaborators": {
+              "type": "integer"
+            },
+            "name": {
+              "type": "string"
+            },
+            "private_repos": {
+              "type": "integer"
+            },
+            "space": {
+              "type": "integer"
+            }
+          },
+          "type": "object"
+        },
+        "private_gists": {
+          "type": "integer"
+        },
+        "public_gists": {
+          "type": "integer"
+        },
+        "public_repos": {
+          "type": "integer"
+        },
+        "starred_url": {
+          "type": "string"
+        },
+        "subscriptions_url": {
+          "type": "string"
+        },
+        "total_private_repos": {
+          "type": "integer"
+        },
+        "type": {
+          "enum": ["User", "Organization"]
+        },
+        "updated_at": {
+          "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "asset": {
+      "properties": {
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string"
+        },
+        "download_count": {
+          "type": "number"
+        },
+        "id": {
+          "type": "number"
+        },
+        "label": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "size": {
+          "type": "number"
+        },
+        "state": {
+          "type": "string"
+        },
+        "updated_at": {
+          "type": "string"
+        },
+        "uploader": {
+          "$ref": "#/definitions/user"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "assetPatch": {
+      "properties": {
+        "label": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": ["name"],
+      "type": "object"
+    },
+    "assets": {
+      "items": {
+        "$ref": "#/definitions/asset"
+      },
+      "type": "array"
+    },
+    "assignees": {
+      "items": {
+        "$ref": "#/definitions/user"
+      },
+      "type": "array"
+    },
+    "blob": {
+      "properties": {
+        "content": {
+          "type": "string"
+        },
+        "encoding": {
+          "enum": ["utf-8", "base64"]
+        },
+        "sha": {
+          "type": "string"
+        },
+        "size": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "blobs": {
+      "properties": {
+        "sha": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "branch": {
+      "properties": {
+        "_links": {
+          "properties": {
+            "html": {
+              "type": "string"
+            },
+            "self": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "commit": {
+          "properties": {
+            "author": {
+              "$ref": "#/definitions/user"
+            },
+            "commit": {
+              "properties": {
+                "author": {
+                  "properties": {
+                    "date": {
+                      "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+                      "type": "string"
+                    },
+                    "email": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "committer": {
+                  "properties": {
+                    "date": {
+                      "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+                      "type": "string"
+                    },
+                    "email": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "message": {
+                  "type": "string"
+                },
+                "tree": {
+                  "properties": {
+                    "sha": {
+                      "type": "string"
+                    },
+                    "url": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "committer": {
+              "$ref": "#/definitions/user"
+            },
+            "parents": {
+              "items": {
+                "properties": {
+                  "sha": {
+                    "type": "string"
+                  },
+                  "url": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "sha": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "branches": {
+      "items": {
+        "properties": {
+          "commit": {
+            "properties": {
+              "sha": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "codeFrequencyStats": {
+      "items": {
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "comment": {
+      "properties": {
+        "body": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "commentBody": {
+      "properties": {
+        "body": {
+          "type": "string"
+        }
+      },
+      "required": ["body"],
+      "type": "object"
+    },
+    "comments": {
+      "items": {
+        "properties": {
+          "body": {
+            "type": "string"
+          },
+          "created_at": {
+            "description": "ISO 8601.",
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "url": {
+            "type": "string"
+          },
+          "user": {
+            "$ref": "#/definitions/user"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "commit": {
+      "properties": {
+        "author": {
+          "$ref": "#/definitions/user"
+        },
+        "commit": {
+          "properties": {
+            "author": {
+              "properties": {
+                "date": {
+                  "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+                  "type": "string"
+                },
+                "email": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "committer": {
+              "properties": {
+                "date": {
+                  "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+                  "type": "string"
+                },
+                "email": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "message": {
+              "type": "string"
+            },
+            "tree": {
+              "properties": {
+                "sha": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "committer": {
+          "$ref": "#/definitions/user"
+        },
+        "files": {
+          "items": {
+            "properties": {
+              "additions": {
+                "type": "integer"
+              },
+              "blob_url": {
+                "type": "string"
+              },
+              "changes": {
+                "type": "integer"
+              },
+              "deletions": {
+                "type": "integer"
+              },
+              "filename": {
+                "type": "string"
+              },
+              "patch": {
+                "type": "string"
+              },
+              "raw_url": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "parents": {
+          "items": {
+            "properties": {
+              "sha": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "sha": {
+          "type": "string"
+        },
+        "stats": {
+          "properties": {
+            "additions": {
+              "type": "integer"
+            },
+            "deletions": {
+              "type": "integer"
+            },
+            "total": {
+              "type": "integer"
+            }
+          },
+          "type": "object"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "commitActivityStats": {
+      "items": {
+        "properties": {
+          "days": {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "total": {
+            "type": "integer"
+          },
+          "week": {
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "commitComment": {
+      "properties": {
+        "body": {
+          "type": "string"
+        },
+        "commit_id": {
+          "type": "string"
+        },
+        "created_at": {
+          "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+          "type": "string"
+        },
+        "html_url": {
+          "type": "string"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "line": {
+          "type": "integer"
+        },
+        "path": {
+          "type": "string"
+        },
+        "position": {
+          "type": "integer"
+        },
+        "updated_at": {
+          "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "user": {
+          "$ref": "#/definitions/user"
+        }
+      },
+      "type": "object"
+    },
+    "commitCommentBody": {
+      "properties": {
+        "body": {
+          "type": "string"
+        },
+        "line": {
+          "description": "Deprecated - Use position parameter instead.",
+          "type": "string"
+        },
+        "number": {
+          "description": "Line number in the file to comment on. Defaults to null.",
+          "type": "string"
+        },
+        "path": {
+          "description": "Relative path of the file to comment on.",
+          "type": "string"
+        },
+        "position": {
+          "description": "Line index in the diff to comment on.",
+          "type": "integer"
+        },
+        "sha": {
+          "description": "SHA of the commit to comment on.",
+          "type": "string"
+        }
+      },
+      "required": ["sha", "body"],
+      "type": "object"
+    },
+    "commits": {
+      "items": {
+        "properties": {
+          "author": {
+            "$ref": "#/definitions/user"
+          },
+          "commit": {
+            "properties": {
+              "author": {
+                "properties": {
+                  "date": {
+                    "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+                    "type": "string"
+                  },
+                  "email": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "committer": {
+                "properties": {
+                  "date": {
+                    "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+                    "type": "string"
+                  },
+                  "email": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "message": {
+                "type": "string"
+              },
+              "tree": {
+                "properties": {
+                  "sha": {
+                    "type": "string"
+                  },
+                  "url": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "committer": {
+            "$ref": "#/definitions/user"
+          },
+          "parents": {
+            "items": {
+              "properties": {
+                "sha": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "sha": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "compare-commits": {
+      "properties": {
+        "ahead_by": {
+          "type": "integer"
+        },
+        "base_commit": {
+          "properties": {
+            "author": {
+              "$ref": "#/definitions/user"
+            },
+            "commit": {
+              "properties": {
+                "author": {
+                  "properties": {
+                    "date": {
+                      "type": "string"
+                    },
+                    "email": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "committer": {
+                  "properties": {
+                    "date": {
+                      "type": "string"
+                    },
+                    "email": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "message": {
+                  "type": "string"
+                },
+                "tree": {
+                  "properties": {
+                    "sha": {
+                      "type": "string"
+                    },
+                    "url": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "committer": {
+              "$ref": "#/definitions/user"
+            },
+            "parents": {
+              "items": {
+                "properties": {
+                  "sha": {
+                    "type": "string"
+                  },
+                  "url": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "sha": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "behind_by": {
+          "type": "integer"
+        },
+        "commits": {
+          "items": {
+            "properties": {
+              "author": {
+                "$ref": "#/definitions/user"
+              },
+              "commit": {
+                "properties": {
+                  "author": {
+                    "properties": {
+                      "date": {
+                        "type": "string"
+                      },
+                      "email": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "committer": {
+                    "properties": {
+                      "date": {
+                        "type": "string"
+                      },
+                      "email": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "message": {
+                    "type": "string"
+                  },
+                  "tree": {
+                    "properties": {
+                      "sha": {
+                        "type": "string"
+                      },
+                      "url": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "url": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "committer": {
+                "$ref": "#/definitions/user"
+              },
+              "parents": {
+                "items": {
+                  "properties": {
+                    "sha": {
+                      "type": "string"
+                    },
+                    "url": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "sha": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "diff_url": {
+          "type": "string"
+        },
+        "files": {
+          "items": {
+            "properties": {
+              "additions": {
+                "type": "integer"
+              },
+              "blob_url": {
+                "type": "string"
+              },
+              "changes": {
+                "type": "integer"
+              },
+              "contents_url": {
+                "type": "string"
+              },
+              "deletions": {
+                "type": "integer"
+              },
+              "filename": {
+                "type": "string"
+              },
+              "patch": {
+                "type": "string"
+              },
+              "raw_url": {
+                "type": "string"
+              },
+              "sha": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "html_url": {
+          "type": "string"
+        },
+        "patch_url": {
+          "type": "string"
+        },
+        "permalink_url": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "total_commits": {
+          "type": "integer"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "contents-path": {
+      "properties": {
+        "_links": {
+          "properties": {
+            "git": {
+              "type": "string"
+            },
+            "html": {
+              "type": "string"
+            },
+            "self": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "content": {
+          "type": "string"
+        },
+        "encoding": {
+          "type": "string"
+        },
+        "git_url": {
+          "type": "string"
+        },
+        "html_url": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "sha": {
+          "type": "string"
+        },
+        "size": {
+          "type": "integer"
+        },
+        "type": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "contributorsStats": {
+      "items": {
+        "properties": {
+          "author": {
+            "properties": {
+              "avatar_url": {
+                "type": "string"
+              },
+              "gravatar_id": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer"
+              },
+              "login": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "total": {
+            "description": "The Total number of commits authored by the contributor.",
+            "type": "integer"
+          },
+          "weeks": {
+            "items": {
+              "properties": {
+                "a": {
+                  "description": "Number of additions.",
+                  "type": "integer"
+                },
+                "c": {
+                  "description": "Number of commits.",
+                  "type": "integer"
+                },
+                "d": {
+                  "description": "Number of deletions.",
+                  "type": "integer"
+                },
+                "w": {
+                  "description": "Start of the week.",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "createFile": {
+      "properties": {
+        "commit": {
+          "properties": {
+            "author": {
+              "properties": {
+                "date": {
+                  "type": "string"
+                },
+                "email": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "committer": {
+              "properties": {
+                "date": {
+                  "type": "string"
+                },
+                "email": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "html_url": {
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            },
+            "parents": {
+              "items": {
+                "properties": {
+                  "html_url": {
+                    "type": "string"
+                  },
+                  "sha": {
+                    "type": "string"
+                  },
+                  "url": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "sha": {
+              "type": "string"
+            },
+            "tree": {
+              "properties": {
+                "sha": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "content": {
+          "properties": {
+            "_links": {
+              "properties": {
+                "git": {
+                  "type": "string"
+                },
+                "html": {
+                  "type": "string"
+                },
+                "self": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "git_url": {
+              "type": "string"
+            },
+            "html_url": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "path": {
+              "type": "string"
+            },
+            "sha": {
+              "type": "string"
+            },
+            "size": {
+              "type": "integer"
+            },
+            "type": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "createFileBody": {
+      "properties": {
+        "committer": {
+          "properties": {
+            "email": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "content": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "deleteFile": {
+      "properties": {
+        "commit": {
+          "properties": {
+            "author": {
+              "properties": {
+                "date": {
+                  "type": "string"
+                },
+                "email": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "committer": {
+              "properties": {
+                "date": {
+                  "type": "string"
+                },
+                "email": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              }
+            },
+            "html_url": {
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            },
+            "parents": {
+              "properties": {
+                "html_url": {
+                  "type": "string"
+                },
+                "sha": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "sha": {
+              "type": "string"
+            },
+            "tree": {
+              "properties": {
+                "sha": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "content": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "deleteFileBody": {
+      "properties": {
+        "committer": {
+          "properties": {
+            "email": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "message": {
+          "type": "string"
+        },
+        "sha": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "deployment": {
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "payload": {
+          "properties": {
+            "deploy_user": {
+              "type": "string"
+            },
+            "environment": {
+              "type": "string"
+            },
+            "room_id": {
+              "type": "number"
+            }
+          },
+          "type": "object"
+        },
+        "ref": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "deployment-resp": {
+      "properties": {
+        "created_at": {
+          "type": "string"
+        },
+        "creator": {
+          "$ref": "#/definitions/user"
+        },
+        "description": {
+          "type": "string"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "payload": {
+          "type": "string"
+        },
+        "sha": {
+          "type": "string"
+        },
+        "statuses_url": {
+          "type": "string"
+        },
+        "updated_at": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "deployment-statuses": {
+      "items": {
+        "properties": {
+          "created_at": {
+            "type": "string"
+          },
+          "creator": {
+            "$ref": "#/definitions/user"
+          },
+          "description": {
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "payload": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          },
+          "target_url": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "deployment-statuses-create": {
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "state": {
+          "type": "string"
+        },
+        "target_url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "download": {
+      "properties": {
+        "content_type": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "download_count": {
+          "type": "integer"
+        },
+        "html_url": {
+          "type": "string"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "size": {
+          "type": "integer"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "downloads": {
+      "items": {
+        "$ref": "#/definitions/download"
+      },
+      "type": "array"
+    },
+    "editTeam": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "permission": {
+          "enum": ["pull", "push", "admin"]
+        }
+      },
+      "required": ["name"],
+      "type": "object"
+    },
+    "emailsPost": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "emojis": {
+      "additionalProperties": {
+        "description": "A URL for an image representing this emoji",
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "event": {
+      "properties": {
+        "actor": {
+          "$ref": "#/definitions/actor"
+        },
+        "created_at": {
+          "type": "object"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "org": {
+          "$ref": "#/definitions/organization"
+        },
+        "payload": {
+          "properties": {},
+          "type": "object"
+        },
+        "public": {
+          "type": "boolean"
+        },
+        "repo": {
+          "properties": {
+            "id": {
+              "type": "integer"
+            },
+            "name": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "events": {
+      "items": {
+        "$ref": "#/definitions/event"
+      },
+      "type": "array"
+    },
+    "feeds": {
+      "properties": {
+        "_links": {
+          "properties": {
+            "current_user": {
+              "properties": {
+                "href": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "current_user_actor": {
+              "properties": {
+                "href": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "current_user_organization": {
+              "properties": {
+                "href": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "current_user_public": {
+              "properties": {
+                "href": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "timeline": {
+              "properties": {
+                "href": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "user": {
+              "properties": {
+                "href": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          }
+        },
+        "current_user_actor_url": {
+          "type": "string"
+        },
+        "current_user_organization_url": {
+          "type": "string"
+        },
+        "current_user_public": {
+          "type": "string"
+        },
+        "current_user_url": {
+          "type": "string"
+        },
+        "timeline_url": {
+          "type": "string"
+        },
+        "user_url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "forkBody": {
+      "properties": {
+        "organization": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "forks": {
+      "$ref": "#/definitions/repos"
+    },
+    "gist": {
+      "properties": {
+        "comments": {
+          "type": "integer"
+        },
+        "comments_url": {
+          "type": "string"
+        },
+        "created_at": {
+          "description": "Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ.",
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "files": {
+          "properties": {
+            "ring.erl": {
+              "properties": {
+                "filename": {
+                  "type": "string"
+                },
+                "raw_url": {
+                  "type": "string"
+                },
+                "size": {
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "forks": {
+          "items": {
+            "properties": {
+              "created_at": {
+                "description": "Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ.",
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              },
+              "user": {
+                "$ref": "#/definitions/user"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "git_pull_url": {
+          "type": "string"
+        },
+        "git_push_url": {
+          "type": "string"
+        },
+        "history": {
+          "items": {
+            "properties": {
+              "change_status": {
+                "properties": {
+                  "additions": {
+                    "type": "integer"
+                  },
+                  "deletions": {
+                    "type": "integer"
+                  },
+                  "total": {
+                    "type": "integer"
+                  }
+                },
+                "type": "object"
+              },
+              "committed_at": {
+                "description": "Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ.",
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              },
+              "user": {
+                "$ref": "#/definitions/user"
+              },
+              "version": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "html_url": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "public": {
+          "type": "boolean"
+        },
+        "url": {
+          "type": "string"
+        },
+        "user": {
+          "$ref": "#/definitions/user"
+        }
+      },
+      "type": "object"
+    },
+    "gists": {
+      "items": {
+        "properties": {
+          "comments": {
+            "type": "integer"
+          },
+          "comments_url": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "files": {
+            "properties": {
+              "ring.erl": {
+                "properties": {
+                  "filename": {
+                    "type": "string"
+                  },
+                  "raw_url": {
+                    "type": "string"
+                  },
+                  "size": {
+                    "type": "integer"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "git_pull_url": {
+            "type": "string"
+          },
+          "git_push_url": {
+            "type": "string"
+          },
+          "html_url": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "public": {
+            "type": "boolean"
+          },
+          "url": {
+            "type": "string"
+          },
+          "user": {
+            "$ref": "#/definitions/user"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "gitCommit": {
+      "properties": {
+        "author": {
+          "properties": {
+            "date": {
+              "type": "string"
+            },
+            "email": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "message": {
+          "type": "string"
+        },
+        "parents": {
+          "type": "string"
+        },
+        "tree": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "gitRefPatch": {
+      "properties": {
+        "force": {
+          "type": "boolean"
+        },
+        "sha": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "gitignore": {
+      "items": {},
+      "type": "array"
+    },
+    "gitignore-lang": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "source": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "headBranch": {
+      "properties": {
+        "object": {
+          "properties": {
+            "sha": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "ref": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "hook": {
+      "items": {
+        "properties": {
+          "active": {
+            "type": "boolean"
+          },
+          "config": {
+            "properties": {
+              "content_type": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "created_at": {
+            "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+            "type": "string"
+          },
+          "events": {
+            "items": {
+              "enum": [
+                "push",
+                "issues",
+                "issue_comment",
+                "commit_comment",
+                "pull_request",
+                "pull_request_review_comment",
+                "gollum",
+                "watch",
+                "download",
+                "fork",
+                "fork_apply",
+                "member",
+                "public",
+                "team_add",
+                "status"
+              ]
+            },
+            "type": "array"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "updated_at": {
+            "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "hookBody": {
+      "properties": {
+        "active": {
+          "type": "boolean"
+        },
+        "add_events": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "issue": {
+      "properties": {
+        "assignee": {
+          "type": "string"
+        },
+        "body": {
+          "type": "string"
+        },
+        "labels": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "milestone": {
+          "type": "number"
+        },
+        "title": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "issueEvent": {
+      "properties": {
+        "actor": {
+          "$ref": "#/definitions/actor"
+        },
+        "commit_id": {
+          "type": "string"
+        },
+        "created_at": {
+          "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+          "type": "string"
+        },
+        "event": {
+          "type": "string"
+        },
+        "issue": {
+          "properties": {
+            "assignee": {
+              "$ref": "#/definitions/user"
+            },
+            "body": {
+              "type": "string"
+            },
+            "closed_at": {
+              "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+              "type": "string"
+            },
+            "comments": {
+              "type": "integer"
+            },
+            "created_at": {
+              "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+              "type": "string"
+            },
+            "html_url": {
+              "type": "string"
+            },
+            "labels": {
+              "items": {
+                "properties": {
+                  "color": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "url": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "milestone": {
+              "properties": {
+                "closed_issues": {
+                  "type": "integer"
+                },
+                "created_at": {
+                  "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+                  "type": "string"
+                },
+                "creator": {
+                  "$ref": "#/definitions/user"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "due_on": {
+                  "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+                  "type": "string"
+                },
+                "number": {
+                  "type": "integer"
+                },
+                "open_issues": {
+                  "type": "integer"
+                },
+                "state": {
+                  "enum": ["open", "closed"]
+                },
+                "title": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "number": {
+              "type": "integer"
+            },
+            "pull_request": {
+              "properties": {
+                "diff_url": {
+                  "type": "string"
+                },
+                "html_url": {
+                  "type": "string"
+                },
+                "patch_url": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "state": {
+              "enum": ["open", "closed"]
+            },
+            "title": {
+              "type": "string"
+            },
+            "updated_at": {
+              "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            },
+            "user": {
+              "$ref": "#/definitions/user"
+            }
+          },
+          "type": "object"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "issueEvents": {
+      "items": {
+        "$ref": "#/definitions/issueEvent"
+      },
+      "type": "array"
+    },
+    "issues": {
+      "items": {
+        "properties": {
+          "assignee": {
+            "$ref": "#/definitions/user"
+          },
+          "body": {
+            "type": "string"
+          },
+          "closed_at": {
+            "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+            "type": "string"
+          },
+          "comments": {
+            "type": "integer"
+          },
+          "created_at": {
+            "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+            "type": "string"
+          },
+          "html_url": {
+            "type": "string"
+          },
+          "labels": {
+            "items": {
+              "properties": {
+                "color": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "milestone": {
+            "properties": {
+              "closed_issues": {
+                "type": "integer"
+              },
+              "created_at": {
+                "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+                "type": "string"
+              },
+              "creator": {
+                "$ref": "#/definitions/user"
+              },
+              "description": {
+                "type": "string"
+              },
+              "due_on": {
+                "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+                "type": "string"
+              },
+              "number": {
+                "type": "integer"
+              },
+              "open_issues": {
+                "type": "integer"
+              },
+              "state": {
+                "enum": ["open", "closed"]
+              },
+              "title": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "number": {
+            "type": "integer"
+          },
+          "pull_request": {
+            "properties": {
+              "diff_url": {
+                "type": "string"
+              },
+              "html_url": {
+                "type": "string"
+              },
+              "patch_url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "state": {
+            "enum": ["open", "closed"]
+          },
+          "title": {
+            "type": "string"
+          },
+          "updated_at": {
+            "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "user": {
+            "$ref": "#/definitions/user"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "issuesComment": {
+      "properties": {
+        "body": {
+          "type": "string"
+        },
+        "created_at": {
+          "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+          "type": "string"
+        },
+        "html_url": {
+          "type": "string"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "updated_at": {
+          "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "user": {
+          "$ref": "#/definitions/user"
+        }
+      },
+      "type": "object"
+    },
+    "issuesComments": {
+      "items": {
+        "properties": {
+          "_links": {
+            "properties": {
+              "html": {
+                "properties": {
+                  "href": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "pull_request": {
+                "properties": {
+                  "href": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "self": {
+                "properties": {
+                  "href": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "body": {
+            "type": "string"
+          },
+          "commit_id": {
+            "type": "string"
+          },
+          "created_at": {
+            "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "path": {
+            "type": "string"
+          },
+          "position": {
+            "type": "integer"
+          },
+          "updated_at": {
+            "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "user": {
+            "$ref": "#/definitions/user"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "keys": {
+      "items": {
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "key": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "label": {
+      "properties": {
+        "color": {
+          "maxLength": 6,
+          "minLength": 6,
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "labels": {
+      "items": {
+        "properties": {
+          "color": {
+            "maxLength": 6,
+            "minLength": 6,
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "languages": {
+      "additionalProperties": {
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "markdown": {
+      "properties": {
+        "context": {
+          "type": "string"
+        },
+        "mode": {
+          "type": "string"
+        },
+        "text": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "merge": {
+      "properties": {
+        "merged": {
+          "type": "boolean"
+        },
+        "message": {
+          "type": "string"
+        },
+        "sha": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "mergePullBody": {
+      "properties": {
+        "commit_message": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "mergesBody": {
+      "properties": {
+        "base": {
+          "type": "string"
+        },
+        "commit_message": {
+          "type": "string"
+        },
+        "head": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "mergesConflict": {
+      "properties": {
+        "message": {
+          "description": "Error message",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "mergesSuccessful": {
+      "properties": {
+        "author": {
+          "$ref": "#/definitions/user"
+        },
+        "comments_url": {
+          "type": "string"
+        },
+        "commit": {
+          "properties": {
+            "author": {
+              "properties": {
+                "date": {
+                  "type": "string"
+                },
+                "email": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "comment_count": {
+              "type": "integer"
+            },
+            "committer": {
+              "properties": {
+                "date": {
+                  "type": "string"
+                },
+                "email": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "message": {
+              "type": "string"
+            },
+            "tree": {
+              "properties": {
+                "sha": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "committer": {
+          "$ref": "#/definitions/user"
+        },
+        "merged": {
+          "type": "boolean"
+        },
+        "message": {
+          "type": "string"
+        },
+        "parents": {
+          "items": {
+            "properties": {
+              "sha": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "sha": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "meta": {
+      "properties": {
+        "git": {
+          "items": {
+            "description": "An Array of IP addresses in CIDR format specifying the Git servers at GitHub.",
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "hooks": {
+          "items": {
+            "description": "An Array of IP addresses in CIDR format specifying the addresses that incoming service hooks will originate from.",
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "milestone": {
+      "properties": {
+        "closed_issues": {
+          "type": "integer"
+        },
+        "created_at": {
+          "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+          "type": "string"
+        },
+        "creator": {
+          "$ref": "#/definitions/user"
+        },
+        "description": {
+          "type": "string"
+        },
+        "due_on": {
+          "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+          "type": "string"
+        },
+        "number": {
+          "type": "integer"
+        },
+        "open_issues": {
+          "type": "integer"
+        },
+        "state": {
+          "enum": ["open", "closed"]
+        },
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "milestoneUpdate": {
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "due_on": {
+          "type": "string"
+        },
+        "state": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "notificationMarkRead": {
+      "properties": {
+        "last_read_at": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "notifications": {
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "last_read_at": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "repository": {
+          "properties": {
+            "description": {
+              "type": "string"
+            },
+            "fork": {
+              "type": "boolean"
+            },
+            "full_name": {
+              "type": "string"
+            },
+            "html_url": {
+              "type": "string"
+            },
+            "id": {
+              "type": "integer"
+            },
+            "name": {
+              "type": "string"
+            },
+            "owner": {
+              "$ref": "#/definitions/actor"
+            },
+            "private": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "subject": {
+          "properties": {
+            "latest_comment_url": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "unread": {
+          "type": "boolean"
+        },
+        "updated_at": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "orgTeamsPost": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "permission": {
+          "enum": ["pull", "push", "admin"]
+        },
+        "repo_names": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": ["name"],
+      "type": "object"
+    },
+    "organization": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/actor"
+        },
+        {
+          "description": "A GitHub organization"
+        }
+      ],
+      "type": "object"
+    },
+    "organizationAsTeamMember": {
+      "properties": {
+        "errors": {
+          "items": {
+            "properties": {
+              "code": {
+                "type": "string"
+              },
+              "field": {
+                "type": "string"
+              },
+              "resource": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "message": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "participationStats": {
+      "properties": {
+        "all": {
+          "items": {
+            "type": "integer"
+          },
+          "type": "array"
+        },
+        "owner": {
+          "items": {
+            "type": "integer"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "patchGist": {
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "files": {
+          "properties": {
+            "delete_this_file.txt": {
+              "type": "string"
+            },
+            "file1.txt": {
+              "properties": {
+                "content": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "new_file.txt": {
+              "properties": {
+                "content": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "old_name.txt": {
+              "properties": {
+                "content": {
+                  "type": "string"
+                },
+                "filename": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          }
+        }
+      },
+      "type": "object"
+    },
+    "patchOrg": {
+      "properties": {
+        "billing_email": {
+          "description": "Billing email address. This address is not publicized.",
+          "type": "string"
+        },
+        "company": {
+          "type": "string"
+        },
+        "email": {
+          "description": "Publicly visible email address.",
+          "type": "string"
+        },
+        "location": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "postGist": {
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "files": {
+          "properties": {
+            "file1.txt": {
+              "properties": {
+                "content": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "public": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "postRepo": {
+      "properties": {
+        "auto_init": {
+          "description": "True to create an initial commit with empty README. Default is false.",
+          "type": "boolean"
+        },
+        "description": {
+          "type": "string"
+        },
+        "gitignore_template": {
+          "description": "Desired language or platform .gitignore template to apply. Use the name of the template without the extension. For example, \"Haskell\" Ignored if auto_init parameter is not provided. ",
+          "type": "string"
+        },
+        "has_downloads": {
+          "description": "True to enable downloads for this repository, false to disable them. Default is true.",
+          "type": "boolean"
+        },
+        "has_issues": {
+          "description": "True to enable issues for this repository, false to disable them. Default is true.",
+          "type": "boolean"
+        },
+        "has_wiki": {
+          "description": "True to enable the wiki for this repository, false to disable it. Default is true.",
+          "type": "boolean"
+        },
+        "homepage": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "private": {
+          "description": "True to create a private repository, false to create a public one. Creating private repositories requires a paid GitHub account.",
+          "type": "boolean"
+        },
+        "team_id": {
+          "description": "The id of the team that will be granted access to this repository. This is only valid when creating a repo in an organization.",
+          "type": "integer"
+        }
+      },
+      "required": ["name"],
+      "type": "object"
+    },
+    "pullRequest": {
+      "properties": {
+        "_links": {
+          "properties": {
+            "comments": {
+              "properties": {
+                "href": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "html": {
+              "properties": {
+                "href": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "review_comments": {
+              "properties": {
+                "href": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "self": {
+              "properties": {
+                "href": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "additions": {
+          "type": "integer"
+        },
+        "base": {
+          "properties": {
+            "label": {
+              "type": "string"
+            },
+            "ref": {
+              "type": "string"
+            },
+            "repo": {
+              "$ref": "#/definitions/repo"
+            },
+            "sha": {
+              "type": "string"
+            },
+            "user": {
+              "properties": {
+                "avatar_url": {
+                  "type": "string"
+                },
+                "gravatar_id": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "integer"
+                },
+                "login": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "body": {
+          "type": "string"
+        },
+        "changed_files": {
+          "type": "integer"
+        },
+        "closed_at": {
+          "type": "string"
+        },
+        "comments": {
+          "type": "integer"
+        },
+        "commits": {
+          "type": "integer"
+        },
+        "created_at": {
+          "type": "string"
+        },
+        "deletions": {
+          "type": "integer"
+        },
+        "diff_url": {
+          "type": "string"
+        },
+        "head": {
+          "properties": {
+            "label": {
+              "type": "string"
+            },
+            "ref": {
+              "type": "string"
+            },
+            "repo": {
+              "$ref": "#/definitions/repo"
+            },
+            "sha": {
+              "type": "string"
+            },
+            "user": {
+              "properties": {
+                "avatar_url": {
+                  "type": "string"
+                },
+                "gravatar_id": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "integer"
+                },
+                "login": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "html_url": {
+          "type": "string"
+        },
+        "issue_url": {
+          "type": "string"
+        },
+        "merge_commit_sha": {
+          "type": "string"
+        },
+        "mergeable": {
+          "type": "boolean"
+        },
+        "merged": {
+          "type": "boolean"
+        },
+        "merged_at": {
+          "type": "string"
+        },
+        "merged_by": {
+          "properties": {
+            "avatar_url": {
+              "type": "string"
+            },
+            "gravatar_id": {
+              "type": "string"
+            },
+            "id": {
+              "type": "integer"
+            },
+            "login": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "number": {
+          "type": "integer"
+        },
+        "patch_url": {
+          "type": "string"
+        },
+        "state": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "user": {
+          "properties": {
+            "avatar_url": {
+              "type": "string"
+            },
+            "gravatar_id": {
+              "type": "string"
+            },
+            "id": {
+              "type": "integer"
+            },
+            "login": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "pullUpdate": {
+      "properties": {
+        "body": {
+          "type": "string"
+        },
+        "state": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "pulls": {
+      "items": {
+        "properties": {
+          "_links": {
+            "properties": {
+              "comments": {
+                "properties": {
+                  "href": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "html": {
+                "properties": {
+                  "href": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "review_comments": {
+                "properties": {
+                  "href": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "self": {
+                "properties": {
+                  "href": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "base": {
+            "properties": {
+              "label": {
+                "type": "string"
+              },
+              "ref": {
+                "type": "string"
+              },
+              "repo": {
+                "$ref": "#/definitions/repo"
+              },
+              "sha": {
+                "type": "string"
+              },
+              "user": {
+                "properties": {
+                  "avatar_url": {
+                    "type": "string"
+                  },
+                  "gravatar_id": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "integer"
+                  },
+                  "login": {
+                    "type": "string"
+                  },
+                  "url": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "body": {
+            "type": "string"
+          },
+          "closed_at": {
+            "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+            "type": "string"
+          },
+          "created_at": {
+            "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+            "type": "string"
+          },
+          "diff_url": {
+            "type": "string"
+          },
+          "head": {
+            "properties": {
+              "label": {
+                "type": "string"
+              },
+              "ref": {
+                "type": "string"
+              },
+              "repo": {
+                "$ref": "#/definitions/repo"
+              },
+              "sha": {
+                "type": "string"
+              },
+              "user": {
+                "properties": {
+                  "avatar_url": {
+                    "type": "string"
+                  },
+                  "gravatar_id": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "integer"
+                  },
+                  "login": {
+                    "type": "string"
+                  },
+                  "url": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "html_url": {
+            "type": "string"
+          },
+          "issue_url": {
+            "type": "string"
+          },
+          "merged_at": {
+            "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+            "type": "string"
+          },
+          "number": {
+            "type": "integer"
+          },
+          "patch_url": {
+            "type": "string"
+          },
+          "state": {
+            "enum": ["open", "closed"]
+          },
+          "title": {
+            "type": "string"
+          },
+          "updated_at": {
+            "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "user": {
+            "properties": {
+              "avatar_url": {
+                "type": "string"
+              },
+              "gravatar_id": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer"
+              },
+              "login": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "pullsComment": {
+      "properties": {
+        "_links": {
+          "properties": {
+            "html": {
+              "properties": {
+                "href": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "pull_request": {
+              "properties": {
+                "href": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "self": {
+              "properties": {
+                "href": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "body": {
+          "type": "string"
+        },
+        "commit_id": {
+          "type": "string"
+        },
+        "created_at": {
+          "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+          "type": "string"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "path": {
+          "type": "string"
+        },
+        "position": {
+          "type": "integer"
+        },
+        "updated_at": {
+          "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "user": {
+          "properties": {
+            "avatar_url": {
+              "type": "string"
+            },
+            "gravatar_id": {
+              "type": "string"
+            },
+            "id": {
+              "type": "integer"
+            },
+            "login": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "pullsCommentPost": {
+      "properties": {
+        "body": {
+          "type": "string"
+        },
+        "commit_id": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "position": {
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
+    "pullsComments": {
+      "items": {
+        "properties": {
+          "_links": {
+            "properties": {
+              "html": {
+                "properties": {
+                  "href": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "pull_request": {
+                "properties": {
+                  "href": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "self": {
+                "properties": {
+                  "href": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "body": {
+            "type": "string"
+          },
+          "commit_id": {
+            "type": "string"
+          },
+          "created_at": {
+            "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "path": {
+            "type": "string"
+          },
+          "position": {
+            "type": "integer"
+          },
+          "updated_at": {
+            "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "user": {
+            "properties": {
+              "avatar_url": {
+                "type": "string"
+              },
+              "gravatar_id": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer"
+              },
+              "login": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "pullsPost": {
+      "properties": {
+        "base": {
+          "type": "string"
+        },
+        "body": {
+          "type": "string"
+        },
+        "head": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "putSubscription": {
+      "properties": {
+        "created_at": {
+          "type": "string"
+        },
+        "ignored": {
+          "type": "boolean"
+        },
+        "reason": {
+          "type": "object"
+        },
+        "subscribed": {
+          "type": "boolean"
+        },
+        "thread_url": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "rate_limit": {
+      "properties": {
+        "rate": {
+          "properties": {
+            "limit": {
+              "type": "integer"
+            },
+            "remaining": {
+              "type": "integer"
+            },
+            "reset": {
+              "type": "integer"
+            }
+          }
+        }
+      },
+      "type": "object"
+    },
+    "ref": {
+      "items": {
+        "properties": {
+          "created_at": {
+            "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+            "type": "string"
+          },
+          "creator": {
+            "properties": {
+              "avatar_url": {
+                "type": "string"
+              },
+              "gravatar_id": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer"
+              },
+              "login": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "description": {
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "state": {
+            "type": "string"
+          },
+          "target_url": {
+            "type": "string"
+          },
+          "updated_at": {
+            "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "refStatus": {
+      "items": {
+        "properties": {
+          "commit_url": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "repository_url": {
+            "type": "string"
+          },
+          "sha": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          },
+          "statuses": {
+            "items": {
+              "properties": {
+                "context": {
+                  "type": "string"
+                },
+                "created_at": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "number"
+                },
+                "state": {
+                  "type": "string"
+                },
+                "target_url": {
+                  "type": "string"
+                },
+                "updated_at": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "refs": {
+      "items": {
+        "properties": {
+          "object": {
+            "properties": {
+              "sha": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "ref": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "refsBody": {
+      "properties": {
+        "ref": {
+          "type": "string"
+        },
+        "sha": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "release": {
+      "properties": {
+        "assets": {
+          "items": {
+            "properties": {
+              "content_type": {
+                "type": "string"
+              },
+              "created_at": {
+                "type": "string"
+              },
+              "download_count": {
+                "type": "integer"
+              },
+              "id": {
+                "type": "integer"
+              },
+              "label": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "size": {
+                "type": "integer"
+              },
+              "state": {
+                "type": "string"
+              },
+              "updated_at": {
+                "type": "string"
+              },
+              "uploader": {
+                "$ref": "#/definitions/user"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "assets_url": {
+          "type": "string"
+        },
+        "author": {
+          "$ref": "#/definitions/user"
+        },
+        "body": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string"
+        },
+        "draft": {
+          "type": "boolean"
+        },
+        "html_url": {
+          "type": "string"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "prerelease": {
+          "type": "boolean"
+        },
+        "published_at": {
+          "type": "string"
+        },
+        "tag_name": {
+          "type": "string"
+        },
+        "tarball_url": {
+          "type": "string"
+        },
+        "target_commitish": {
+          "type": "string"
+        },
+        "upload_url": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "zipball_url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "release-create": {
+      "properties": {
+        "body": {
+          "type": "string"
+        },
+        "draft": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "prerelease": {
+          "type": "boolean"
+        },
+        "tag_name": {
+          "type": "string"
+        },
+        "target_commitish": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "releases": {
+      "items": {
+        "properties": {
+          "assets": {
+            "items": {
+              "properties": {
+                "content_type": {
+                  "type": "string"
+                },
+                "created_at": {
+                  "type": "string"
+                },
+                "download_count": {
+                  "type": "integer"
+                },
+                "id": {
+                  "type": "integer"
+                },
+                "label": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "size": {
+                  "type": "integer"
+                },
+                "state": {
+                  "type": "string"
+                },
+                "updated_at": {
+                  "type": "string"
+                },
+                "uploader": {
+                  "$ref": "#/definitions/user"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "assets_url": {
+            "type": "string"
+          },
+          "author": {
+            "$ref": "#/definitions/user"
+          },
+          "body": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "draft": {
+            "type": "boolean"
+          },
+          "html_url": {
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "prerelease": {
+            "type": "boolean"
+          },
+          "published_at": {
+            "type": "string"
+          },
+          "tag_name": {
+            "type": "string"
+          },
+          "tarball_url": {
+            "type": "string"
+          },
+          "target_commitish": {
+            "type": "string"
+          },
+          "upload_url": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "zipball_url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "repo": {
+      "properties": {
+        "clone_url": {
+          "type": "string"
+        },
+        "created_at": {
+          "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "fork": {
+          "type": "boolean"
+        },
+        "forks": {
+          "type": "integer"
+        },
+        "forks_count": {
+          "type": "integer"
+        },
+        "full_name": {
+          "type": "string"
+        },
+        "git_url": {
+          "type": "string"
+        },
+        "has_downloads": {
+          "type": "boolean"
+        },
+        "has_issues": {
+          "type": "boolean"
+        },
+        "has_wiki": {
+          "type": "boolean"
+        },
+        "homepage": {
+          "type": "string"
+        },
+        "html_url": {
+          "type": "string"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "language": {
+          "type": "string"
+        },
+        "master_branch": {
+          "type": "string"
+        },
+        "mirror_url": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "open_issues": {
+          "type": "integer"
+        },
+        "open_issues_count": {
+          "type": "integer"
+        },
+        "organization": {
+          "$ref": "#/definitions/organization"
+        },
+        "owner": {
+          "$ref": "#/definitions/actor"
+        },
+        "parent": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/repo"
+            },
+            {
+              "description": "Is present when the repo is a fork. Parent is the repo this repo was forked from."
+            }
+          ]
+        },
+        "private": {
+          "type": "boolean"
+        },
+        "pushed_at": {
+          "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+          "type": "string"
+        },
+        "size": {
+          "type": "integer"
+        },
+        "source": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/repo"
+            },
+            {
+              "description": "Is present when the repo is a fork. Source is the ultimate source for the network."
+            }
+          ]
+        },
+        "ssh_url": {
+          "type": "string"
+        },
+        "svn_url": {
+          "type": "string"
+        },
+        "updated_at": {
+          "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "watchers": {
+          "type": "integer"
+        },
+        "watchers_count": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "repo-deployments": {
+      "items": {
+        "properties": {
+          "created_at": {
+            "type": "string"
+          },
+          "creator": {
+            "$ref": "#/definitions/user"
+          },
+          "description": {
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "payload": {
+            "type": "string"
+          },
+          "sha": {
+            "type": "string"
+          },
+          "statuses_url": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "repoComments": {
+      "items": {
+        "properties": {
+          "body": {
+            "type": "string"
+          },
+          "commit_id": {
+            "type": "string"
+          },
+          "created_at": {
+            "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+            "type": "string"
+          },
+          "html_url": {
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "line": {
+            "type": "integer"
+          },
+          "path": {
+            "type": "string"
+          },
+          "position": {
+            "type": "integer"
+          },
+          "updated_at": {
+            "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "user": {
+            "$ref": "#/definitions/user"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "repoCommit": {
+      "properties": {
+        "author": {
+          "properties": {
+            "date": {
+              "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+              "type": "string"
+            },
+            "email": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "committer": {
+          "properties": {
+            "date": {
+              "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+              "type": "string"
+            },
+            "email": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "message": {
+          "type": "string"
+        },
+        "parents": {
+          "items": {
+            "properties": {
+              "sha": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "sha": {
+          "type": "string"
+        },
+        "tree": {
+          "properties": {
+            "sha": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "repoCommitBody": {
+      "properties": {
+        "author": {
+          "properties": {
+            "date": {
+              "type": "string"
+            },
+            "email": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "message": {
+          "type": "string"
+        },
+        "parents": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "tree": {
+          "type": "string"
+        }
+      },
+      "required": ["message", "parents", "tree"],
+      "type": "object"
+    },
+    "repoEdit": {
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "has_downloads": {
+          "type": "boolean"
+        },
+        "has_issues": {
+          "type": "boolean"
+        },
+        "has_wiki": {
+          "type": "boolean"
+        },
+        "homepage": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "private": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "repos": {
+      "items": {
+        "$ref": "#/definitions/repo"
+      },
+      "type": "array"
+    },
+    "search-code": {
+      "properties": {
+        "items": {
+          "items": {
+            "properties": {
+              "git_url": {
+                "type": "string"
+              },
+              "html_url": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "path": {
+                "type": "string"
+              },
+              "repository": {
+                "properties": {
+                  "archive_url": {
+                    "type": "string"
+                  },
+                  "assignees_url": {
+                    "type": "string"
+                  },
+                  "blobs_url": {
+                    "type": "string"
+                  },
+                  "branches_url": {
+                    "type": "string"
+                  },
+                  "collaborators_url": {
+                    "type": "string"
+                  },
+                  "comments_url": {
+                    "type": "string"
+                  },
+                  "commits_url": {
+                    "type": "string"
+                  },
+                  "compare_url": {
+                    "type": "string"
+                  },
+                  "contents_url": {
+                    "type": "string"
+                  },
+                  "contributors_url": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "downloads_url": {
+                    "type": "string"
+                  },
+                  "events_url": {
+                    "type": "string"
+                  },
+                  "fork": {
+                    "type": "boolean"
+                  },
+                  "forks_url": {
+                    "type": "string"
+                  },
+                  "full_name": {
+                    "type": "string"
+                  },
+                  "git_commits_url": {
+                    "type": "string"
+                  },
+                  "git_refs_url": {
+                    "type": "string"
+                  },
+                  "git_tags_url": {
+                    "type": "string"
+                  },
+                  "hooks_url": {
+                    "type": "string"
+                  },
+                  "html_url": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "integer"
+                  },
+                  "issue_comment_url": {
+                    "type": "string"
+                  },
+                  "issue_events_url": {
+                    "type": "string"
+                  },
+                  "issues_url": {
+                    "type": "string"
+                  },
+                  "keys_url": {
+                    "type": "string"
+                  },
+                  "labels_url": {
+                    "type": "string"
+                  },
+                  "languages_url": {
+                    "type": "string"
+                  },
+                  "merges_url": {
+                    "type": "string"
+                  },
+                  "milestones_url": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "notifications_url": {
+                    "type": "string"
+                  },
+                  "owner": {
+                    "$ref": "#/definitions/actor"
+                  },
+                  "private": {
+                    "type": "boolean"
+                  },
+                  "pulls_url": {
+                    "type": "string"
+                  },
+                  "stargazers_url": {
+                    "type": "string"
+                  },
+                  "statuses_url": {
+                    "type": "string"
+                  },
+                  "subscribers_url": {
+                    "type": "string"
+                  },
+                  "subscription_url": {
+                    "type": "string"
+                  },
+                  "tags_url": {
+                    "type": "string"
+                  },
+                  "teams_url": {
+                    "type": "string"
+                  },
+                  "trees_url": {
+                    "type": "string"
+                  },
+                  "url": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "score": {
+                "type": "number"
+              },
+              "sha": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "total_count": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "search-issues": {
+      "properties": {
+        "items": {
+          "items": {
+            "properties": {
+              "assignee": {
+                "type": "null"
+              },
+              "body": {
+                "type": "string"
+              },
+              "closed_at": {
+                "type": "null"
+              },
+              "comments": {
+                "type": "integer"
+              },
+              "comments_url": {
+                "type": "string"
+              },
+              "created_at": {
+                "type": "string"
+              },
+              "events_url": {
+                "type": "string"
+              },
+              "html_url": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer"
+              },
+              "labels": {
+                "items": {
+                  "properties": {
+                    "color": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "url": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "labels_url": {
+                "type": "string"
+              },
+              "milestone": {
+                "type": "null"
+              },
+              "number": {
+                "type": "integer"
+              },
+              "pull_request": {
+                "properties": {
+                  "diff_url": {
+                    "type": "null"
+                  },
+                  "html_url": {
+                    "type": "null"
+                  },
+                  "patch_url": {
+                    "type": "null"
+                  }
+                },
+                "type": "object"
+              },
+              "score": {
+                "type": "number"
+              },
+              "state": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "updated_at": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              },
+              "user": {
+                "$ref": "#/definitions/user"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "total_count": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "search-issues-by-keyword": {
+      "properties": {
+        "issues": {
+          "items": {
+            "properties": {
+              "body": {
+                "type": "string"
+              },
+              "comments": {
+                "type": "integer"
+              },
+              "created_at": {
+                "type": "string"
+              },
+              "gravatar_id": {
+                "type": "string"
+              },
+              "html_url": {
+                "type": "string"
+              },
+              "labels": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "number": {
+                "type": "integer"
+              },
+              "position": {
+                "type": "integer"
+              },
+              "state": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "updated_at": {
+                "type": "string"
+              },
+              "user": {
+                "type": "string"
+              },
+              "votes": {
+                "type": "integer"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "search-repositories": {
+      "properties": {
+        "items": {
+          "items": {
+            "$ref": "#/definitions/repo"
+          },
+          "type": "array"
+        },
+        "total_count": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "search-repositories-by-keyword": {
+      "properties": {
+        "repositories": {
+          "items": {
+            "$ref": "#/definitions/repo"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "search-user-by-email": {
+      "properties": {
+        "user": {
+          "$ref": "#/definitions/user"
+        }
+      },
+      "type": "object"
+    },
+    "search-users": {
+      "properties": {
+        "items": {
+          "$ref": "#/definitions/users"
+        },
+        "total_count": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "search-users-by-keyword": {
+      "properties": {
+        "users": {
+          "$ref": "#/definitions/users"
+        }
+      },
+      "type": "object"
+    },
+    "subscription": {
+      "properties": {
+        "created_at": {
+          "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+          "type": "string"
+        },
+        "ignored": {
+          "type": "boolean"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "repository_url": {
+          "type": "string"
+        },
+        "subscribed": {
+          "type": "boolean"
+        },
+        "thread_url": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "subscriptionBody": {
+      "properties": {
+        "ignored": {
+          "type": "boolean"
+        },
+        "subscribed": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "tag": {
+      "properties": {
+        "message": {
+          "description": "String of the tag message.",
+          "type": "string"
+        },
+        "object": {
+          "properties": {
+            "sha": {
+              "type": "string"
+            },
+            "type": {
+              "description": "String of the type of the tagged object. Normally this is a commit but it can also be a tree or a blob.",
+              "enum": ["commit", "tree", "blob"]
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "sha": {
+          "type": "string"
+        },
+        "tag": {
+          "description": "The tag's name. This is typically a version (e.g., \"v0.0.1\").",
+          "type": "string"
+        },
+        "tagger": {
+          "properties": {
+            "date": {
+              "description": "Timestamp of when this object was tagged, in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+              "type": "string"
+            },
+            "email": {
+              "description": "String of the email of the author of the tag.",
+              "type": "string"
+            },
+            "name": {
+              "description": "String of the name of the author of the tag.",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "tagBody": {
+      "properties": {
+        "message": {
+          "description": "String of the tag message.",
+          "type": "string"
+        },
+        "object": {
+          "description": "String of the SHA of the git object this is tagging.",
+          "type": "string"
+        },
+        "tag": {
+          "description": "The tag's name. This is typically a version (e.g., \"v0.0.1\").",
+          "type": "string"
+        },
+        "tagger": {
+          "properties": {
+            "date": {
+              "description": "Timestamp of when this object was tagged, in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+              "type": "string"
+            },
+            "email": {
+              "description": "String of the email of the author of the tag.",
+              "type": "string"
+            },
+            "name": {
+              "description": "String of the name of the author of the tag.",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "type": {
+          "description": "String of the type of the object we’re tagging. Normally this is a commit but it can also be a tree or a blob.",
+          "enum": ["commit", "tree", "blob"]
+        }
+      },
+      "required": ["tag", "message", "object", "type", "tagger"],
+      "type": "object"
+    },
+    "tags": {
+      "items": {
+        "$ref": "#/definitions/tag"
+      },
+      "type": "array"
+    },
+    "team": {
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "members_count": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "permission": {
+          "type": "string"
+        },
+        "repos_count": {
+          "type": "integer"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "teamMembership": {
+      "properties": {
+        "state": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "teamRepos": {
+      "$ref": "#/definitions/repos"
+    },
+    "teams": {
+      "items": {
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "teams-list": {
+      "items": {
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "members_count": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "organization": {
+            "properties": {
+              "avatar_url": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer"
+              },
+              "login": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "permission": {
+            "type": "string"
+          },
+          "repos_count": {
+            "type": "integer"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "tree": {
+      "properties": {
+        "sha": {
+          "type": "string"
+        },
+        "tree": {
+          "items": {
+            "properties": {
+              "mode": {
+                "description": "One of 100644 for file (blob), 100755 for executable (blob), 040000 for subdirectory (tree), 160000 for submodule (commit) or 120000 for a blob that specifies the path of a symlink.",
+                "enum": ["100644", "100755", "040000", "160000", "120000"],
+                "type": "string"
+              },
+              "path": {
+                "type": "string"
+              },
+              "sha": {
+                "description": "SHA1 checksum ID of the object in the tree.",
+                "type": "string"
+              },
+              "size": {
+                "type": "integer"
+              },
+              "type": {
+                "enum": ["blob", "tree", "commit"],
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "trees": {
+      "properties": {
+        "base_tree": {
+          "type": "string"
+        },
+        "sha": {
+          "description": "SHA1 checksum ID of the object in the tree.",
+          "type": "string"
+        },
+        "tree": {
+          "items": {
+            "$ref": "#/definitions/tree"
+          },
+          "type": "array"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "user": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/actor"
+        },
+        {
+          "description": "A GitHub user"
+        }
+      ],
+      "type": "object"
+    },
+    "user-emails": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "user-keys-keyId": {
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "key": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "user-keys-post": {
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "user-update": {
+      "properties": {
+        "bio": {
+          "type": "string"
+        },
+        "blog": {
+          "type": "string"
+        },
+        "company": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "hireable": {
+          "type": "boolean"
+        },
+        "location": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "users": {
+      "items": {
+        "$ref": "#/definitions/user"
+      },
+      "type": "array"
+    }
+  }
+}

--- a/tests/spec/js/test.js
+++ b/tests/spec/js/test.js
@@ -1,0 +1,20 @@
+const { generateApi } = require("../../../src");
+const { resolve } = require("path");
+const validateGeneratedModule = require("../../helpers/validateGeneratedModule");
+const createSchemasInfos = require("../../helpers/createSchemaInfos");
+
+const schemas = createSchemasInfos({ absolutePathToSchemas: resolve(__dirname, "./") });
+
+schemas.forEach(({ absolutePath, apiFileName }) => {
+  console.info("apiFileName", apiFileName);
+
+  generateApi({
+    name: apiFileName,
+    input: absolutePath,
+    output: resolve(__dirname, "./"),
+    toJS: true,
+  }).catch((e) => {
+    console.error("js option test failed.");
+    throw e;
+  });
+});

--- a/tests/spec/noClient/schema.ts
+++ b/tests/spec/noClient/schema.ts
@@ -1,6 +1,5 @@
 /* tslint:disable */
 /* eslint-disable */
-
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/spec/responses/schema.ts
+++ b/tests/spec/responses/schema.ts
@@ -1,6 +1,5 @@
 /* tslint:disable */
 /* eslint-disable */
-
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/spec/responses/schema.ts
+++ b/tests/spec/responses/schema.ts
@@ -96,7 +96,7 @@ enum BodyType {
 class HttpClient<SecurityDataType> {
   public baseUrl: string = "https://6-dot-authentiqio.appspot.com/";
   private securityData: SecurityDataType = null as any;
-  private securityWorker: ApiConfig<SecurityDataType>["securityWorker"] = (() => {}) as any;
+  private securityWorker: null | ApiConfig<SecurityDataType>["securityWorker"] = null;
 
   private baseApiParams: RequestParams = {
     credentials: "same-origin",
@@ -107,10 +107,8 @@ class HttpClient<SecurityDataType> {
     referrerPolicy: "no-referrer",
   };
 
-  constructor({ baseUrl, baseApiParams, securityWorker }: ApiConfig<SecurityDataType> = {}) {
-    this.baseUrl = baseUrl || this.baseUrl;
-    this.baseApiParams = baseApiParams || this.baseApiParams;
-    this.securityWorker = securityWorker || this.securityWorker;
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
   }
 
   public setSecurityData = (data: SecurityDataType) => {
@@ -182,17 +180,22 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): TPromise<HttpResponse<T, E>> =>
-    fetch(`${this.baseUrl}${path}`, {
-      // @ts-ignore
-      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+  ): TPromise<HttpResponse<T, E>> => {
+    const requestUrl = `${this.baseUrl}${path}`;
+    const secureOptions =
+      (secureByDefault || secure) && this.securityWorker ? this.securityWorker(this.securityData) : {};
+    const requestOptions = {
+      ...this.mergeRequestOptions(params, secureOptions),
       method,
       body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
-    }).then(async (response) => {
+    };
+
+    return fetch(requestUrl, requestOptions).then(async (response) => {
       const data = await this.safeParseResponse<T, E>(response);
       if (!response.ok) throw data;
       return data;
     });
+  };
 }
 
 /**

--- a/tests/spec/routeTypes/schema.ts
+++ b/tests/spec/routeTypes/schema.ts
@@ -1,6 +1,5 @@
 /* tslint:disable */
 /* eslint-disable */
-
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/spec/routeTypes/schema.ts
+++ b/tests/spec/routeTypes/schema.ts
@@ -4204,11 +4204,16 @@ export type RequestParams = Omit<RequestInit, "body" | "method"> & {
 
 export type RequestQueryParamsType = Record<string | number, any>;
 
-type ApiConfig<SecurityDataType> = {
+interface ApiConfig<SecurityDataType> {
   baseUrl?: string;
   baseApiParams?: RequestParams;
   securityWorker?: (securityData: SecurityDataType) => RequestParams;
-};
+}
+
+interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+  data: D | null;
+  error: E | null;
+}
 
 enum BodyType {
   Json,
@@ -4275,11 +4280,26 @@ class HttpClient<SecurityDataType> {
     };
   }
 
-  private safeParseResponse = <T = any, E = any>(response: Response): Promise<T> =>
-    response
+  private safeParseResponse = <T = any, E = any>(response: Response): Promise<HttpResponse<T, E>> => {
+    const r = response.clone() as HttpResponse<T, E>;
+    r.data = null;
+    r.error = null;
+
+    return response
       .json()
-      .then((data) => data)
-      .catch((e) => response.text);
+      .then((data) => {
+        if (r.ok) {
+          r.data = data;
+        } else {
+          r.error = data;
+        }
+        return r;
+      })
+      .catch((e) => {
+        r.error = e;
+        return r;
+      });
+  };
 
   public request = <T = any, E = any>(
     path: string,
@@ -4288,7 +4308,7 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<T> =>
+  ): Promise<HttpResponse<T>> =>
     fetch(`${this.baseUrl}${path}`, {
       // @ts-ignore
       ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),

--- a/tests/spec/routeTypes/schema.ts
+++ b/tests/spec/routeTypes/schema.ts
@@ -4222,7 +4222,7 @@ enum BodyType {
 class HttpClient<SecurityDataType> {
   public baseUrl: string = "https://api.github.com/";
   private securityData: SecurityDataType = null as any;
-  private securityWorker: ApiConfig<SecurityDataType>["securityWorker"] = (() => {}) as any;
+  private securityWorker: null | ApiConfig<SecurityDataType>["securityWorker"] = null;
 
   private baseApiParams: RequestParams = {
     credentials: "same-origin",
@@ -4233,10 +4233,8 @@ class HttpClient<SecurityDataType> {
     referrerPolicy: "no-referrer",
   };
 
-  constructor({ baseUrl, baseApiParams, securityWorker }: ApiConfig<SecurityDataType> = {}) {
-    this.baseUrl = baseUrl || this.baseUrl;
-    this.baseApiParams = baseApiParams || this.baseApiParams;
-    this.securityWorker = securityWorker || this.securityWorker;
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
   }
 
   public setSecurityData = (data: SecurityDataType) => {
@@ -4308,17 +4306,22 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<HttpResponse<T>> =>
-    fetch(`${this.baseUrl}${path}`, {
-      // @ts-ignore
-      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+  ): Promise<HttpResponse<T>> => {
+    const requestUrl = `${this.baseUrl}${path}`;
+    const secureOptions =
+      (secureByDefault || secure) && this.securityWorker ? this.securityWorker(this.securityData) : {};
+    const requestOptions = {
+      ...this.mergeRequestOptions(params, secureOptions),
       method,
       body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
-    }).then(async (response) => {
+    };
+
+    return fetch(requestUrl, requestOptions).then(async (response) => {
       const data = await this.safeParseResponse<T, E>(response);
       if (!response.ok) throw data;
       return data;
     });
+  };
 }
 
 /**

--- a/tests/spec/specProperty/schema.ts
+++ b/tests/spec/specProperty/schema.ts
@@ -1,6 +1,5 @@
 /* tslint:disable */
 /* eslint-disable */
-
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/spec/specProperty/schema.ts
+++ b/tests/spec/specProperty/schema.ts
@@ -87,11 +87,16 @@ export type RequestParams = Omit<RequestInit, "body" | "method"> & {
 
 export type RequestQueryParamsType = Record<string | number, any>;
 
-type ApiConfig<SecurityDataType> = {
+interface ApiConfig<SecurityDataType> {
   baseUrl?: string;
   baseApiParams?: RequestParams;
   securityWorker?: (securityData: SecurityDataType) => RequestParams;
-};
+}
+
+interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+  data: D | null;
+  error: E | null;
+}
 
 enum BodyType {
   Json,
@@ -158,11 +163,26 @@ class HttpClient<SecurityDataType> {
     };
   }
 
-  private safeParseResponse = <T = any, E = any>(response: Response): Promise<T> =>
-    response
+  private safeParseResponse = <T = any, E = any>(response: Response): Promise<HttpResponse<T, E>> => {
+    const r = response.clone() as HttpResponse<T, E>;
+    r.data = null;
+    r.error = null;
+
+    return response
       .json()
-      .then((data) => data)
-      .catch((e) => response.text);
+      .then((data) => {
+        if (r.ok) {
+          r.data = data;
+        } else {
+          r.error = data;
+        }
+        return r;
+      })
+      .catch((e) => {
+        r.error = e;
+        return r;
+      });
+  };
 
   public request = <T = any, E = any>(
     path: string,
@@ -171,7 +191,7 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<T> =>
+  ): Promise<HttpResponse<T>> =>
     fetch(`${this.baseUrl}${path}`, {
       // @ts-ignore
       ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),

--- a/tests/spec/specProperty/schema.ts
+++ b/tests/spec/specProperty/schema.ts
@@ -105,7 +105,7 @@ enum BodyType {
 class HttpClient<SecurityDataType> {
   public baseUrl: string = "http://petstore.swagger.io/api";
   private securityData: SecurityDataType = null as any;
-  private securityWorker: ApiConfig<SecurityDataType>["securityWorker"] = (() => {}) as any;
+  private securityWorker: null | ApiConfig<SecurityDataType>["securityWorker"] = null;
 
   private baseApiParams: RequestParams = {
     credentials: "same-origin",
@@ -116,10 +116,8 @@ class HttpClient<SecurityDataType> {
     referrerPolicy: "no-referrer",
   };
 
-  constructor({ baseUrl, baseApiParams, securityWorker }: ApiConfig<SecurityDataType> = {}) {
-    this.baseUrl = baseUrl || this.baseUrl;
-    this.baseApiParams = baseApiParams || this.baseApiParams;
-    this.securityWorker = securityWorker || this.securityWorker;
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
   }
 
   public setSecurityData = (data: SecurityDataType) => {
@@ -191,17 +189,22 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<HttpResponse<T>> =>
-    fetch(`${this.baseUrl}${path}`, {
-      // @ts-ignore
-      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+  ): Promise<HttpResponse<T>> => {
+    const requestUrl = `${this.baseUrl}${path}`;
+    const secureOptions =
+      (secureByDefault || secure) && this.securityWorker ? this.securityWorker(this.securityData) : {};
+    const requestOptions = {
+      ...this.mergeRequestOptions(params, secureOptions),
       method,
       body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
-    }).then(async (response) => {
+    };
+
+    return fetch(requestUrl, requestOptions).then(async (response) => {
       const data = await this.safeParseResponse<T, E>(response);
       if (!response.ok) throw data;
       return data;
     });
+  };
 }
 
 /**

--- a/tests/spec/templates/schema.ts
+++ b/tests/spec/templates/schema.ts
@@ -12,20 +12,26 @@ export type RequestParams = Omit<RequestInit, "body" | "method"> & {
   secure?: boolean;
 };
 
-type ApiConfig<SecurityDataType> = {
+interface ApiConfig<SecurityDataType> {
   baseUrl?: string;
   baseApiParams?: RequestParams;
-  securityWorker?: (securityData: SecurityDataType) => RequestParams;
-};
+  securityWorker?: (securityData: SecurityDataType) => Promise<RequestParams>;
+  CUSTOM_API_CONFIG_PARAM?: string;
+}
 
-const enum BodyType {
+interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+  data: D | null;
+  error: E | null;
+}
+
+enum BodyType {
   Json,
 }
 
 class HttpClient<SecurityDataType> {
   public baseUrl: string = "http://petstore.swagger.io/api";
   private securityData: SecurityDataType = null as any;
-  private securityWorker: ApiConfig<SecurityDataType>["securityWorker"] = (() => {}) as any;
+  private securityWorker: null | ApiConfig<SecurityDataType>["securityWorker"] = null;
 
   private baseApiParams: RequestParams = {
     credentials: "same-origin",
@@ -36,10 +42,8 @@ class HttpClient<SecurityDataType> {
     referrerPolicy: "no-referrer",
   };
 
-  constructor({ baseUrl, baseApiParams, securityWorker }: ApiConfig<SecurityDataType> = {}) {
-    this.baseUrl = baseUrl || this.baseUrl;
-    this.baseApiParams = baseApiParams || this.baseApiParams;
-    this.securityWorker = securityWorker || this.securityWorker;
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
   }
 
   public setSecurityData = (data: SecurityDataType) => {
@@ -63,34 +67,65 @@ class HttpClient<SecurityDataType> {
     };
   }
 
-  private safeParseResponse = <T = any, E = any>(response: Response): Promise<T> =>
-    response
-      .json()
-      .then((data) => data)
-      .catch((e) => response.text);
+  private safeParseResponse = <T = any, E = any>(response: Response): Promise<HttpResponse<T, E>> => {
+    const r = response.clone() as HttpResponse<T, E>;
+    r.data = null;
+    r.error = null;
 
-  public request = <T = any, E = any>(
+    return response
+      .json()
+      .then((data) => {
+        if (r.ok) {
+          r.data = data;
+        } else {
+          r.error = data;
+        }
+        return r;
+      })
+      .catch((e) => {
+        r.error = e;
+        return r;
+      });
+  };
+
+  public request = async <T = any, E = any>(
     path: string,
     method: string,
     { secure, ...params }: RequestParams = {},
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<T> =>
-    fetch(`${this.baseUrl}${path}`, {
-      // @ts-ignore
-      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+  ): Promise<HttpResponse<T>> => {
+    const requestUrl = `${this.baseUrl}${path}`;
+    const secureOptions =
+      (secureByDefault || secure) && this.securityWorker ? await this.securityWorker(this.securityData) : {};
+    const requestOptions = {
+      ...this.mergeRequestOptions(params, secureOptions),
       method,
       body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
-    }).then(async (response) => {
+    };
+
+    return fetch(requestUrl, requestOptions).then(async (response) => {
       const data = await this.safeParseResponse<T, E>(response);
       if (!response.ok) throw data;
       return data;
     });
+  };
 }
 
+/**
+ * @title Swagger Petstore
+ * @version 1.0.0
+ * @baseUrl http://petstore.swagger.io/api
+ * A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification
+ */
 export class Api<SecurityDataType = any> extends HttpClient<SecurityDataType> {
   pets = {
+    /**
+     * @name petsList
+     * @request GET:/pets
+     * @description Returns all pets from the system that the user has access to
+     */
     petsList: (params?: RequestParams) => this.request<Pet[], any>(`/pets`, "GET", params),
   };
 }

--- a/tests/spec/templates/spec_templates/client.mustache
+++ b/tests/spec/templates/spec_templates/client.mustache
@@ -7,13 +7,27 @@ export type RequestParams = Omit<RequestInit, "body" | "method"> & {
 export type RequestQueryParamsType = Record<string | number, any>;
 {{/hasQueryRoutes}}
 
-type ApiConfig<{{#apiConfig.generic}}{{name}},{{/apiConfig.generic}}> = {
-{{#apiConfig.props}}
-  {{name}}{{#optional}}?{{/optional}}: {{type}},
-{{/apiConfig.props}}
+interface ApiConfig<{{#apiConfig.generic}}{{name}},{{/apiConfig.generic}}> {
+  baseUrl?: string;
+  baseApiParams?: RequestParams;
+  securityWorker?: (securityData: SecurityDataType) => Promise<RequestParams>;
+  CUSTOM_API_CONFIG_PARAM?: string;
 }
 
-const enum BodyType {
+{{#generateResponses}}
+/** Overrided Promise type. Needs for additional typings of `.catch` callback */
+type TPromise<ResolveType, RejectType = any> = Omit<Promise<ResolveType>, "then" | "catch"> & {
+  then<TResult1 = ResolveType, TResult2 = never>(onfulfilled?: ((value: ResolveType) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: RejectType) => TResult2 | PromiseLike<TResult2>) | undefined | null): TPromise<TResult1 | TResult2, RejectType>;
+  catch<TResult = never>(onrejected?: ((reason: RejectType) => TResult | PromiseLike<TResult>) | undefined | null): TPromise<ResolveType | TResult, RejectType>;
+}
+{{/generateResponses}}
+
+interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+  data: D | null;
+  error: E | null;
+}
+
+enum BodyType {
   Json,
   {{#hasFormDataRoutes}}
   FormData,
@@ -23,7 +37,7 @@ const enum BodyType {
 class HttpClient<{{#apiConfig.generic}}{{name}},{{/apiConfig.generic}}> {
   public baseUrl: string = "{{apiConfig.baseUrl}}";
   private securityData: SecurityDataType = (null as any);
-  private securityWorker: ApiConfig<{{#apiConfig.generic}}{{name}},{{/apiConfig.generic}}>["securityWorker"] = (() => {}) as any
+  private securityWorker: null | ApiConfig<{{#apiConfig.generic}}{{name}},{{/apiConfig.generic}}>["securityWorker"] = null;
   
   private baseApiParams: RequestParams = {
     credentials: 'same-origin',
@@ -34,10 +48,8 @@ class HttpClient<{{#apiConfig.generic}}{{name}},{{/apiConfig.generic}}> {
     referrerPolicy: 'no-referrer',
   }
 
-  constructor({ {{#apiConfig.props}}{{name}},{{/apiConfig.props}} }: ApiConfig<{{#apiConfig.generic}}{{name}},{{/apiConfig.generic}}> = {}) {
-  {{#apiConfig.props}}
-    this.{{name}} = {{name}} || this.{{name}};
-  {{/apiConfig.props}}
+  constructor(apiConfig: ApiConfig<{{#apiConfig.generic}}{{name}},{{/apiConfig.generic}}> = {}) {
+    Object.assign(this, apiConfig);
   }
 
   public setSecurityData = (data: SecurityDataType) => {
@@ -84,36 +96,69 @@ class HttpClient<{{#apiConfig.generic}}{{name}},{{/apiConfig.generic}}> {
     }
   }
   
-  private safeParseResponse = <T = any, E = any>(response: Response): {{#generateResponses}}TPromise<T, E>{{/generateResponses}}{{^generateResponses}}Promise<T>{{/generateResponses}} =>
-    response.json()
-      .then(data => data)
-      .catch(e => response.text);
+  private safeParseResponse = <T = any, E = any>(response: Response): Promise<HttpResponse<T, E>> => {
+    const r = response.clone() as HttpResponse<T, E>;
+    r.data = null;
+    r.error = null;
+
+    return response
+      .json()
+      .then((data) => {
+        if (r.ok) {
+          r.data = data;
+        } else {
+          r.error = data;
+        }
+        return r;
+      })
+      .catch((e) => {
+        r.error = e;
+        return r;
+      });
+  }
   
-  public request = <T = any, E = any>(
+  public request = async <T = any, E = any>(
     path: string,
     method: string,
     { secure, ...params }: RequestParams = {},
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): {{#generateResponses}}TPromise<T, E>{{/generateResponses}}{{^generateResponses}}Promise<T>{{/generateResponses}} =>
-    fetch(`${this.baseUrl}${path}`, {
-      // @ts-ignore
-      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+  ): {{#generateResponses}}TPromise<HttpResponse<T, E>>{{/generateResponses}}{{^generateResponses}}Promise<HttpResponse<T>>{{/generateResponses}} => {
+    const requestUrl = `${this.baseUrl}${path}`;
+    const secureOptions = (secureByDefault || secure) && this.securityWorker ? await this.securityWorker(this.securityData) : {};
+    const requestOptions = {
+      ...this.mergeRequestOptions(params, secureOptions),
       method,
       body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
-    }).then(async response => {
+    }
+
+    return fetch(requestUrl, requestOptions).then(async response => {
       const data = await this.safeParseResponse<T, E>(response);
       if (!response.ok) throw data
       return data
     })
+  }
 }
 
+{{#apiConfig.hasDescription}}
+/**
+{{#apiConfig.description}}
+ * {{.}}
+{{/apiConfig.description}}
+ */
+{{/apiConfig.hasDescription}}
 export class Api<{{#apiConfig.generic}}{{name}}{{#defaultValue}} = {{.}}{{/defaultValue}},{{/apiConfig.generic}}> extends HttpClient<{{#apiConfig.generic}}{{name}},{{/apiConfig.generic}}>{
 {{#routes}}
 
   {{#outOfModule}}
 
+
+  /**
+  {{#comments}}
+   * {{.}}
+  {{/comments}}
+   */
   {{name}} = ({{#routeArgs}}{{name}}{{#optional}}?{{/optional}}: {{type}}, {{/routeArgs}}) =>
     this.request<{{returnType}}, {{errorReturnType}}>({{requestMethodContent}})
   {{/outOfModule}}
@@ -122,6 +167,12 @@ export class Api<{{#apiConfig.generic}}{{name}}{{#defaultValue}} = {{.}}{{/defau
   {{moduleName}} = {
     {{#routes}}
 
+
+    /**
+    {{#comments}}
+     * {{.}}
+    {{/comments}}
+     */
     {{name}}: ({{#routeArgs}}{{name}}{{#optional}}?{{/optional}}: {{type}}, {{/routeArgs}}) =>
       this.request<{{returnType}}, {{errorReturnType}}>({{requestMethodContent}}),
     {{/routes}}

--- a/tests/spec/unionEnums/schema.ts
+++ b/tests/spec/unionEnums/schema.ts
@@ -1,6 +1,5 @@
 /* tslint:disable */
 /* eslint-disable */
-
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/spec/unionEnums/schema.ts
+++ b/tests/spec/unionEnums/schema.ts
@@ -35,7 +35,7 @@ enum BodyType {
 class HttpClient<SecurityDataType> {
   public baseUrl: string = "http://localhost:8080/api/v1";
   private securityData: SecurityDataType = null as any;
-  private securityWorker: ApiConfig<SecurityDataType>["securityWorker"] = (() => {}) as any;
+  private securityWorker: null | ApiConfig<SecurityDataType>["securityWorker"] = null;
 
   private baseApiParams: RequestParams = {
     credentials: "same-origin",
@@ -46,10 +46,8 @@ class HttpClient<SecurityDataType> {
     referrerPolicy: "no-referrer",
   };
 
-  constructor({ baseUrl, baseApiParams, securityWorker }: ApiConfig<SecurityDataType> = {}) {
-    this.baseUrl = baseUrl || this.baseUrl;
-    this.baseApiParams = baseApiParams || this.baseApiParams;
-    this.securityWorker = securityWorker || this.securityWorker;
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
   }
 
   public setSecurityData = (data: SecurityDataType) => {
@@ -101,17 +99,22 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<HttpResponse<T>> =>
-    fetch(`${this.baseUrl}${path}`, {
-      // @ts-ignore
-      ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),
+  ): Promise<HttpResponse<T>> => {
+    const requestUrl = `${this.baseUrl}${path}`;
+    const secureOptions =
+      (secureByDefault || secure) && this.securityWorker ? this.securityWorker(this.securityData) : {};
+    const requestOptions = {
+      ...this.mergeRequestOptions(params, secureOptions),
       method,
       body: body ? this.bodyFormatters[bodyType || BodyType.Json](body) : null,
-    }).then(async (response) => {
+    };
+
+    return fetch(requestUrl, requestOptions).then(async (response) => {
       const data = await this.safeParseResponse<T, E>(response);
       if (!response.ok) throw data;
       return data;
     });
+  };
 }
 
 /**

--- a/tests/spec/unionEnums/schema.ts
+++ b/tests/spec/unionEnums/schema.ts
@@ -17,11 +17,16 @@ export type RequestParams = Omit<RequestInit, "body" | "method"> & {
   secure?: boolean;
 };
 
-type ApiConfig<SecurityDataType> = {
+interface ApiConfig<SecurityDataType> {
   baseUrl?: string;
   baseApiParams?: RequestParams;
   securityWorker?: (securityData: SecurityDataType) => RequestParams;
-};
+}
+
+interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+  data: D | null;
+  error: E | null;
+}
 
 enum BodyType {
   Json,
@@ -68,11 +73,26 @@ class HttpClient<SecurityDataType> {
     };
   }
 
-  private safeParseResponse = <T = any, E = any>(response: Response): Promise<T> =>
-    response
+  private safeParseResponse = <T = any, E = any>(response: Response): Promise<HttpResponse<T, E>> => {
+    const r = response.clone() as HttpResponse<T, E>;
+    r.data = null;
+    r.error = null;
+
+    return response
       .json()
-      .then((data) => data)
-      .catch((e) => response.text);
+      .then((data) => {
+        if (r.ok) {
+          r.data = data;
+        } else {
+          r.error = data;
+        }
+        return r;
+      })
+      .catch((e) => {
+        r.error = e;
+        return r;
+      });
+  };
 
   public request = <T = any, E = any>(
     path: string,
@@ -81,7 +101,7 @@ class HttpClient<SecurityDataType> {
     body?: any,
     bodyType?: BodyType,
     secureByDefault?: boolean,
-  ): Promise<T> =>
+  ): Promise<HttpResponse<T>> =>
     fetch(`${this.baseUrl}${path}`, {
       // @ts-ignore
       ...this.mergeRequestOptions(params, (secureByDefault || secure) && this.securityWorker(this.securityData)),


### PR DESCRIPTION

Features:
- `--js` CLI option. [[feature request]](https://github.com/acacode/swagger-typescript-api/issues/79)  

BREAKING_CHANGES:  
- Requests returns `Promise<HttpResponse<Data, Error>>` type.  
  `HttpResponse` it is [Fetch.Response](https://developer.mozilla.org/en-US/docs/Web/API/Response) wrapper with fields `data` and `error`
  Example:  
  ```ts
    const api = new Api()
    
    //
    const response: HttpResponse<Data, Error> = await api.fruits.getAll()

    response.data // Data (can be null if response.ok is false)
    response.error // Error (can be null if response.ok is true)
  ```  
- Breaking changes in the `client.mustache` template. Needs to update local custom templates.  

Fixes:  
- Security configuration in methods. When the security definition is in the main configuration of the swagger definition  
