### PR TITLE
Release 5.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # next release  
 
+
+Features:   
+- `onCreateRouteName(routeNameInfo: RouteNameInfo, rawRouteInfo: RawRouteInfo): RouteNameInfo | void` hook  
+  Which allows to customize route name without customizing `route-name.eta` template  
+- Improved content kinds for request infos  
+
+Minor:  
+- A bit improve type declaration file (index.d.ts) for this tool     
+
+Internal:  
+- clearing `routeNameDuplicatesMap` before each `parseRoutes()` function call  
+
+
 # 5.1.0  
 
 Fixes:  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # next release  
 
+Fixes:  
+- The HttpResponse type is no longer exported from http-client (issue #161, thanks @Styn)  
+
 # 5.1.0  
 
 Fixes:  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,23 +9,6 @@ Features:
 - `onCreateRouteName(routeNameInfo: RouteNameInfo, rawRouteInfo: RawRouteInfo): RouteNameInfo | void` hook  
   Which allows to customize route name without customizing `route-name.eta` template  
 - Improved content kinds for request infos  
-
-Minor:  
-- A bit improve type declaration file (index.d.ts) for this tool     
-
-Internal:  
-- clearing `routeNameDuplicatesMap` before each `parseRoutes()` function call  
-
-
-# 5.1.0  
-
-Fixes:  
-- Bug with optional nested properties of object schema type (issue #156, thanks @Fabiencdp)  
-
-Features:   
-- `onCreateRouteName(routeNameInfo: RouteNameInfo, rawRouteInfo: RawRouteInfo): RouteNameInfo | void` hook  
-  Which allows to customize route name without customizing `route-name.eta` template  
-- Improved content kinds for request infos  
 - `--single-http-client` option which allows to send HttpClient instance to Api constructor and not to create many count of HttpClient instances with `--modular` api (issue #155)   
 
 Minor:  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # next release  
 
+Fixes:  
+- Bug with optional nested properties of object schema type (issue #156, thanks @Fabiencdp)  
 
 Features:   
 - `onCreateRouteName(routeNameInfo: RouteNameInfo, rawRouteInfo: RawRouteInfo): RouteNameInfo | void` hook  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # next release  
 
+# 5.1.0  
+
 Fixes:  
 - Bug with optional nested properties of object schema type (issue #156, thanks @Fabiencdp)  
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # next release  
 
+# 5.1.1  
+
 Fixes:  
 - The HttpResponse type is no longer exported from http-client (issue #161, thanks @Styn)  
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-typescript-api",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -88,5 +88,9 @@
   "bugs": {
     "url": "https://github.com/acacode/swagger-typescript-api/issues"
   },
-  "homepage": "https://github.com/acacode/swagger-typescript-api"
+  "homepage": "https://github.com/acacode/swagger-typescript-api",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/acacode/swagger-typescript-api"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-typescript-api",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "Create typescript api module from swagger schema",
   "scripts": {
     "cli:json": "node index.js -r -d -p ./swagger-test-cli.json -n swagger-test-cli.ts --extract-request-params --enum-names-as-values",

--- a/templates/default/http-client.eta
+++ b/templates/default/http-client.eta
@@ -41,7 +41,7 @@ type TPromise<ResolveType, RejectType = any> = Omit<Promise<ResolveType>, "then"
 }
 <% } %>
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
     data: D;
     error: E;
 }

--- a/templates/modular/http-client.eta
+++ b/templates/modular/http-client.eta
@@ -41,7 +41,7 @@ type TPromise<ResolveType, RejectType = any> = Omit<Promise<ResolveType>, "then"
 }
 <% } %>
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
     data: D;
     error: E;
 }

--- a/tests/generated/v2.0/adafruit.ts
+++ b/tests/generated/v2.0/adafruit.ts
@@ -194,7 +194,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
   securityWorker?: (securityData: SecurityDataType) => RequestParams | void;
 }
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }

--- a/tests/generated/v2.0/another-example.ts
+++ b/tests/generated/v2.0/another-example.ts
@@ -170,7 +170,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
   securityWorker?: (securityData: SecurityDataType) => RequestParams | void;
 }
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }

