### PR TITLE
Fix: unable to cancel fetch request with AbortSignal

### DIFF
--- a/templates/base/http-clients/fetch-http-client.eta
+++ b/templates/base/http-clients/fetch-http-client.eta
@@ -183,7 +183,7 @@ export class HttpClient<SecurityDataType = unknown> {
             ...(type && type !== ContentType.FormData ? { "Content-Type": type } : {}),
             ...(requestParams.headers || {}),
             },
-            signal: cancelToken ? this.createAbortSignal(cancelToken) : void 0,
+            signal: cancelToken ? this.createAbortSignal(cancelToken) : requestParams.signal,
             body: typeof body === "undefined" || body === null ? null : payloadFormatter(body),
         }
         ).then(async (response) => {


### PR DESCRIPTION
Passed [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) is overridden by `signal: undefined` here: https://github.com/acacode/swagger-typescript-api/blob/7df956c236d1e7fc051658cd7012c8ea22286b44/templates/base/http-clients/fetch-http-client.eta#L186 it will never be passed to `fetch` function