### PR TITLE
Split routes based on first tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Options:
                                 Also combine path params and query params into one object
   --module-name-index <number>  determines which path index should be used for routes separation (default: 0)
                                 (example: GET:/fruites/getFruit -> index:0 -> moduleName -> fruites)
+  --module-name-first-tag       splits routes based on the first tag
   --modular                     generate separated files for http client, data contracts, and routes (default: false)
   --disableStrictSSL            disabled strict SSL (default: false)
   --clean-output                clean output folder before generate api. WARNING: May cause data loss (default: false)
@@ -172,6 +173,9 @@ Example:
 `GET:/api/vegetables/addVegetable`  
 with `--module-name-index 0` Api class will have one property `api`  
 When we change it to `--module-name-index 1` then Api class have two properties `fruits` and `vegetables`  
+
+### **`--module-name-first-tag`**  
+This option will group your API operations based on their first tag - mirroring how the Swagger UI groups displayed operations
 
 
 ## 📄 Mass media  

--- a/index.d.ts
+++ b/index.d.ts
@@ -64,6 +64,10 @@ interface GenerateApiParams {
    */
   moduleNameIndex?: number;
   /**
+   * users operation's first tag for route separation
+   */
+  moduleNameFirstTag?: boolean;
+  /**
    * disabled SSL check
    */
   disableStrictSSL?: boolean;
@@ -254,6 +258,7 @@ export interface GenerateApiConfiguration {
     componentsMap: Record<string, SchemaComponent>;
     convertedFromSwagger2: boolean;
     moduleNameIndex: number;
+    moduleNameFirstTag: boolean;
     disableStrictSSL: boolean;
     extractRequestParams: boolean;
     fileNames: {

--- a/index.js
+++ b/index.js
@@ -61,6 +61,7 @@ program
     "determines which path index should be used for routes separation (example: GET:/fruites/getFruit -> index:0 -> moduleName -> fruites)",
     0,
   )
+  .option("--module-name-first-tag", "splits routes based on the first tag", false)
   .option("--disableStrictSSL", "disabled strict SSL", false)
   .option("--axios", "generate axios http client", false)
   .option("--single-http-client", "Ability to send HttpClient instance to Api constructor", false)
@@ -87,6 +88,7 @@ const {
   modular,
   js,
   moduleNameIndex,
+  moduleNameFirstTag,
   extractRequestParams,
   enumNamesAsValues,
   disableStrictSSL,
@@ -115,6 +117,7 @@ generateApi({
   toJS: !!js,
   enumNamesAsValues: enumNamesAsValues,
   moduleNameIndex: +(moduleNameIndex || 0),
+  moduleNameFirstTag: moduleNameFirstTag,
   disableStrictSSL: !!disableStrictSSL,
   singleHttpClient: !!singleHttpClient,
   cleanOutput: !!cleanOutput,

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test:--responses": "node tests/spec/responses/test.js",
     "test:specProperty": "node tests/spec/specProperty/test.js",
     "test:--module-name-index": "node tests/spec/moduleNameIndex/test.js",
+    "test:--module-name-first-tag": "node tests/spec/moduleNameFirstTag/test.js",
     "test:--modular": "node tests/spec/modular/test.js",
     "test:--single-http-client": "node tests/spec/singleHttpClient/test.js",
     "test:--extract-request-params": "node tests/spec/extractRequestParams/test.js",

--- a/src/config.js
+++ b/src/config.js
@@ -28,6 +28,9 @@ const config = {
 
   /** url index from paths used for merging into modules */
   moduleNameIndex: 0,
+
+  /** use the first tag for the module name */
+  moduleNameFirstTag: false,
   disableStrictSSL: false,
   extractRequestParams: false,
   fileNames: {

--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,7 @@ module.exports = {
     httpClientType = config.httpClientType,
     generateUnionEnums = config.generateUnionEnums,
     moduleNameIndex = config.moduleNameIndex,
+    moduleNameFirstTag = config.moduleNameFirstTag,
     extractRequestParams = config.extractRequestParams,
     defaultResponseType = config.defaultResponseType,
     singleHttpClient = config.singleHttpClient,
@@ -57,6 +58,7 @@ module.exports = {
         templates,
         generateUnionEnums,
         moduleNameIndex,
+        moduleNameFirstTag,
         prettierOptions,
         modular,
         extractRequestParams,
@@ -102,6 +104,7 @@ module.exports = {
             usageSchema,
             parsedSchemas,
             moduleNameIndex,
+            moduleNameFirstTag,
             extractRequestParams,
           });
 

--- a/src/routes.js
+++ b/src/routes.js
@@ -451,7 +451,13 @@ const getResponseBodyInfo = (routeInfo, routeParams, parsedSchemas) => {
   };
 };
 
-const parseRoutes = ({ usageSchema, parsedSchemas, moduleNameIndex, extractRequestParams }) => {
+const parseRoutes = ({
+  usageSchema,
+  parsedSchemas,
+  moduleNameIndex,
+  moduleNameFirstTag,
+  extractRequestParams,
+}) => {
   const { paths, security: globalSecurity } = usageSchema;
   const pathsEntries = _.entries(paths);
 
@@ -480,7 +486,11 @@ const parseRoutes = ({ usageSchema, parsedSchemas, moduleNameIndex, extractReque
         const { route, pathParams } = parseRoute(rawRoute);
 
         const routeId = nanoid(12);
-        const moduleName = _.camelCase(_.compact(_.split(route, "/"))[moduleNameIndex]);
+        const firstTag = tags && tags.length > 0 ? tags[0] : null;
+        const moduleName =
+          moduleNameFirstTag && firstTag
+            ? _.camelCase(firstTag)
+            : _.camelCase(_.compact(_.split(route, "/"))[moduleNameIndex]);
         const hasSecurity = !!(
           (globalSecurity && globalSecurity.length) ||
           (security && security.length)

--- a/tests/spec/moduleNameFirstTag/schema.json
+++ b/tests/spec/moduleNameFirstTag/schema.json
@@ -1,0 +1,1099 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "description": "This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.",
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "email": "apiteam@swagger.io"
+    },
+    "license": {
+      "name": "Apache-2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/v2",
+  "tags": [
+    {
+      "name": "pet",
+      "description": "Everything about your Pets",
+      "externalDocs": {
+        "description": "Find out more",
+        "url": "http://swagger.io"
+      }
+    },
+    {
+      "name": "store",
+      "description": "Access to Petstore orders"
+    },
+    {
+      "name": "user",
+      "description": "Operations about user",
+      "externalDocs": {
+        "description": "Find out more about our store",
+        "url": "http://swagger.io"
+      }
+    }
+  ],
+  "schemes": ["http"],
+  "paths": {
+    "api/v1/pet": {
+      "post": {
+        "tags": ["pet"],
+        "summary": "Add a new pet to the store",
+        "description": "",
+        "operationId": "addPet",
+        "consumes": ["application/json", "application/xml"],
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Pet object that needs to be added to the store",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          }
+        ],
+        "responses": {
+          "405": {
+            "description": "Invalid input"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": ["write:pets", "read:pets"]
+          }
+        ],
+        "x-contentType": "application/json",
+        "x-accepts": "application/json"
+      },
+      "put": {
+        "tags": ["pet"],
+        "summary": "Update an existing pet",
+        "description": "",
+        "operationId": "updatePet",
+        "consumes": ["application/json", "application/xml"],
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Pet object that needs to be added to the store",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Pet not found"
+          },
+          "405": {
+            "description": "Validation exception"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": ["write:pets", "read:pets"]
+          }
+        ],
+        "x-contentType": "application/json",
+        "x-accepts": "application/json"
+      }
+    },
+    "api/v1/pet/findByStatus": {
+      "get": {
+        "tags": ["pet"],
+        "summary": "Finds Pets by status",
+        "description": "Multiple status values can be provided with comma separated strings",
+        "operationId": "findPetsByStatus",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Status values that need to be considered for filter",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": "available",
+              "enum": ["available", "pending", "sold"]
+            },
+            "collectionFormat": "csv"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Pet"
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid status value"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": ["write:pets", "read:pets"]
+          }
+        ],
+        "x-accepts": "application/json"
+      }
+    },
+    "api/v1/pet/findByTags": {
+      "get": {
+        "tags": ["pet"],
+        "summary": "Finds Pets by tags",
+        "description": "Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.",
+        "operationId": "findPetsByTags",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "Tags to filter by",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "csv"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Pet"
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid tag value"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": ["write:pets", "read:pets"]
+          }
+        ],
+        "deprecated": true,
+        "x-accepts": "application/json"
+      }
+    },
+    "api/v1/pet/{petId}": {
+      "get": {
+        "tags": ["pet"],
+        "summary": "Find pet by ID",
+        "description": "Returns a single pet",
+        "operationId": "getPetById",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet to return",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Pet not found"
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ],
+        "x-accepts": "application/json"
+      },
+      "post": {
+        "tags": ["pet"],
+        "summary": "Updates a pet in the store with form data",
+        "description": "",
+        "operationId": "updatePetWithForm",
+        "consumes": ["application/x-www-form-urlencoded"],
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet that needs to be updated",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "name",
+            "in": "formData",
+            "description": "Updated name of the pet",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "status",
+            "in": "formData",
+            "description": "Updated status of the pet",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "405": {
+            "description": "Invalid input"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": ["write:pets", "read:pets"]
+          }
+        ],
+        "x-contentType": "application/x-www-form-urlencoded",
+        "x-accepts": "application/json"
+      },
+      "delete": {
+        "tags": ["pet"],
+        "summary": "Deletes a pet",
+        "description": "",
+        "operationId": "deletePet",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "api_key",
+            "in": "header",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "Pet id to delete",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid pet value"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": ["write:pets", "read:pets"]
+          }
+        ],
+        "x-accepts": "application/json"
+      }
+    },
+    "api/v1/pet/{petId}/uploadImage": {
+      "post": {
+        "tags": ["pet"],
+        "summary": "uploads an image",
+        "description": "",
+        "operationId": "uploadFile",
+        "consumes": ["multipart/form-data"],
+        "produces": ["application/json"],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet to update",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "additionalMetadata",
+            "in": "formData",
+            "description": "Additional data to pass to server",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "file",
+            "in": "formData",
+            "description": "file to upload",
+            "required": false,
+            "type": "file"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/ApiResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": ["write:pets", "read:pets"]
+          }
+        ],
+        "x-contentType": "multipart/form-data",
+        "x-accepts": "application/json"
+      }
+    },
+    "api/v1/store/inventory": {
+      "get": {
+        "tags": ["store"],
+        "summary": "Returns pet inventories by status",
+        "description": "Returns a map of status codes to quantities",
+        "operationId": "getInventory",
+        "produces": ["application/json"],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ],
+        "x-accepts": "application/json"
+      }
+    },
+    "api/v1/store/order": {
+      "post": {
+        "tags": ["store"],
+        "summary": "Place an order for a pet",
+        "description": "",
+        "operationId": "placeOrder",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "order placed for purchasing the pet",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Order"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/Order"
+            }
+          },
+          "400": {
+            "description": "Invalid Order"
+          }
+        },
+        "x-contentType": "application/json",
+        "x-accepts": "application/json"
+      }
+    },
+    "api/v1/store/order/{orderId}": {
+      "get": {
+        "tags": ["store"],
+        "summary": "Find purchase order by ID",
+        "description": "For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions",
+        "operationId": "getOrderById",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "orderId",
+            "in": "path",
+            "description": "ID of pet that needs to be fetched",
+            "required": true,
+            "type": "integer",
+            "maximum": 5,
+            "minimum": 1,
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/Order"
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Order not found"
+          }
+        },
+        "x-accepts": "application/json"
+      },
+      "delete": {
+        "tags": ["store"],
+        "summary": "Delete purchase order by ID",
+        "description": "For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors",
+        "operationId": "deleteOrder",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "orderId",
+            "in": "path",
+            "description": "ID of the order that needs to be deleted",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Order not found"
+          }
+        },
+        "x-accepts": "application/json"
+      }
+    },
+    "api/v1/user": {
+      "post": {
+        "tags": ["user"],
+        "summary": "Create user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "createUser",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Created user object",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        },
+        "x-contentType": "application/json",
+        "x-accepts": "application/json"
+      }
+    },
+    "api/v1/user/createWithArray": {
+      "post": {
+        "tags": ["user"],
+        "summary": "Creates list of users with given input array",
+        "description": "",
+        "operationId": "createUsersWithArrayInput",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "List of user object",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/User"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        },
+        "x-contentType": "application/json",
+        "x-accepts": "application/json"
+      }
+    },
+    "api/v1/user/createWithList": {
+      "post": {
+        "tags": ["user"],
+        "summary": "Creates list of users with given input array",
+        "description": "",
+        "operationId": "createUsersWithListInput",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "List of user object",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/User"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        },
+        "x-contentType": "application/json",
+        "x-accepts": "application/json"
+      }
+    },
+    "api/v1/user/login": {
+      "get": {
+        "tags": ["user"],
+        "summary": "Logs user into the system",
+        "description": "",
+        "operationId": "loginUser",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "username",
+            "in": "query",
+            "description": "The user name for login",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "password",
+            "in": "query",
+            "description": "The password for login in clear text",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "headers": {
+              "X-Rate-Limit": {
+                "type": "integer",
+                "format": "int32",
+                "description": "calls per hour allowed by the user"
+              },
+              "X-Expires-After": {
+                "type": "string",
+                "format": "date-time",
+                "description": "date in UTC when toekn expires"
+              }
+            },
+            "schema": {
+              "type": "string"
+            }
+          },
+          "400": {
+            "description": "Invalid username/password supplied"
+          }
+        },
+        "x-accepts": "application/json"
+      }
+    },
+    "api/v1/user/logout": {
+      "get": {
+        "tags": ["user"],
+        "summary": "Logs out current logged in user session",
+        "description": "",
+        "operationId": "logoutUser",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [],
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        },
+        "x-accepts": "application/json"
+      }
+    },
+    "api/v1/user/{username}": {
+      "get": {
+        "tags": ["user"],
+        "summary": "Get user by user name",
+        "description": "",
+        "operationId": "getUserByName",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "The name that needs to be fetched. Use user1 for testing.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          },
+          "400": {
+            "description": "Invalid username supplied"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        },
+        "x-accepts": "application/json"
+      },
+      "put": {
+        "tags": ["user"],
+        "summary": "Updated user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "updateUser",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "name that need to be deleted",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Updated user object",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid user supplied"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        },
+        "x-contentType": "application/json",
+        "x-accepts": "application/json"
+      },
+      "delete": {
+        "tags": ["user"],
+        "summary": "Delete user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "deleteUser",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "The name that needs to be deleted",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid username supplied"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        },
+        "x-accepts": "application/json"
+      }
+    },
+    "api/v1/{username}": {
+      "get": {
+        "tags": ["user"],
+        "summary": "Get user by user name",
+        "description": "",
+        "operationId": "getUserByName",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "The name that needs to be fetched. Use user1 for testing.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          },
+          "400": {
+            "description": "Invalid username supplied"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        },
+        "x-accepts": "application/json"
+      },
+      "put": {
+        "tags": ["user"],
+        "summary": "Updated user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "updateUser",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "name that need to be deleted",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Updated user object",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid user supplied"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        },
+        "x-contentType": "application/json",
+        "x-accepts": "application/json"
+      },
+      "delete": {
+        "tags": ["user"],
+        "summary": "Delete user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "deleteUser",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "The name that needs to be deleted",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid username supplied"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        },
+        "x-accepts": "application/json"
+      }
+    }
+  },
+  "securityDefinitions": {
+    "petstore_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "http://petstore.swagger.io/api/v1/oauth/dialog",
+      "flow": "implicit",
+      "scopes": {
+        "write:pets": "modify pets in your account",
+        "read:pets": "read your pets"
+      }
+    },
+    "api_key": {
+      "type": "apiKey",
+      "name": "api_key",
+      "in": "header"
+    }
+  },
+  "definitions": {
+    "Order": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "petId": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "quantity": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "shipDate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "status": {
+          "type": "string",
+          "description": "Order Status",
+          "enum": ["placed", "approved", "delivered"]
+        },
+        "complete": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "title": "Pet Order",
+      "xml": {
+        "name": "Order"
+      },
+      "description": "An order for a pets from the pet store",
+      "example": {
+        "petId": 6,
+        "quantity": 1,
+        "id": 0,
+        "shipDate": "2000-01-23T04:56:07.000+00:00",
+        "complete": false,
+        "status": "placed"
+      }
+    },
+    "Category": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "title": "Pet category",
+      "xml": {
+        "name": "Category"
+      },
+      "description": "A category for a pet",
+      "example": {
+        "name": "name",
+        "id": 6
+      }
+    },
+    "User": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "username": {
+          "type": "string"
+        },
+        "firstName": {
+          "type": "string"
+        },
+        "lastName": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        },
+        "phone": {
+          "type": "string"
+        },
+        "userStatus": {
+          "type": "integer",
+          "format": "int32",
+          "description": "User Status"
+        }
+      },
+      "title": "a User",
+      "xml": {
+        "name": "User"
+      },
+      "description": "A User who is purchasing from the pet store",
+      "example": {
+        "firstName": "firstName",
+        "lastName": "lastName",
+        "password": "password",
+        "userStatus": 6,
+        "phone": "phone",
+        "id": 0,
+        "email": "email",
+        "username": "username"
+      }
+    },
+    "Tag": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "title": "Pet Tag",
+      "xml": {
+        "name": "Tag"
+      },
+      "description": "A tag for a pet",
+      "example": {
+        "name": "name",
+        "id": 1
+      }
+    },
+    "PetNames": {
+      "type": "string",
+      "enum": ["Fluffy Hero", "Piggy Po", "Swagger Typescript Api"]
+    },
+    "PetIds": {
+      "type": "integer",
+      "enum": [10, 20, 30, 40]
+    },
+    "Pet": {
+      "type": "object",
+      "required": ["name", "photoUrls"],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "category": {
+          "$ref": "#/definitions/Category"
+        },
+        "name": {
+          "type": "string",
+          "example": "doggie"
+        },
+        "photoUrls": {
+          "type": "array",
+          "xml": {
+            "name": "photoUrl",
+            "wrapped": true
+          },
+          "items": {
+            "type": "string"
+          }
+        },
+        "tags": {
+          "type": "array",
+          "xml": {
+            "name": "tag",
+            "wrapped": true
+          },
+          "items": {
+            "$ref": "#/definitions/Tag"
+          }
+        },
+        "status": {
+          "type": "string",
+          "description": "pet status in the store",
+          "enum": ["available", "pending", "sold"]
+        }
+      },
+      "title": "a Pet",
+      "xml": {
+        "name": "Pet"
+      },
+      "description": "A pet for sale in the pet store",
+      "example": {
+        "photoUrls": ["photoUrls", "photoUrls"],
+        "name": "doggie",
+        "id": 0,
+        "category": {
+          "name": "name",
+          "id": 6
+        },
+        "tags": [
+          {
+            "name": "name",
+            "id": 1
+          },
+          {
+            "name": "name",
+            "id": 1
+          }
+        ],
+        "status": "available"
+      }
+    },
+    "ApiResponse": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "type": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        }
+      },
+      "title": "An uploaded response",
+      "description": "Describes the result of uploading an image resource",
+      "example": {
+        "code": 0,
+        "type": "type",
+        "message": "message"
+      }
+    },
+    "Amount": {
+      "type": "object",
+      "required": ["currency", "value"],
+      "properties": {
+        "value": {
+          "type": "number",
+          "format": "double",
+          "description": "some description\n",
+          "minimum": 0.01,
+          "maximum": 1000000000000000
+        },
+        "currency": {
+          "$ref": "#/definitions/Currency"
+        }
+      },
+      "description": "some description\n"
+    },
+    "Currency": {
+      "type": "string",
+      "pattern": "^[A-Z]{3,3}$",
+      "description": "some description\n"
+    }
+  },
+  "externalDocs": {
+    "description": "Find out more about Swagger",
+    "url": "http://swagger.io"
+  }
+}

