### PR TITLE
Release 4.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # next release  
 
+# 4.0.2  
+
+Fixes:  
+ - `Unexpected token '.'` on v4 (Thanks @savingprivatebryan for issue #111)  
+    Replaced all new syntax sugar like `?.` or `??` to prev. alternatives for support nodejs 12  
+
 # 4.0.1  
 
 Fixes:  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,10 @@ Fixes:
 - Remove const enum from default template #73  
 - enums with spaces throw an error #71  
 
+# 1.11.1  
+
+Fixes:  
+- handling `x-omitempty` property for definition properties ([#68 issue](https://github.com/acacode/swagger-typescript-api/issues/68))  
 
 # 1.11.0  
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,10 +144,6 @@ Fixes:
 - Remove const enum from default template #73  
 - enums with spaces throw an error #71  
 
-# 1.11.1  
-
-Fixes:  
-- handling `x-omitempty` property for definition properties ([#68 issue](https://github.com/acacode/swagger-typescript-api/issues/68))  
 
 # 1.11.0  
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "swagger-typescript-api",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "MIT",
       "dependencies": {
         "@types/swagger-schema-official": "2.0.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-typescript-api",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Create typescript api module from swagger schema",
   "scripts": {
     "cli:json": "node index.js -r -d -p ./swagger-test-cli.json -n swagger-test-cli.ts --extract-request-params --enum-names-as-values",

--- a/src/routes.js
+++ b/src/routes.js
@@ -412,7 +412,7 @@ const parseRoutes = ({ usageSchema, parsedSchemas, moduleNameIndex, extractReque
         const jsDocDescription =
           description && ` * @description ${formatDescription(description, true)}`;
         const jsDocLines = _.compact([
-          tags?.length && ` * @tags ${tags.join(", ")}`,
+          _.size(tags) && ` * @tags ${tags.join(", ")}`,
           ` * @name ${routeId}`,
           summary && ` * @summary ${summary}`,
           ` * @request ${_.upperCase(method)}:${route}`,

--- a/templates/default/procedure-call.eta
+++ b/templates/default/procedure-call.eta
@@ -4,7 +4,7 @@ const { _, getInlineParseContent, getParseContent, parseSchema, getComponentByRe
 const { parameters, path, method, payload, params, query, formData, security, requestParams } = route.request;
 const { type, errorType } = route.response;
 const routeDocs = includeFile("./route-docs", { config, route, utils });
-const queryName = query?.name ?? "query";
+const queryName = (query && query.name) || "query";
 const pathParams = _.values(parameters);
 
 const argToTmpl = ({ name, optional, type }) => `${name}${optional ? '?' : ''}: ${type}`;
@@ -42,7 +42,7 @@ const securityTmpl = security ? 'true' : null
 const pathTmpl = query != null
     ? `\`${path}\${this.addQueryParams(${queryName})}\``
     : `\`${path}\``
-const requestArgs = [pathTmpl, `'${_.upperCase(method)}'`, params?.name, payload?.name, bodyModeTmpl, securityTmpl]
+const requestArgs = [pathTmpl, `'${_.upperCase(method)}'`, _.get(params, "name"), _.get(payload, "name"), bodyModeTmpl, securityTmpl]
     .reverse()
     .reduce((args, arg) => {
         if (args.length === 0 && !arg) return args

--- a/templates/default/route-docs.eta
+++ b/templates/default/route-docs.eta
@@ -6,7 +6,7 @@ const jsDocDescription = raw.description ?
     ` * @description ${formatDescription(raw.description, true)}` :
     fmtToJSDocLine('No description', { eol: false });
 const jsDocLines = _.compact([
-    raw.tags?.length && ` * @tags ${raw.tags.join(", ")}`,
+    _.size(raw.tags) && ` * @tags ${raw.tags.join(", ")}`,
     ` * @name ${classNameCase(routeName.usage)}`,
     raw.summary && ` * @summary ${raw.summary}`,
     ` * @request ${_.upperCase(request.method)}:${raw.route}`,

--- a/templates/default/route-type.eta
+++ b/templates/default/route-type.eta
@@ -5,9 +5,9 @@ const { query, payload } = route.request
 const { type: responseType } = route.response
 
 const routeDocs = includeFile("./route-docs", { config, route, utils });
-const routeNamespace = classNameCase(route.routeName.usage)
-const queryType = query?.type || '{}'
-const bodyType = payload?.type || 'never'
+const routeNamespace = classNameCase(route.routeName.usage);
+const queryType = (query && query.type) || '{}';
+const bodyType = (payload && payload.type) || 'never';
 %>
 /**
 <%~ routeDocs.description %>

--- a/templates/modular/procedure-call.eta
+++ b/templates/modular/procedure-call.eta
@@ -4,7 +4,7 @@ const { _, getInlineParseContent, getParseContent, parseSchema, getComponentByRe
 const { parameters, path, method, payload, params, query, formData, security, requestParams } = route.request;
 const { type, errorType } = route.response;
 const routeDocs = includeFile("./route-docs", { config, route, utils });
-const queryName = query?.name ?? "query";
+const queryName = (query && query.name) || "query";
 const pathParams = _.values(parameters);
 
 const argToTmpl = ({ name, optional, type }) => `${name}${optional ? '?' : ''}: ${type}`;
@@ -42,7 +42,7 @@ const securityTmpl = security ? 'true' : null
 const pathTmpl = query != null
     ? '`' + path + '${this.addQueryParams(' + query.name + ')}' + '`'
     : '`' + path + '`'
-const requestArgs = [pathTmpl, `'${_.upperCase(method)}'`, params?.name ?? null, payload?.name ?? null, bodyModeTmpl, securityTmpl]
+const requestArgs = [pathTmpl, `'${_.upperCase(method)}'`, _.get(params, "name"), _.get(payload, "name"), bodyModeTmpl, securityTmpl]
     .reverse()
     .reduce((args, arg) => {
         if (args.length === 0 && !arg) return args

--- a/templates/modular/route-docs.eta
+++ b/templates/modular/route-docs.eta
@@ -6,7 +6,7 @@ const jsDocDescription = raw.description ?
     ` * @description ${formatDescription(raw.description, true)}` :
     fmtToJSDocLine('No description', { eol: false });
 const jsDocLines = _.compact([
-    raw.tags?.length && ` * @tags ${raw.tags.join(", ")}`,
+    _.size(raw.tags) && ` * @tags ${raw.tags.join(", ")}`,
     ` * @name ${classNameCase(routeName.usage)}`,
     raw.summary && ` * @summary ${raw.summary}`,
     ` * @request ${_.upperCase(request.method)}:${raw.route}`,

--- a/templates/modular/route-type.eta
+++ b/templates/modular/route-type.eta
@@ -7,8 +7,8 @@ const { type: responseType } = route.response;
 
 const routeDocs = includeFile("./route-docs", { config, route, utils });
 const routeNamespace = classNameCase(routeName.usage);
-const queryType = query?.type || '{}';
-const bodyType = payload?.type || 'never';
+const queryType = (query && query.type) || '{}';
+const bodyType = (payload && payload.type) || 'never';
 %>
 /**
 <%~ routeDocs.description %>

--- a/tests/spec/templates/spec_templates/procedure-call.eta
+++ b/tests/spec/templates/spec_templates/procedure-call.eta
@@ -27,7 +27,7 @@ const securityTmpl = security ? 'true' : null
 const pathTmpl = query != null
     ? '`' + path + '${this.addQueryParams(' + query.name + ')}' + '`'
     : '`' + path + '`'
-const requestArgs = [pathTmpl, `'${_.upperCase(method)}'`, params?.name ?? null, payload?.name ?? null, bodyModeTmpl, securityTmpl]
+const requestArgs = [pathTmpl, `'${_.upperCase(method)}'`, _.get(params, "name"), _.get(payload, "name"), bodyModeTmpl, securityTmpl]
     .reverse()
     .reduce((args, arg) => {
         if (args.length === 0 && !arg) return args

--- a/tests/spec/templates/spec_templates/route-docs.eta
+++ b/tests/spec/templates/spec_templates/route-docs.eta
@@ -6,7 +6,7 @@ const jsDocDescription = raw.description ?
     ` * @description ${formatDescription(raw.description, true)}` :
     fmtToJSDocLine('No description', { eol: false });
 const jsDocLines = _.compact([
-    raw.tags?.length && ` * @tags ${raw.tags.join(", ")}`,
+    _.size(raw.tags) && ` * @tags ${raw.tags.join(", ")}`,
     ` * @name ${classNameCase(routeName.usage)}`,
     raw.summary && ` * @summary ${raw.summary}`,
     ` * @request ${_.upperCase(request.method)}:${raw.route}`,

--- a/tests/spec/templates/spec_templates/route-type.eta
+++ b/tests/spec/templates/spec_templates/route-type.eta
@@ -6,8 +6,8 @@ const { type: responseType } = route.response
 
 const routeDocs = includeFile("./route-docs", { config, route, utils });
 const routeNamespace = classNameCase(route.routeName.usage)
-const queryType = query?.type || '{}'
-const bodyType = payload?.type || 'never'
+const queryType = (query && query.type) || '{}'
+const bodyType = (payload && payload.type) || 'never'
 %>
 /**
 <%~ routeDocs.description %>


### PR DESCRIPTION
Fixes:  
 - `Unexpected token '.'` on v4 (Thanks @savingprivatebryan for issue #111)  
    Replaced all new syntax sugar like `?.` or `??` to prev. alternatives for support nodejs 12  