--- a/tests/generated/v2.0/api-with-examples.ts
+++ b/tests/generated/v2.0/api-with-examples.ts
@@ -39,7 +39,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
   securityWorker?: (securityData: SecurityDataType) => RequestParams | void;
 }
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }

--- a/tests/generated/v2.0/authentiq.ts
+++ b/tests/generated/v2.0/authentiq.ts
@@ -91,7 +91,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
   securityWorker?: (securityData: SecurityDataType) => RequestParams | void;
 }
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }

--- a/tests/generated/v2.0/example1.ts
+++ b/tests/generated/v2.0/example1.ts
@@ -66,7 +66,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
   securityWorker?: (securityData: SecurityDataType) => RequestParams | void;
 }
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }

--- a/tests/generated/v2.0/file-formdata-example.ts
+++ b/tests/generated/v2.0/file-formdata-example.ts
@@ -39,7 +39,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
   securityWorker?: (securityData: SecurityDataType) => RequestParams | void;
 }
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }

--- a/tests/generated/v2.0/furkot-example.ts
+++ b/tests/generated/v2.0/furkot-example.ts
@@ -102,7 +102,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
   securityWorker?: (securityData: SecurityDataType) => RequestParams | void;
 }
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }

--- a/tests/generated/v2.0/giphy.ts
+++ b/tests/generated/v2.0/giphy.ts
@@ -321,7 +321,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
   securityWorker?: (securityData: SecurityDataType) => RequestParams | void;
 }
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }

--- a/tests/generated/v2.0/github-swagger.ts
+++ b/tests/generated/v2.0/github-swagger.ts
@@ -1464,7 +1464,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
   securityWorker?: (securityData: SecurityDataType) => RequestParams | void;
 }
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }

--- a/tests/generated/v2.0/path-args.ts
+++ b/tests/generated/v2.0/path-args.ts
@@ -39,7 +39,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
   securityWorker?: (securityData: SecurityDataType) => RequestParams | void;
 }
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }

--- a/tests/generated/v2.0/petstore-expanded.ts
+++ b/tests/generated/v2.0/petstore-expanded.ts
@@ -76,7 +76,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
   securityWorker?: (securityData: SecurityDataType) => RequestParams | void;
 }
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }

--- a/tests/generated/v2.0/petstore-minimal.ts
+++ b/tests/generated/v2.0/petstore-minimal.ts
@@ -47,7 +47,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
   securityWorker?: (securityData: SecurityDataType) => RequestParams | void;
 }
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }

--- a/tests/generated/v2.0/petstore-simple.ts
+++ b/tests/generated/v2.0/petstore-simple.ts
@@ -62,7 +62,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
   securityWorker?: (securityData: SecurityDataType) => RequestParams | void;
 }
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }

--- a/tests/generated/v2.0/petstore-swagger-io.ts
+++ b/tests/generated/v2.0/petstore-swagger-io.ts
@@ -107,7 +107,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
   securityWorker?: (securityData: SecurityDataType) => RequestParams | void;
 }
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }

--- a/tests/generated/v2.0/petstore-with-external-docs.ts
+++ b/tests/generated/v2.0/petstore-with-external-docs.ts
@@ -52,7 +52,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
   securityWorker?: (securityData: SecurityDataType) => RequestParams | void;
 }
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }

--- a/tests/generated/v2.0/petstore.ts
+++ b/tests/generated/v2.0/petstore.ts
@@ -54,7 +54,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
   securityWorker?: (securityData: SecurityDataType) => RequestParams | void;
 }
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }

--- a/tests/generated/v2.0/query-path-param.ts
+++ b/tests/generated/v2.0/query-path-param.ts
@@ -39,7 +39,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
   securityWorker?: (securityData: SecurityDataType) => RequestParams | void;
 }
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }

--- a/tests/generated/v2.0/uber.ts
+++ b/tests/generated/v2.0/uber.ts
@@ -134,7 +134,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
   securityWorker?: (securityData: SecurityDataType) => RequestParams | void;
 }
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }

