### PR TITLE
Fix boolean enum handling

### DIFF
--- a/src/schema.js
+++ b/src/schema.js
@@ -234,7 +234,7 @@ const schemaParsers = {
     const enumNamesAsValues = config.enumNamesAsValues;
     const keyType = getType(schema);
     const enumNames = getEnumNames(schema);
-    const isIntegerEnum = keyType === types.number;
+    const isIntegerOrBooleanEnum = keyType === types.number || keyType === types.boolean;
     let content = null;
 
     if (_.isArray(enumNames) && _.size(enumNames)) {
@@ -253,15 +253,20 @@ const schemaParsers = {
         return {
           key: formattedKey,
           type: keyType,
-          value: enumValue === null ? enumValue : isIntegerEnum ? `${enumValue}` : `"${enumValue}"`,
+          value:
+            enumValue === null
+              ? enumValue
+              : isIntegerOrBooleanEnum
+              ? `${enumValue}`
+              : `"${enumValue}"`,
         };
       });
     } else {
       content = _.map(schema.enum, (key) => {
         return {
-          key: isIntegerEnum ? key : formatModelName(key),
+          key: isIntegerOrBooleanEnum ? key : formatModelName(key),
           type: keyType,
-          value: key === null ? key : isIntegerEnum ? `${key}` : `"${key}"`,
+          value: key === null ? key : isIntegerOrBooleanEnum ? `${key}` : `"${key}"`,
         };
       });
     }
@@ -272,7 +277,7 @@ const schemaParsers = {
       schemaType: SCHEMA_TYPES.ENUM,
       type: SCHEMA_TYPES.ENUM,
       keyType: keyType,
-      typeIdentifier: !enumNames && isIntegerEnum ? TS_KEYWORDS.TYPE : TS_KEYWORDS.ENUM,
+      typeIdentifier: !enumNames && isIntegerOrBooleanEnum ? TS_KEYWORDS.TYPE : TS_KEYWORDS.ENUM,
       name: typeName,
       description: formatDescription(schema.description),
       content,

--- a/tests/spec/unionEnums/schema.json
+++ b/tests/spec/unionEnums/schema.json
@@ -14,6 +14,10 @@
         "enum": [1, 2, 3, 4],
         "type": "number"
       },
+      "BooleanEnum": {
+        "enum": ["true", "false"],
+        "type": "boolean"
+      },
       "IntEnumWithNames": {
         "enum": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
         "type": "integer",

--- a/tests/spec/unionEnums/schema.ts
+++ b/tests/spec/unionEnums/schema.ts
@@ -13,6 +13,8 @@ export type StringEnum = "String1" | "String2" | "String3" | "String4";
 
 export type NumberEnum = 1 | 2 | 3 | 4;
 
+export type BooleanEnum = "true" | "false";
+
 /**
  * FooBar
  * @format int32

--- a/tests/spec/unionEnums/schema.ts
+++ b/tests/spec/unionEnums/schema.ts
@@ -13,7 +13,7 @@ export type StringEnum = "String1" | "String2" | "String3" | "String4";
 
 export type NumberEnum = 1 | 2 | 3 | 4;
 
-export type BooleanEnum = "true" | "false";
+export type BooleanEnum = true | false;
 
 /**
  * FooBar


### PR DESCRIPTION
Hello.
First, I really appreciate typescript-specialized codegen project!
I've got here searching for alternatives to swagger-codegen, openapi-generator as both of these didn't feel seamless & neat with typescript.

Trying swagger-typescript-api, I found this little bug. please give me a feedback :)

as-is:
```typescript
export type BooleanEnum = "true" | "false";
```

to-be:
```ts
export type BooleanEnum = true | false;
```