### PR TITLE
Do not fail if template file does not exist

### DIFF
--- a/src/templates.js
+++ b/src/templates.js
@@ -1,6 +1,6 @@
 const _ = require("lodash");
 const Eta = require("eta");
-const { getFileContent } = require("./files");
+const { getFileContent, pathIsExist } = require("./files");
 const { resolve } = require("path");
 
 const getTemplates = ({ templates, modular }) => {
@@ -27,7 +27,8 @@ const getTemplates = ({ templates, modular }) => {
   const templatesMap = _.reduce(
     templatePaths,
     (acc, pathToTemplate, key) => {
-      let fileContent = getFileContent(resolve(customTemplatesPath, pathToTemplate));
+      const customFullPath = resolve(customTemplatesPath, pathToTemplate)
+      let fileContent = pathIsExist(customFullPath) && getFileContent(customFullPath);
 
       if (!fileContent) {
         console.log(


### PR DESCRIPTION
This allows overriding specific template files and fallback on the defaults.

Before this change, the behavior was for the tool to fail with `Error: ENOENT: no such file or directory` if one of the template files in a custom templates directory does not exist.

Caveat: With this fix it will still error if the overridden template uses `includeFile` on a template file that is not overridden:

```
Error [Eta Error]: Could not find the template "./route-docs". Paths tried: /redacted/route-docs.eta
```

Example output:

```
✨ try to read templates from directory "/redacted"
❗❗❗ data contracts template not found in ./data-contracts.eta
Code generator will use the default template
❗❗❗ http client template not found in ./http-client.eta
Code generator will use the default template
❗❗❗ route types template not found in ./route-types.eta
Code generator will use the default template
❗❗❗ route name template not found in ./route-name.eta
Code generator will use the default template
☄️  start generating your typescript api
```

Related: #166 