--- a/tests/generated/v3.0/additional-properties.ts
+++ b/tests/generated/v3.0/additional-properties.ts
@@ -46,7 +46,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
   securityWorker?: (securityData: SecurityDataType) => RequestParams | void;
 }
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }

--- a/tests/generated/v3.0/additional-properties2.ts
+++ b/tests/generated/v3.0/additional-properties2.ts
@@ -43,7 +43,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
   securityWorker?: (securityData: SecurityDataType) => RequestParams | void;
 }
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }

--- a/tests/generated/v3.0/allof-example.ts
+++ b/tests/generated/v3.0/allof-example.ts
@@ -47,7 +47,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
   securityWorker?: (securityData: SecurityDataType) => RequestParams | void;
 }
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }

--- a/tests/generated/v3.0/anyof-example.ts
+++ b/tests/generated/v3.0/anyof-example.ts
@@ -49,7 +49,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
   securityWorker?: (securityData: SecurityDataType) => RequestParams | void;
 }
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }

--- a/tests/generated/v3.0/api-with-examples.ts
+++ b/tests/generated/v3.0/api-with-examples.ts
@@ -39,7 +39,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
   securityWorker?: (securityData: SecurityDataType) => RequestParams | void;
 }
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }

--- a/tests/generated/v3.0/callback-example.ts
+++ b/tests/generated/v3.0/callback-example.ts
@@ -39,7 +39,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
   securityWorker?: (securityData: SecurityDataType) => RequestParams | void;
 }
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }

--- a/tests/generated/v3.0/components-responses.ts
+++ b/tests/generated/v3.0/components-responses.ts
@@ -39,7 +39,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
   securityWorker?: (securityData: SecurityDataType) => RequestParams | void;
 }
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }

--- a/tests/generated/v3.0/explode-param-3.0.1.ts
+++ b/tests/generated/v3.0/explode-param-3.0.1.ts
@@ -55,7 +55,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
   securityWorker?: (securityData: SecurityDataType) => RequestParams | void;
 }
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }

--- a/tests/generated/v3.0/link-example.ts
+++ b/tests/generated/v3.0/link-example.ts
@@ -56,7 +56,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
   securityWorker?: (securityData: SecurityDataType) => RequestParams | void;
 }
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }

--- a/tests/generated/v3.0/no-definitions-schema.ts
+++ b/tests/generated/v3.0/no-definitions-schema.ts
@@ -51,7 +51,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
   securityWorker?: (securityData: SecurityDataType) => RequestParams | void;
 }
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }

--- a/tests/generated/v3.0/nullable-refs.ts
+++ b/tests/generated/v3.0/nullable-refs.ts
@@ -53,7 +53,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
   securityWorker?: (securityData: SecurityDataType) => RequestParams | void;
 }
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }

--- a/tests/generated/v3.0/oneof-example.ts
+++ b/tests/generated/v3.0/oneof-example.ts
@@ -49,7 +49,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
   securityWorker?: (securityData: SecurityDataType) => RequestParams | void;
 }
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }

--- a/tests/generated/v3.0/personal-api-example.ts
+++ b/tests/generated/v3.0/personal-api-example.ts
@@ -240,7 +240,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
   securityWorker?: (securityData: SecurityDataType) => RequestParams | void;
 }
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }

--- a/tests/generated/v3.0/petstore-expanded.ts
+++ b/tests/generated/v3.0/petstore-expanded.ts
@@ -52,7 +52,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
   securityWorker?: (securityData: SecurityDataType) => RequestParams | void;
 }
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }

--- a/tests/generated/v3.0/petstore.ts
+++ b/tests/generated/v3.0/petstore.ts
@@ -56,7 +56,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
   securityWorker?: (securityData: SecurityDataType) => RequestParams | void;
 }
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }

--- a/tests/generated/v3.0/responses.ts
+++ b/tests/generated/v3.0/responses.ts
@@ -39,7 +39,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
   securityWorker?: (securityData: SecurityDataType) => RequestParams | void;
 }
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }

