### PR TITLE
fix(types): add silent as param in declarations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -89,6 +89,10 @@ interface GenerateApiParams {
    */
   prettier?: object;
   /**
+   * Output only errors to console (default: false)
+   */
+  silent?: boolean;
+  /**
    * default type for empty response schema (default: "void")
    */
   defaultResponseType?: boolean;


### PR DESCRIPTION
`silent` was added as an option in 6.1.0.
https://github.com/acacode/swagger-typescript-api/pull/185