--- a/tests/spec/moduleNameFirstTag/schema.ts
+++ b/tests/spec/moduleNameFirstTag/schema.ts
@@ -1,0 +1,743 @@
+/* eslint-disable */
+/* tslint:disable */
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+/**
+ * An order for a pets from the pet store
+ * @example {"petId":6,"quantity":1,"id":0,"shipDate":"2000-01-23T04:56:07.000+00:00","complete":false,"status":"placed"}
+ */
+export interface Order {
+  /** @format int64 */
+  id?: number;
+
+  /** @format int64 */
+  petId?: number;
+
+  /** @format int32 */
+  quantity?: number;
+
+  /** @format date-time */
+  shipDate?: string;
+
+  /** Order Status */
+  status?: "placed" | "approved" | "delivered";
+  complete?: boolean;
+}
+
+/**
+ * A category for a pet
+ * @example {"name":"name","id":6}
+ */
+export interface Category {
+  /** @format int64 */
+  id?: number;
+  name?: string;
+}
+
+/**
+ * A User who is purchasing from the pet store
+ * @example {"firstName":"firstName","lastName":"lastName","password":"password","userStatus":6,"phone":"phone","id":0,"email":"email","username":"username"}
+ */
+export interface User {
+  /** @format int64 */
+  id?: number;
+  username?: string;
+  firstName?: string;
+  lastName?: string;
+  email?: string;
+  password?: string;
+  phone?: string;
+
+  /**
+   * User Status
+   * @format int32
+   */
+  userStatus?: number;
+}
+
+/**
+ * A tag for a pet
+ * @example {"name":"name","id":1}
+ */
+export interface Tag {
+  /** @format int64 */
+  id?: number;
+  name?: string;
+}
+
+export enum PetNames {
+  FluffyHero = "Fluffy Hero",
+  PiggyPo = "Piggy Po",
+  SwaggerTypescriptApi = "Swagger Typescript Api",
+}
+
+export type PetIds = 10 | 20 | 30 | 40;
+
+/**
+ * A pet for sale in the pet store
+ * @example {"photoUrls":["photoUrls","photoUrls"],"name":"doggie","id":0,"category":{"name":"name","id":6},"tags":[{"name":"name","id":1},{"name":"name","id":1}],"status":"available"}
+ */
+export interface Pet {
+  /** @format int64 */
+  id?: number;
+
+  /** A category for a pet */
+  category?: Category;
+
+  /** @example doggie */
+  name: string;
+  photoUrls: string[];
+  tags?: Tag[];
+
+  /** pet status in the store */
+  status?: "available" | "pending" | "sold";
+}
+
+/**
+ * Describes the result of uploading an image resource
+ * @example {"code":0,"type":"type","message":"message"}
+ */
+export interface ApiResponse {
+  /** @format int32 */
+  code?: number;
+  type?: string;
+  message?: string;
+}
+
+/**
+ * some description
+ */
+export interface Amount {
+  /**
+   * some description
+   *
+   * @format double
+   * @min 0.01
+   * @max 1000000000000000
+   */
+  value: number;
+
+  /**
+   * some description
+   *
+   */
+  currency: Currency;
+}
+
+/**
+ * some description
+ * @pattern ^[A-Z]{3,3}$
+ */
+export type Currency = string;
+
+export type QueryParamsType = Record<string | number, any>;
+export type ResponseFormat = keyof Omit<Body, "body" | "bodyUsed">;
+
+export interface FullRequestParams extends Omit<RequestInit, "body"> {
+  /** set parameter to `true` for call `securityWorker` for this request */
+  secure?: boolean;
+  /** request path */
+  path: string;
+  /** content type of request body */
+  type?: ContentType;
+  /** query params */
+  query?: QueryParamsType;
+  /** format of response (i.e. response.json() -> format: "json") */
+  format?: ResponseFormat;
+  /** request body */
+  body?: unknown;
+  /** base url */
+  baseUrl?: string;
+  /** request cancellation token */
+  cancelToken?: CancelToken;
+}
+
+export type RequestParams = Omit<FullRequestParams, "body" | "method" | "query" | "path">;
+
+export interface ApiConfig<SecurityDataType = unknown> {
+  baseUrl?: string;
+  baseApiParams?: Omit<RequestParams, "baseUrl" | "cancelToken" | "signal">;
+  securityWorker?: (securityData: SecurityDataType | null) => Promise<RequestParams | void> | RequestParams | void;
+}
+
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+  data: D;
+  error: E;
+}
+
+type CancelToken = Symbol | string | number;
+
+export enum ContentType {
+  Json = "application/json",
+  FormData = "multipart/form-data",
+  UrlEncoded = "application/x-www-form-urlencoded",
+}
+
+export class HttpClient<SecurityDataType = unknown> {
+  public baseUrl: string = "http://petstore.swagger.io/v2";
+  private securityData: SecurityDataType | null = null;
+  private securityWorker?: ApiConfig<SecurityDataType>["securityWorker"];
+  private abortControllers = new Map<CancelToken, AbortController>();
+
+  private baseApiParams: RequestParams = {
+    credentials: "same-origin",
+    headers: {},
+    redirect: "follow",
+    referrerPolicy: "no-referrer",
+  };
+
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
+  }
+
+  public setSecurityData = (data: SecurityDataType | null) => {
+    this.securityData = data;
+  };
+
+  private addQueryParam(query: QueryParamsType, key: string) {
+    const value = query[key];
+
+    return (
+      encodeURIComponent(key) +
+      "=" +
+      encodeURIComponent(Array.isArray(value) ? value.join(",") : typeof value === "number" ? value : `${value}`)
+    );
+  }
+
+  protected toQueryString(rawQuery?: QueryParamsType): string {
+    const query = rawQuery || {};
+    const keys = Object.keys(query).filter((key) => "undefined" !== typeof query[key]);
+    return keys
+      .map((key) =>
+        typeof query[key] === "object" && !Array.isArray(query[key])
+          ? this.toQueryString(query[key] as QueryParamsType)
+          : this.addQueryParam(query, key),
+      )
+      .join("&");
+  }
+
+  protected addQueryParams(rawQuery?: QueryParamsType): string {
+    const queryString = this.toQueryString(rawQuery);
+    return queryString ? `?${queryString}` : "";
+  }
+
+  private contentFormatters: Record<ContentType, (input: any) => any> = {
+    [ContentType.Json]: (input: any) =>
+      input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
+    [ContentType.FormData]: (input: any) =>
+      Object.keys(input || {}).reduce((data, key) => {
+        data.append(key, input[key]);
+        return data;
+      }, new FormData()),
+    [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),
+  };
+
+  private mergeRequestParams(params1: RequestParams, params2?: RequestParams): RequestParams {
+    return {
+      ...this.baseApiParams,
+      ...params1,
+      ...(params2 || {}),
+      headers: {
+        ...(this.baseApiParams.headers || {}),
+        ...(params1.headers || {}),
+        ...((params2 && params2.headers) || {}),
+      },
+    };
+  }
+
+  private createAbortSignal = (cancelToken: CancelToken): AbortSignal | undefined => {
+    if (this.abortControllers.has(cancelToken)) {
+      const abortController = this.abortControllers.get(cancelToken);
+      if (abortController) {
+        return abortController.signal;
+      }
+      return void 0;
+    }
+
+    const abortController = new AbortController();
+    this.abortControllers.set(cancelToken, abortController);
+    return abortController.signal;
+  };
+
+  public abortRequest = (cancelToken: CancelToken) => {
+    const abortController = this.abortControllers.get(cancelToken);
+
+    if (abortController) {
+      abortController.abort();
+      this.abortControllers.delete(cancelToken);
+    }
+  };
+
+  public request = async <T = any, E = any>({
+    body,
+    secure,
+    path,
+    type,
+    query,
+    format = "json",
+    baseUrl,
+    cancelToken,
+    ...params
+  }: FullRequestParams): Promise<HttpResponse<T, E>> => {
+    const secureParams = (secure && this.securityWorker && (await this.securityWorker(this.securityData))) || {};
+    const requestParams = this.mergeRequestParams(params, secureParams);
+    const queryString = query && this.toQueryString(query);
+    const payloadFormatter = this.contentFormatters[type || ContentType.Json];
+
+    return fetch(`${baseUrl || this.baseUrl || ""}${path}${queryString ? `?${queryString}` : ""}`, {
+      ...requestParams,
+      headers: {
+        ...(type && type !== ContentType.FormData ? { "Content-Type": type } : {}),
+        ...(requestParams.headers || {}),
+      },
+      signal: cancelToken ? this.createAbortSignal(cancelToken) : void 0,
+      body: typeof body === "undefined" || body === null ? null : payloadFormatter(body),
+    }).then(async (response) => {
+      const r = response as HttpResponse<T, E>;
+      r.data = (null as unknown) as T;
+      r.error = (null as unknown) as E;
+
+      const data = await response[format]()
+        .then((data) => {
+          if (r.ok) {
+            r.data = data;
+          } else {
+            r.error = data;
+          }
+          return r;
+        })
+        .catch((e) => {
+          r.error = e;
+          return r;
+        });
+
+      if (cancelToken) {
+        this.abortControllers.delete(cancelToken);
+      }
+
+      if (!response.ok) throw data;
+      return data;
+    });
+  };
+}
+
+/**
+ * @title Swagger Petstore
+ * @version 1.0.0
+ * @baseUrl http://petstore.swagger.io/v2
+ * This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.
+ */
+export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDataType> {
+  pet = {
+    /**
+     * No description
+     *
+     * @tags pet
+     * @name AddPet
+     * @summary Add a new pet to the store
+     * @request POST:api/v1/pet
+     * @secure
+     */
+    addPet: (body: Pet, params: RequestParams = {}) =>
+      this.request<any, void>({
+        path: `api/v1/pet`,
+        method: "POST",
+        body: body,
+        secure: true,
+        type: ContentType.Json,
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags pet
+     * @name UpdatePet
+     * @summary Update an existing pet
+     * @request PUT:api/v1/pet
+     * @secure
+     */
+    updatePet: (body: Pet, params: RequestParams = {}) =>
+      this.request<any, void>({
+        path: `api/v1/pet`,
+        method: "PUT",
+        body: body,
+        secure: true,
+        type: ContentType.Json,
+        ...params,
+      }),
+
+    /**
+     * @description Multiple status values can be provided with comma separated strings
+     *
+     * @tags pet
+     * @name FindPetsByStatus
+     * @summary Finds Pets by status
+     * @request GET:api/v1/pet/findByStatus
+     * @secure
+     */
+    findPetsByStatus: (query: { status: ("available" | "pending" | "sold")[] }, params: RequestParams = {}) =>
+      this.request<Pet[], void>({
+        path: `api/v1/pet/findByStatus`,
+        method: "GET",
+        query: query,
+        secure: true,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+     *
+     * @tags pet
+     * @name FindPetsByTags
+     * @summary Finds Pets by tags
+     * @request GET:api/v1/pet/findByTags
+     * @secure
+     */
+    findPetsByTags: (query: { tags: string[] }, params: RequestParams = {}) =>
+      this.request<Pet[], void>({
+        path: `api/v1/pet/findByTags`,
+        method: "GET",
+        query: query,
+        secure: true,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Returns a single pet
+     *
+     * @tags pet
+     * @name GetPetById
+     * @summary Find pet by ID
+     * @request GET:api/v1/pet/{petId}
+     * @secure
+     */
+    getPetById: (petId: number, params: RequestParams = {}) =>
+      this.request<Pet, void>({
+        path: `api/v1/pet/${petId}`,
+        method: "GET",
+        secure: true,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags pet
+     * @name UpdatePetWithForm
+     * @summary Updates a pet in the store with form data
+     * @request POST:api/v1/pet/{petId}
+     * @secure
+     */
+    updatePetWithForm: (petId: number, data: { name?: string; status?: string }, params: RequestParams = {}) =>
+      this.request<any, void>({
+        path: `api/v1/pet/${petId}`,
+        method: "POST",
+        body: data,
+        secure: true,
+        type: ContentType.FormData,
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags pet
+     * @name DeletePet
+     * @summary Deletes a pet
+     * @request DELETE:api/v1/pet/{petId}
+     * @secure
+     */
+    deletePet: (petId: number, params: RequestParams = {}) =>
+      this.request<any, void>({
+        path: `api/v1/pet/${petId}`,
+        method: "DELETE",
+        secure: true,
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags pet
+     * @name UploadFile
+     * @summary uploads an image
+     * @request POST:api/v1/pet/{petId}/uploadImage
+     * @secure
+     */
+    uploadFile: (petId: number, data: { additionalMetadata?: string; file?: File }, params: RequestParams = {}) =>
+      this.request<ApiResponse, any>({
+        path: `api/v1/pet/${petId}/uploadImage`,
+        method: "POST",
+        body: data,
+        secure: true,
+        type: ContentType.FormData,
+        format: "json",
+        ...params,
+      }),
+  };
+  store = {
+    /**
+     * @description Returns a map of status codes to quantities
+     *
+     * @tags store
+     * @name GetInventory
+     * @summary Returns pet inventories by status
+     * @request GET:api/v1/store/inventory
+     * @secure
+     */
+    getInventory: (params: RequestParams = {}) =>
+      this.request<Record<string, number>, any>({
+        path: `api/v1/store/inventory`,
+        method: "GET",
+        secure: true,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags store
+     * @name PlaceOrder
+     * @summary Place an order for a pet
+     * @request POST:api/v1/store/order
+     */
+    placeOrder: (body: Order, params: RequestParams = {}) =>
+      this.request<Order, void>({
+        path: `api/v1/store/order`,
+        method: "POST",
+        body: body,
+        type: ContentType.Json,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
+     *
+     * @tags store
+     * @name GetOrderById
+     * @summary Find purchase order by ID
+     * @request GET:api/v1/store/order/{orderId}
+     */
+    getOrderById: (orderId: number, params: RequestParams = {}) =>
+      this.request<Order, void>({
+        path: `api/v1/store/order/${orderId}`,
+        method: "GET",
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
+     *
+     * @tags store
+     * @name DeleteOrder
+     * @summary Delete purchase order by ID
+     * @request DELETE:api/v1/store/order/{orderId}
+     */
+    deleteOrder: (orderId: string, params: RequestParams = {}) =>
+      this.request<any, void>({
+        path: `api/v1/store/order/${orderId}`,
+        method: "DELETE",
+        ...params,
+      }),
+  };
+  user = {
+    /**
+     * @description This can only be done by the logged in user.
+     *
+     * @tags user
+     * @name CreateUser
+     * @summary Create user
+     * @request POST:api/v1/user
+     */
+    createUser: (body: User, params: RequestParams = {}) =>
+      this.request<any, void>({
+        path: `api/v1/user`,
+        method: "POST",
+        body: body,
+        type: ContentType.Json,
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags user
+     * @name CreateUsersWithArrayInput
+     * @summary Creates list of users with given input array
+     * @request POST:api/v1/user/createWithArray
+     */
+    createUsersWithArrayInput: (body: User[], params: RequestParams = {}) =>
+      this.request<any, void>({
+        path: `api/v1/user/createWithArray`,
+        method: "POST",
+        body: body,
+        type: ContentType.Json,
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags user
+     * @name CreateUsersWithListInput
+     * @summary Creates list of users with given input array
+     * @request POST:api/v1/user/createWithList
+     */
+    createUsersWithListInput: (body: User[], params: RequestParams = {}) =>
+      this.request<any, void>({
+        path: `api/v1/user/createWithList`,
+        method: "POST",
+        body: body,
+        type: ContentType.Json,
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags user
+     * @name LoginUser
+     * @summary Logs user into the system
+     * @request GET:api/v1/user/login
+     */
+    loginUser: (query: { username: string; password: string }, params: RequestParams = {}) =>
+      this.request<Currency, void>({
+        path: `api/v1/user/login`,
+        method: "GET",
+        query: query,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags user
+     * @name LogoutUser
+     * @summary Logs out current logged in user session
+     * @request GET:api/v1/user/logout
+     */
+    logoutUser: (params: RequestParams = {}) =>
+      this.request<any, void>({
+        path: `api/v1/user/logout`,
+        method: "GET",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags user
+     * @name GetUserByName
+     * @summary Get user by user name
+     * @request GET:api/v1/user/{username}
+     */
+    getUserByName: (username: string, params: RequestParams = {}) =>
+      this.request<User, void>({
+        path: `api/v1/user/${username}`,
+        method: "GET",
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description This can only be done by the logged in user.
+     *
+     * @tags user
+     * @name UpdateUser
+     * @summary Updated user
+     * @request PUT:api/v1/user/{username}
+     */
+    updateUser: (username: string, body: User, params: RequestParams = {}) =>
+      this.request<any, void>({
+        path: `api/v1/user/${username}`,
+        method: "PUT",
+        body: body,
+        type: ContentType.Json,
+        ...params,
+      }),
+
+    /**
+     * @description This can only be done by the logged in user.
+     *
+     * @tags user
+     * @name DeleteUser
+     * @summary Delete user
+     * @request DELETE:api/v1/user/{username}
+     */
+    deleteUser: (username: string, params: RequestParams = {}) =>
+      this.request<any, void>({
+        path: `api/v1/user/${username}`,
+        method: "DELETE",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags user
+     * @name GetUserByName2
+     * @summary Get user by user name
+     * @request GET:api/v1/{username}
+     * @originalName getUserByName
+     * @duplicate
+     */
+    getUserByName2: (username: string, params: RequestParams = {}) =>
+      this.request<User, void>({
+        path: `api/v1/${username}`,
+        method: "GET",
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description This can only be done by the logged in user.
+     *
+     * @tags user
+     * @name UpdateUser2
+     * @summary Updated user
+     * @request PUT:api/v1/{username}
+     * @originalName updateUser
+     * @duplicate
+     */
+    updateUser2: (username: string, body: User, params: RequestParams = {}) =>
+      this.request<any, void>({
+        path: `api/v1/${username}`,
+        method: "PUT",
+        body: body,
+        type: ContentType.Json,
+        ...params,
+      }),
+
+    /**
+     * @description This can only be done by the logged in user.
+     *
+     * @tags user
+     * @name DeleteUser2
+     * @summary Delete user
+     * @request DELETE:api/v1/{username}
+     * @originalName deleteUser
+     * @duplicate
+     */
+    deleteUser2: (username: string, params: RequestParams = {}) =>
+      this.request<any, void>({
+        path: `api/v1/${username}`,
+        method: "DELETE",
+        ...params,
+      }),
+  };
+}

--- a/tests/spec/moduleNameFirstTag/test.js
+++ b/tests/spec/moduleNameFirstTag/test.js
@@ -1,0 +1,26 @@
+const { generateApi } = require("../../../src");
+const { resolve } = require("path");
+const validateGeneratedModule = require("../../helpers/validateGeneratedModule");
+const createSchemasInfos = require("../../helpers/createSchemaInfos");
+
+const schemas = createSchemasInfos({ absolutePathToSchemas: resolve(__dirname, "./") });
+
+schemas.forEach(({ absolutePath, apiFileName }) => {
+  generateApi({
+    silent: true,
+    name: apiFileName,
+    spec: require(absolutePath),
+    output: resolve(__dirname, "./"),
+    moduleNameFirstTag: true,
+  })
+    .then(() => {
+      const diagnostics = validateGeneratedModule({
+        pathToFile: resolve(__dirname, `./${apiFileName}`),
+      });
+      if (diagnostics.length) throw "Failed";
+    })
+    .catch((e) => {
+      console.error("moduleNameFirstTag option test failed.");
+      throw e;
+    });
+});


### PR DESCRIPTION
Adds an option to split the routes/API based on the first tag of the operation.

This feature is inspired by the `--module-name-index` option, which didn't quite work for our use case. We have more complex nested routes - like `/api/company/{companyId}/employee/{employeeId}`, which are driven by corporate security policies. Splitting on the index in the URL didn't work - in this example we have company operations and employee operations.

The solution: use the first tag for the operation as the module name. Tags in the openapi/swagger spec are collections/arrays, so should be stable.

For us, we then create a company class, an employee class, etc.
