### PR TITLE
Generation of the module name: added the ability to pass the url inde…

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -55,6 +55,11 @@ interface GenerateApiParams {
    * generate js api module with declaration file (default: false)
    */
   toJS?: boolean;
+
+  /**
+   * url index from paths used for merging into modules
+   */
+  moduleNameIndex?: number;
 }
 
 export declare function generateApi(

--- a/src/config.js
+++ b/src/config.js
@@ -22,6 +22,9 @@ const config = {
   componentsMap: {},
   /** flag for catching convertion from swagger 2.0 */
   convertedFromSwagger2: false,
+
+  /** url index from paths used for merging into modules */
+  moduleNameIndex: 0,
 };
 
 /** needs to use data everywhere in project */

--- a/src/index.js
+++ b/src/index.js
@@ -44,6 +44,7 @@ module.exports = {
     generateRouteTypes = config.generateRouteTypes,
     generateClient = config.generateClient,
     generateUnionEnums = config.generateUnionEnums,
+    moduleNameIndex = config.moduleNameIndex,
   }) =>
     new Promise((resolve, reject) => {
       addToConfig({
@@ -53,6 +54,7 @@ module.exports = {
         generateResponses,
         templates,
         generateUnionEnums,
+        moduleNameIndex,
       });
       (spec ? convertSwaggerObject(spec) : getSwaggerObject(input, url))
         .then(({ usageSchema, originalSchema }) => {
@@ -78,7 +80,7 @@ module.exports = {
           const schemasMap = filterComponentsMap(componentsMap, "schemas");
 
           const parsedSchemas = parseSchemas(components);
-          const routes = parseRoutes(usageSchema, parsedSchemas, componentsMap, components);
+          const routes = parseRoutes(usageSchema, parsedSchemas, componentsMap, components, moduleNameIndex);
           const hasSecurityRoutes = routes.some((route) => route.security);
           const hasQueryRoutes = routes.some((route) => route.hasQuery);
           const hasFormDataRoutes = routes.some((route) => route.hasFormDataParams);

--- a/src/routes.js
+++ b/src/routes.js
@@ -191,7 +191,7 @@ const createRequestsMap = (requestInfoByMethodsMap) => {
   );
 };
 
-const parseRoutes = ({ paths, security: globalSecurity }, parsedSchemas) =>
+const parseRoutes = ({ paths, security: globalSecurity }, parsedSchemas, componentsMap, components, moduleNameIndex) =>
   _.entries(paths).reduce((routes, [route, requestInfoByMethodsMap]) => {
     if (route.startsWith("x-")) return routes;
 
@@ -224,7 +224,7 @@ const parseRoutes = ({ paths, security: globalSecurity }, parsedSchemas) =>
         let formDataRequestBody =
           requestBodyType && requestBodyType.dataType === "multipart/form-data";
 
-        const moduleName = _.camelCase(_.compact(_.split(route, "/"))[0]);
+        const moduleName = _.camelCase(_.compact(_.split(route, "/"))[moduleNameIndex]);
 
         const routeName = getRouteName(operationId, method, route, moduleName);
         const name = _.camelCase(routeName);


### PR DESCRIPTION
On my project, when generating api using your library, we faced the problem that all urls of requests for api start with / api / and we generate one large module with all methods inside the api. In the code, I saw that the selectable index was hardcoded. Perhaps it will be convenient not only for me if it will be possible to select the index through the config.