### PR TITLE
disableProxy option, added catch to axios get

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -77,6 +77,10 @@ interface GenerateApiParams {
    */
   disableStrictSSL?: boolean;
   /**
+   * disabled Proxy
+   */
+  disableProxy?: boolean;
+  /**
    * generate separated files for http client, data contracts, and routes (default: false)
    */
   modular?: boolean;
@@ -275,6 +279,7 @@ export interface GenerateApiConfiguration {
     moduleNameIndex: number;
     moduleNameFirstTag: boolean;
     disableStrictSSL: boolean;
+    disableProxy: boolean;
     extractRequestParams: boolean;
     fileNames: {
       dataContracts: string;

--- a/index.js
+++ b/index.js
@@ -63,6 +63,7 @@ program
   )
   .option("--module-name-first-tag", "splits routes based on the first tag", false)
   .option("--disableStrictSSL", "disabled strict SSL", false)
+  .option("--disableProxy", "disabled proxy", false)
   .option("--axios", "generate axios http client", false)
   .option("--single-http-client", "Ability to send HttpClient instance to Api constructor", false)
   .option("--silent", "Output only errors to console", false)
@@ -94,6 +95,7 @@ const {
   extractRequestParams,
   enumNamesAsValues,
   disableStrictSSL,
+  disableProxy,
   cleanOutput,
   defaultResponse,
   singleHttpClient,
@@ -123,6 +125,7 @@ generateApi({
   moduleNameIndex: +(moduleNameIndex || 0),
   moduleNameFirstTag: moduleNameFirstTag,
   disableStrictSSL: !!disableStrictSSL,
+  disableProxy: !!disableProxy,
   singleHttpClient: !!singleHttpClient,
   cleanOutput: !!cleanOutput,
   silent: !!silent,

--- a/src/config.js
+++ b/src/config.js
@@ -32,6 +32,7 @@ const config = {
   /** use the first tag for the module name */
   moduleNameFirstTag: false,
   disableStrictSSL: false,
+  disableProxy: false,
   extractRequestParams: false,
   fileNames: {
     dataContracts: "data-contracts",

--- a/src/index.js
+++ b/src/index.js
@@ -48,6 +48,7 @@ module.exports = {
     extraTemplates,
     enumNamesAsValues,
     disableStrictSSL = config.disableStrictSSL,
+    disableProxy = config.disableProxy,
     cleanOutput,
     silent = config.silent,
     typePrefix = config.typePrefix,
@@ -70,6 +71,7 @@ module.exports = {
         hooks: _.merge(config.hooks, rawHooks || {}),
         enumNamesAsValues,
         disableStrictSSL,
+        disableProxy,
         cleanOutput,
         defaultResponseType,
         singleHttpClient,
@@ -79,7 +81,10 @@ module.exports = {
         typePrefix,
         typeSuffix,
       });
-      (spec ? convertSwaggerObject(spec) : getSwaggerObject(input, url, disableStrictSSL))
+      (spec
+        ? convertSwaggerObject(spec)
+        : getSwaggerObject(input, url, disableStrictSSL, disableProxy)
+      )
         .then(({ usageSchema, originalSchema }) => {
           const templatePaths = getTemplatePaths(config);
 

--- a/src/swagger.js
+++ b/src/swagger.js
@@ -17,25 +17,35 @@ const parseSwaggerFile = (file) => {
   }
 };
 
-const getSwaggerFile = (pathToSwagger, urlToSwagger, disableStrictSSL) =>
+const getSwaggerFile = (pathToSwagger, urlToSwagger, disableStrictSSL, disableProxy) =>
   new Promise((resolve) => {
     if (pathIsExist(pathToSwagger)) {
       log(`try to get swagger by path "${pathToSwagger}"`);
       resolve(getFileContent(pathToSwagger));
     } else {
       log(`try to get swagger by url "${urlToSwagger}"`);
-      let agent = undefined;
+      // setup options for Axios
+      const axiosOptions = {};
+      //
       if (disableStrictSSL) {
-        agent = new https.Agent({
+        axiosOptions.httpsAgent = new https.Agent({
           rejectUnauthorized: false,
         });
       }
-      axios.get(urlToSwagger, { httpsAgent: agent }).then((res) => resolve(res.data));
+      //
+      if (disableProxy) axiosOptions.proxy = false;
+      //
+      axios
+        .get(urlToSwagger, axiosOptions)
+        .then((res) => resolve(res.data))
+        .catch((err) =>
+          log(`error while getting swagger by URL ${urlToSwagger}: ${JSON.stringify(err)}`),
+        );
     }
   });
 
-const getSwaggerObject = (pathToSwagger, urlToSwagger, disableStrictSSL) =>
-  getSwaggerFile(pathToSwagger, urlToSwagger, disableStrictSSL).then((file) =>
+const getSwaggerObject = (pathToSwagger, urlToSwagger, disableStrictSSL, disableProxy) =>
+  getSwaggerFile(pathToSwagger, urlToSwagger, disableStrictSSL, disableProxy).then((file) =>
     convertSwaggerObject(parseSwaggerFile(file)),
   );
 


### PR DESCRIPTION
Hi, recently I had problems using swagger-typescript-api at work.

After some investigations I found that our corporate proxy was the problem, and was simply solved by adding "proxy: false" to Axios options.

I also added a catch clause in the Axios GET to print out some infos and to avoid missing "catch" error from nodeJS.

Hope you will include it in next release!

Tnx
Fabio