### PR TITLE
Release 5.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # next release  
 
+# 5.1.7  
+
+Fixes:  
+- Do not fail if template file does not exist (issue #166, thanks @armsnyder )  
+  Caveat: With this fix it will still error if the overridden template uses `includeFile` on a template file that is not overridden  
+
 # 5.1.6  
 
 Fixes:  

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-typescript-api",
-  "version": "5.1.6",
+  "version": "5.1.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-typescript-api",
-  "version": "5.1.6",
+  "version": "5.1.7",
   "description": "Create typescript api module from swagger schema",
   "scripts": {
     "cli:json": "node index.js -r -d -p ./swagger-test-cli.json -n swagger-test-cli.ts --extract-request-params --enum-names-as-values",

--- a/src/templates.js
+++ b/src/templates.js
@@ -1,6 +1,6 @@
 const _ = require("lodash");
 const Eta = require("eta");
-const { getFileContent } = require("./files");
+const { getFileContent, pathIsExist } = require("./files");
 const { resolve } = require("path");
 
 const getTemplates = ({ templates, modular }) => {
@@ -27,7 +27,8 @@ const getTemplates = ({ templates, modular }) => {
   const templatesMap = _.reduce(
     templatePaths,
     (acc, pathToTemplate, key) => {
-      let fileContent = getFileContent(resolve(customTemplatesPath, pathToTemplate));
+      const customFullPath = resolve(customTemplatesPath, pathToTemplate)
+      let fileContent = pathIsExist(customFullPath) && getFileContent(customFullPath);
 
       if (!fileContent) {
         console.log(


### PR DESCRIPTION
Fixes:  
- Do not fail if template file does not exist (issue #166, thanks @armsnyder )  
  Caveat: With this fix it will still error if the overridden template uses `includeFile` on a template file that is not overridden  