--- a/tests/generated/v3.0/swaggerhub-template.ts
+++ b/tests/generated/v3.0/swaggerhub-template.ts
@@ -39,7 +39,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
   securityWorker?: (securityData: SecurityDataType) => RequestParams | void;
 }
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }

--- a/tests/generated/v3.0/tsoa-odd-types-3.0.2.ts
+++ b/tests/generated/v3.0/tsoa-odd-types-3.0.2.ts
@@ -160,7 +160,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
   securityWorker?: (securityData: SecurityDataType) => RequestParams | void;
 }
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }

--- a/tests/generated/v3.0/up-banking.ts
+++ b/tests/generated/v3.0/up-banking.ts
@@ -567,7 +567,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
   securityWorker?: (securityData: SecurityDataType) => RequestParams | void;
 }
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }

--- a/tests/generated/v3.0/uspto.ts
+++ b/tests/generated/v3.0/uspto.ts
@@ -56,7 +56,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
   securityWorker?: (securityData: SecurityDataType) => RequestParams | void;
 }
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }

--- a/tests/generated/v3.0/wrong-enum-subtypes.ts
+++ b/tests/generated/v3.0/wrong-enum-subtypes.ts
@@ -41,7 +41,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
   securityWorker?: (securityData: SecurityDataType) => RequestParams | void;
 }
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }

--- a/tests/spec/defaultAsSuccess/schema.ts
+++ b/tests/spec/defaultAsSuccess/schema.ts
@@ -91,7 +91,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
   securityWorker?: (securityData: SecurityDataType) => RequestParams | void;
 }
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }

--- a/tests/spec/defaultResponse/schema.ts
+++ b/tests/spec/defaultResponse/schema.ts
@@ -39,7 +39,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
   securityWorker?: (securityData: SecurityDataType) => RequestParams | void;
 }
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }

--- a/tests/spec/enumNamesAsValues/schema.ts
+++ b/tests/spec/enumNamesAsValues/schema.ts
@@ -237,7 +237,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
   securityWorker?: (securityData: SecurityDataType) => RequestParams | void;
 }
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }

--- a/tests/spec/extractRequestParams/schema.ts
+++ b/tests/spec/extractRequestParams/schema.ts
@@ -120,7 +120,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
   securityWorker?: (securityData: SecurityDataType) => RequestParams | void;
 }
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }

--- a/tests/spec/js/schema.d.ts
+++ b/tests/spec/js/schema.d.ts
@@ -1720,7 +1720,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
   baseApiParams?: Omit<RequestParams, "baseUrl" | "cancelToken" | "signal">;
   securityWorker?: (securityData: SecurityDataType) => RequestParams | void;
 }
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }

--- a/tests/spec/modular/http-client.ts
+++ b/tests/spec/modular/http-client.ts
@@ -39,7 +39,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
   securityWorker?: (securityData: SecurityDataType) => RequestParams;
 }
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }

--- a/tests/spec/moduleNameIndex/schema.ts
+++ b/tests/spec/moduleNameIndex/schema.ts
@@ -167,7 +167,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
   securityWorker?: (securityData: SecurityDataType) => RequestParams | void;
 }
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }

--- a/tests/spec/responses/schema.ts
+++ b/tests/spec/responses/schema.ts
@@ -102,7 +102,7 @@ type TPromise<ResolveType, RejectType = any> = Omit<Promise<ResolveType>, "then"
   ): TPromise<ResolveType | TResult, RejectType>;
 };
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }

--- a/tests/spec/singleHttpClient/schema.ts
+++ b/tests/spec/singleHttpClient/schema.ts
@@ -39,7 +39,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
   securityWorker?: (securityData: SecurityDataType) => RequestParams | void;
 }
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }

--- a/tests/spec/unionEnums/schema.ts
+++ b/tests/spec/unionEnums/schema.ts
@@ -49,7 +49,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
   securityWorker?: (securityData: SecurityDataType) => RequestParams | void;
 }
 
-interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
   data: D;
   error: E;
 }


### PR DESCRIPTION


Fixes:  
- The HttpResponse type is no longer exported from http-client (issue #161, thanks @Styn)  
