### PR TITLE
feat: add documentation and types for unwrapResponseData

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Options:
   --disableProxy                disabled proxy (default: false)
   --clean-output                clean output folder before generate api. WARNING: May cause data loss (default: false)
   --axios                       generate axios http client (default: false)
+  --unwrap-response-data        unwrap the data item from the response
   --single-http-client          Ability to send HttpClient instance to Api constructor (default: false)
   --silent                      Output only errors to console (default: false)
   --default-response <type>     default type for empty response schema (default: "void")
@@ -99,6 +100,7 @@ generateApi({
   toJS: false,
   extractRequestParams: false,
   extractRequestBody: false,
+  unwrapResponseData: false,
   prettier: {
     printWidth: 120,
     tabWidth: 2,

--- a/index.d.ts
+++ b/index.d.ts
@@ -60,6 +60,11 @@ interface GenerateApiParams {
   generateResponses?: boolean;
 
   /**
+   * unwrap the data item from the response
+   */
+  unwrapResponseData?: boolean;
+
+  /**
    * generate js api module with declaration file (default: false)
    */
   toJS?: boolean;
@@ -309,6 +314,7 @@ export interface GenerateApiConfiguration {
     disableStrictSSL: boolean;
     disableProxy: boolean;
     extractRequestParams: boolean;
+    unwrapResponseData: boolean;
     fileNames: {
       dataContracts: string;
       routeTypes: string;


### PR DESCRIPTION
# Documentation and types for unwrapResponseData

I didn't know there was a unwrapResponseData feature until I randomly came across it in the templates.

This change makes the option easier to discover by adding it to README.md and enables it in TypeScript via index.d.ts