### PR TITLE
Release 4.1.0

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,7 @@
 tests/**/*.ts
 tests/**/schema.js
 tests/**/*.d.js
+swagger-test-cli
+swagger-test-cli.*
+templates
 *.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 Features:  
 - Improve `require()` function used in ETA templates (using relative path imports)  
+- `--clean-output` option.  
+  clean output folder before generate api  
 
 Fixes:  
 - Error: `Unexpected token =` (Issue #136, Thanks @jlow-mudbath)  
+- Output folder creation (Issue #137, Thanks @Rinta01)  
+  Create output folder if it is not exist  
 
 # 4.0.5  
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # next release  
 
+# 4.1.0  
+
 Features:  
 - Improve `require()` function used in ETA templates (using relative path imports)  
 - `--clean-output` option.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # next release  
 
+Features:  
+- Improve `require()` function used in ETA templates (using relative path imports)  
+
+Fixes:  
+- Error: `Unexpected token =` (Issue #136, Thanks @jlow-mudbath)  
+
 # 4.0.5  
 
 BREAKING_CHANGE:  

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Options:
                                 (example: GET:/fruites/getFruit -> index:0 -> moduleName -> fruites)
   --modular                     generate separated files for http client, data contracts, and routes (default: false)
   --disableStrictSSL            disabled strict SSL (default: false)
+  --clean-output                clean output folder before generate api. WARNING: May cause data loss (default: false)
   -h, --help                    display help for command
 ```
 

--- a/index.js
+++ b/index.js
@@ -60,7 +60,12 @@ program
     "determines which path index should be used for routes separation (example: GET:/fruites/getFruit -> index:0 -> moduleName -> fruites)",
     0,
   )
-  .option("--disableStrictSSL", "disabled strict SSL", false);
+  .option("--disableStrictSSL", "disabled strict SSL", false)
+  .option(
+    "--clean-output",
+    "clean output folder before generate api. WARNING: May cause data loss",
+    false,
+  );
 
 program.parse(process.argv);
 
@@ -80,6 +85,7 @@ const {
   extractRequestParams,
   enumNamesAsValues,
   disableStrictSSL,
+  cleanOutput,
 } = program;
 
 generateApi({
@@ -99,4 +105,5 @@ generateApi({
   enumNamesAsValues: enumNamesAsValues,
   moduleNameIndex: +(moduleNameIndex || 0),
   disableStrictSSL: !!disableStrictSSL,
+  cleanOutput: !!cleanOutput,
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "swagger-typescript-api",
-  "version": "4.0.5",
+  "version": "4.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "4.0.5",
+      "version": "4.1.0",
       "license": "MIT",
       "dependencies": {
         "@types/swagger-schema-official": "2.0.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-typescript-api",
-  "version": "4.0.5",
+  "version": "4.1.0",
   "description": "Create typescript api module from swagger schema",
   "scripts": {
     "cli:json": "node index.js -r -d -p ./swagger-test-cli.json -n swagger-test-cli.ts --extract-request-params --enum-names-as-values",

--- a/src/files.js
+++ b/src/files.js
@@ -5,6 +5,34 @@ const { filePrefix } = require("./filePrefix");
 
 const getFileContent = (path) => fs.readFileSync(path, { encoding: "UTF-8" });
 
+const pathIsDir = (path) => {
+  if (!path) return false;
+
+  try {
+    const stat = fs.statSync(path);
+    return stat.isDirectory();
+  } catch (e) {
+    return false;
+  }
+};
+
+const removeDir = (path) => {
+  try {
+    fs.rmdirSync(path, { recursive: true });
+  } catch (e) {}
+};
+
+const createDir = (path) => {
+  try {
+    fs.mkdirSync(path);
+  } catch (e) {}
+};
+
+const cleanDir = (path) => {
+  removeDir(path);
+  createDir(path);
+};
+
 const pathIsExist = (path) => path && fs.existsSync(path);
 
 const createFile = (pathTo, fileName, content) =>
@@ -12,6 +40,10 @@ const createFile = (pathTo, fileName, content) =>
 
 module.exports = {
   createFile,
+  pathIsDir,
+  cleanDir,
   pathIsExist,
+  createDir,
+  removeDir,
   getFileContent,
 };

--- a/src/formatFileContent.js
+++ b/src/formatFileContent.js
@@ -18,13 +18,27 @@ class LanguageServiceHost {
     });
   }
 
-  getNewLine = () => "\n";
-  getScriptFileNames = () => [this.fileName];
-  getCompilationSettings = () => this.compilerOptions;
-  getDefaultLibFileName = () => ts.getDefaultLibFileName(this.getCompilationSettings());
-  getCurrentDirectory = () => process.cwd();
-  getScriptVersion = () => ts.version;
-  getScriptSnapshot = () => ts.ScriptSnapshot.fromString(this.content);
+  getNewLine() {
+    return "\n";
+  }
+  getScriptFileNames() {
+    return [this.fileName];
+  }
+  getCompilationSettings() {
+    return this.compilerOptions;
+  }
+  getDefaultLibFileName() {
+    return ts.getDefaultLibFileName(this.getCompilationSettings());
+  }
+  getCurrentDirectory() {
+    return process.cwd();
+  }
+  getScriptVersion() {
+    return ts.version;
+  }
+  getScriptSnapshot() {
+    return ts.ScriptSnapshot.fromString(this.content);
+  }
 }
 
 const removeUnusedImports = (content) => {

--- a/src/render/utils/index.js
+++ b/src/render/utils/index.js
@@ -1,5 +1,8 @@
+const _ = require("lodash");
+const path = require("path");
 const { classNameCase, formatDescription, internalCase } = require("../../common");
 const { getComponentByRef } = require("../../components");
+const { config } = require("../../config");
 const { getInlineParseContent, getParseContent, parseSchema } = require("../../schema");
 const { formatters, inlineExtraFormatters } = require("../../typeFormatters");
 
@@ -14,6 +17,14 @@ module.exports = {
   formatters,
   inlineExtraFormatters,
   fmtToJSDocLine: require("./fmtToJSDocLine"),
-  _: require("lodash"),
-  require: require,
+  _: _,
+  require: (packageOrPath) => {
+    const isPath = _.startsWith(packageOrPath, "./") || _.startsWith(packageOrPath, "../");
+
+    if (isPath) {
+      return require(path.resolve(config.templates, packageOrPath));
+    }
+
+    return require(packageOrPath);
+  },
 };


### PR DESCRIPTION
Features:  
- Improve `require()` function used in ETA templates (using relative path imports)  
- `--clean-output` option.  
  clean output folder before generate api  

Fixes:  
- Error: `Unexpected token =` (Issue #136, Thanks @jlow-mudbath)  
- Output folder creation (Issue #137, Thanks @Rinta01)  
  Create output folder if it is not exist  
