### PR TITLE
fix: formdata in axios template

### DIFF
--- a/templates/base/http-clients/axios-http-client.eta
+++ b/templates/base/http-clients/axios-http-client.eta
@@ -103,7 +103,7 @@ export class HttpClient<SecurityDataType = unknown> {
           requestParams.headers.post = {};
           requestParams.headers.put = {};
 
-          const formData = this.createFormData(body as Record<string, unknown>);
+          body = this.createFormData(body as Record<string, unknown>);
         }
 
         return this.instance.request({

--- a/tests/spec/axios/schema.ts
+++ b/tests/spec/axios/schema.ts
@@ -1547,7 +1547,7 @@ export class HttpClient<SecurityDataType = unknown> {
       requestParams.headers.post = {};
       requestParams.headers.put = {};
 
-      const formData = this.createFormData(body as Record<string, unknown>);
+      body = this.createFormData(body as Record<string, unknown>);
     }
 
     return this.instance.request({

--- a/tests/spec/axiosSingleHttpClient/schema.ts
+++ b/tests/spec/axiosSingleHttpClient/schema.ts
@@ -1547,7 +1547,7 @@ export class HttpClient<SecurityDataType = unknown> {
       requestParams.headers.post = {};
       requestParams.headers.put = {};
 
-      const formData = this.createFormData(body as Record<string, unknown>);
+      body = this.createFormData(body as Record<string, unknown>);
     }
 
     return this.instance.request({

--- a/tests/spec/jsAxios/schema.js
+++ b/tests/spec/jsAxios/schema.js
@@ -34,7 +34,7 @@ export class HttpClient {
         requestParams.headers.common = { Accept: "*/*" };
         requestParams.headers.post = {};
         requestParams.headers.put = {};
-        const formData = this.createFormData(body);
+        body = this.createFormData(body);
       }
       return this.instance.request({
         ...requestParams,


### PR DESCRIPTION
Currently FormData is not correctly handled in the axios template.

FormData is correctly built but not passed to axios, causing the requests to fail.