### PR TITLE
Don't set multipart/form-data content-type

### DIFF
--- a/templates/default/http-client.eta
+++ b/templates/default/http-client.eta
@@ -171,7 +171,7 @@ export class HttpClient<SecurityDataType = unknown> {
         {
             ...requestParams,
             headers: {
-            ...(type ? { "Content-Type": type } : {}),
+            ...(type && type !== ContentType.FormData ? { "Content-Type": type } : {}),
             ...(requestParams.headers || {}),
             },
             signal: cancelToken ? this.createAbortSignal(cancelToken) : void 0,

--- a/templates/modular/http-client.eta
+++ b/templates/modular/http-client.eta
@@ -171,7 +171,7 @@ export class HttpClient<SecurityDataType = unknown> {
         {
             ...requestParams,
             headers: {
-            ...(type ? { "Content-Type": type } : {}),
+            ...(type && type !== ContentType.FormData ? { "Content-Type": type } : {}),
             ...(requestParams.headers || {}),
             },
             signal: cancelToken ? this.createAbortSignal(cancelToken) : void 0,


### PR DESCRIPTION
Fixes: https://github.com/acacode/swagger-typescript-api/issues/172

It's better to let the browser handle setting of this content-type, since it will add the correct boundary.
