### PR TITLE
fix: fix missing `title` of object type

### DIFF
--- a/src/schema.js
+++ b/src/schema.js
@@ -140,6 +140,7 @@ const getObjectTypeContent = (schema) => {
 
     return {
       $$raw: property,
+      title: property.title,
       description: _.compact([
         property.description ||
           _.compact(_.map(property[getComplexType(property)], "description"))[0] ||

--- a/src/typeFormatters.js
+++ b/src/typeFormatters.js
@@ -18,10 +18,10 @@ const formatters = {
       const extraSpace = "  ";
       const result = `${extraSpace}${part.field};\n`;
 
-      const comments = _.compact([part.title, part.description]).reduce(
+      const comments = _.uniq(_.compact([part.title, part.description]).reduce(
         (acc, comment) => [...acc, ...comment.split(/\n/g)],
         [],
-      );
+      ));
 
       const commonText = comments.length
         ? [


### PR DESCRIPTION
```json
...
"properties": {
  "level": {
    "type": "number",
    "title": "信用等级",
    "description": "信用等级"
  }
},
```

Should be return `content` is:

```ts
 /** 信用等级 */
level: number;
```