### PR TITLE
Consider 2xx a successful status

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -117,7 +117,8 @@ const getRequestInfoTypes = ({ requestInfos, parsedSchemas, operationId, default
 
 const isSuccessStatus = (status) =>
   (config.defaultResponseAsSuccess && status === "default") ||
-  (+status >= SUCCESS_RESPONSE_STATUS_RANGE[0] && +status < SUCCESS_RESPONSE_STATUS_RANGE[1]);
+  (+status >= SUCCESS_RESPONSE_STATUS_RANGE[0] && +status < SUCCESS_RESPONSE_STATUS_RANGE[1]) ||
+  status === "2xx";
 
 const parseRoute = (route) => {
   const pathParamMatches = (route || "").match(


### PR DESCRIPTION
OpenAPI allows specifying range response codes (https://swagger.io/docs/specification/describing-responses/). I don't think it's particularly good code style tbh, but "2xx" should still probably be considered a successful response