### PR TITLE
Fix header overwrite in modular API template.

### DIFF
--- a/templates/modular/http-client.eta
+++ b/templates/modular/http-client.eta
@@ -169,11 +169,11 @@ export class HttpClient<SecurityDataType = unknown> {
         return fetch(
         `${baseUrl || this.baseUrl || ""}${path}${queryString ? `?${queryString}` : ""}`,
         {
+            ...requestParams,
             headers: {
             ...(type ? { "Content-Type": type } : {}),
             ...(requestParams.headers || {}),
             },
-            ...requestParams,
             signal: cancelToken ? this.createAbortSignal(cancelToken) : void 0,
             body: typeof body === "undefined" || body === null ? null : payloadFormatter(body),
         }


### PR DESCRIPTION
If `requestParams` contained headers, the whole headers would be replaced by these ones, wiping out the automatic `Content-Type` header.

Putting the `requestParams` spread first fixes it, as the re-definition of `headers` will overwrite them.