### PR TITLE
Fixed unsafe clone() of Response causing json() hang.

### DIFF
--- a/src/templates/defaults/http-client.mustache
+++ b/src/templates/defaults/http-client.mustache
@@ -96,7 +96,7 @@ class HttpClient<{{#apiConfig.generic}}{{name}},{{/apiConfig.generic}}> {
   }
   
   private safeParseResponse = <T = any, E = any>(response: Response): Promise<HttpResponse<T, E>> => {
-    const r = response.clone() as HttpResponse<T, E>;
+    const r = response as HttpResponse<T, E>;
     r.data = null;
     r.error = null;
 


### PR DESCRIPTION
It's unfortunately not safe to clone a stream unless each of the clones are processed in parallel. However, currently, the original response is not even being exposed to consumers until the cloned stream is fully processed. Thus, we can end up with a hang when handling large JSON responses, particularly on NodeJS when using node-fetch. See:

https://github.com/node-fetch/node-fetch/issues/139
https://github.com/node-fetch/node-fetch/issues/665

This change does have the side-effect that **consumers will be unable to rewind the stream and inspect the body in the event that JSON parsing fails**. If it succeeds, then we're provided with the parsed body, so it's a non-issue in that case.

**This PR is breaking** for the reason outlined above. However, the breaking change does not affect regular usage. It will however affect users who happened to be doing fancy things with response body stream e.g. if JSON parsing failed. 

Unfortunately, without this change, this library is unusable on Node.js, or at least, will fail in very confusing ways (i.e. request promise that never resolves) once a sufficiently large JSON response is encountered. The responses need not be enormous either, [16KiB I believe](https://github.com/node-fetch/node-fetch#custom-highwatermark).