### PR TITLE
Allow passing custom fetch function

### DIFF
--- a/templates/base/http-clients/fetch-http-client.eta
+++ b/templates/base/http-clients/fetch-http-client.eta
@@ -51,6 +51,7 @@ export class HttpClient<SecurityDataType = unknown> {
     private securityData: SecurityDataType | null = null;
     private securityWorker?: ApiConfig<SecurityDataType>["securityWorker"];
     private abortControllers = new Map<CancelToken, AbortController>();
+    private customFetch = fetch;
 
     private baseApiParams: RequestParams = {
         credentials: 'same-origin',
@@ -59,8 +60,9 @@ export class HttpClient<SecurityDataType = unknown> {
         referrerPolicy: 'no-referrer',
     }
 
-    constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    constructor(apiConfig: ApiConfig<SecurityDataType> = {}, customFetch = fetch) {
         Object.assign(this, apiConfig);
+        this.customFetch = fetch;
     }
 
     public setSecurityData = (data: SecurityDataType | null) => {
@@ -158,7 +160,7 @@ export class HttpClient<SecurityDataType = unknown> {
         const queryString = query && this.toQueryString(query);
         const payloadFormatter = this.contentFormatters[type || ContentType.Json];
 
-        return fetch(
+        return this.customFetch(
         `${baseUrl || this.baseUrl || ""}${path}${queryString ? `?${queryString}` : ""}`,
         {
             ...requestParams,

--- a/templates/base/http-clients/fetch-http-client.eta
+++ b/templates/base/http-clients/fetch-http-client.eta
@@ -62,7 +62,7 @@ export class HttpClient<SecurityDataType = unknown> {
 
     constructor(apiConfig: ApiConfig<SecurityDataType> = {}, customFetch = fetch) {
         Object.assign(this, apiConfig);
-        this.customFetch = fetch;
+        this.customFetch = customFetch;
     }
 
     public setSecurityData = (data: SecurityDataType | null) => {

--- a/templates/base/http-clients/fetch-http-client.eta
+++ b/templates/base/http-clients/fetch-http-client.eta
@@ -31,6 +31,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
     baseUrl?: string;
     baseApiParams?: Omit<RequestParams, "baseUrl" | "cancelToken" | "signal">;
     securityWorker?: (securityData: SecurityDataType | null) => Promise<RequestParams | void> | RequestParams | void;
+    customFetch?: (input: RequestInfo, init?: RequestInit) => Promise<Response>
 }
 
 export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
@@ -60,9 +61,8 @@ export class HttpClient<SecurityDataType = unknown> {
         referrerPolicy: 'no-referrer',
     }
 
-    constructor(apiConfig: ApiConfig<SecurityDataType> = {}, customFetch = fetch) {
+    constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
         Object.assign(this, apiConfig);
-        this.customFetch = customFetch;
     }
 
     public setSecurityData = (data: SecurityDataType | null) => {
@@ -120,7 +120,7 @@ export class HttpClient<SecurityDataType = unknown> {
             },
         };
     }
-    
+
     private createAbortSignal = (cancelToken: CancelToken): AbortSignal | undefined => {
         if (this.abortControllers.has(cancelToken)) {
             const abortController = this.abortControllers.get(cancelToken);
@@ -129,7 +129,7 @@ export class HttpClient<SecurityDataType = unknown> {
             }
             return void 0;
         }
-        
+
         const abortController = new AbortController();
         this.abortControllers.set(cancelToken, abortController);
         return abortController.signal;
@@ -143,7 +143,7 @@ export class HttpClient<SecurityDataType = unknown> {
             this.abortControllers.delete(cancelToken);
         }
     }
-    
+
     public request = async <T = any, E = any>({
         body,
         secure,
@@ -189,7 +189,7 @@ export class HttpClient<SecurityDataType = unknown> {
                     r.error = e;
                     return r;
                 });
-      
+
             if (cancelToken) {
                 this.abortControllers.delete(cancelToken);
             }


### PR DESCRIPTION
This PR introduces a small feature where fetch function used within the HttpClient class can be customized.

Allowing to pass a custom fetch function enables a few things -

- Add implicit telemetry to the fetch function
- hook into before and after the function call is made in a generic way
- Handle special cases in a generic way around fetch function itself

Implements the feature from: #219