### PR TITLE
document approach to disabling output

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ const fs = require("fs");
 /* NOTE: all fields are optional expect one of `output`, `url`, `spec` */
 generateApi({
   name: "MySuperbApi.ts",
+  // set to `false` to prevent the tool from writing to disk
   output: path.resolve(process.cwd(), "./src/__generated__"),
   url: 'http://api.com/swagger.json',
   input: path.resolve(process.cwd(), './foo/swagger.json'),

--- a/index.d.ts
+++ b/index.d.ts
@@ -20,9 +20,12 @@ interface GenerateApiParams {
   name?: string;
 
   /**
-   * path to folder where will been located the created api module
+   * path to folder where will been located the created api module.
+   *
+   * may set to `false` to skip writing content to disk. in this case,
+   * you may access the `files` on the return value.
    */
-  output?: string;
+  output?: string | false;
 
   /**
    * path to folder containing templates (default: ./scr/templates)


### PR DESCRIPTION
Looks like this is possible (not supported, maybe?) but not documented. Helps out a lot with using the exposed API with custom behavior on the tool's output.