### PR TITLE
improve binary payload support

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -9,6 +9,7 @@ const TS_KEYWORDS = {
   UNDEFINED: "undefined",
   OBJECT: "object",
   FILE: "File",
+  ARRAY_BUFFER: "ArrayBuffer",
   DATE: "Date",
   TYPE: "type",
   ENUM: "enum",

--- a/src/routes.js
+++ b/src/routes.js
@@ -369,6 +369,7 @@ const CONTENT_KIND = {
   URL_ENCODED: "URL_ENCODED",
   FORM_DATA: "FORM_DATA",
   IMAGE: "IMAGE",
+  OCTET_STREAM: "OCTET_STREAM",
   OTHER: "OTHER",
 };
 
@@ -390,6 +391,10 @@ const getContentKind = (contentTypes) => {
 
   if (_.some(contentTypes, (contentType) => _.includes(contentType, "image/"))) {
     return CONTENT_KIND.IMAGE;
+  }
+
+  if (contentTypes.includes("application/octet-stream")) {
+    return CONTENT_KIND.OCTET_STREAM;
   }
 
   return CONTENT_KIND.OTHER;

--- a/src/schema.js
+++ b/src/schema.js
@@ -17,7 +17,7 @@ const types = {
     $default: TS_KEYWORDS.STRING,
 
     /** formats */
-    binary: TS_KEYWORDS.FILE,
+    binary: TS_KEYWORDS.ARRAY_BUFFER,
   },
   array: ({ items, ...schemaPart }) => {
     const content = getInlineParseContent(items);

--- a/templates/base/http-clients/axios-http-client.eta
+++ b/templates/base/http-clients/axios-http-client.eta
@@ -96,7 +96,7 @@ export class HttpClient<SecurityDataType = unknown> {
 <% } %>
         const secureParams = ((typeof secure === 'boolean' ? secure : this.secure) && this.securityWorker && (await this.securityWorker(this.securityData))) || {};
         const requestParams = this.mergeRequestParams(params, secureParams);
-        const responseFormat = (format && this.format) || void 0;
+        const responseFormat = format || this.format || void 0;
 
         if (type === ContentType.FormData && body && body !== null && typeof body === "object") {
           requestParams.headers.common = { Accept: "*/*" };

--- a/templates/default/procedure-call.eta
+++ b/templates/default/procedure-call.eta
@@ -55,7 +55,8 @@ const requestContentKind = {
 const responseContentKind = {
     "JSON": '"json"',
     "IMAGE": '"blob"',
-    "FORM_DATA": isFetchTemplate ? '"formData"' : '"document"'
+    "FORM_DATA": isFetchTemplate ? '"formData"' : '"document"',
+    "OCTET_STREAM": '"arraybuffer"',
 }
 
 const bodyTmpl = _.get(payload, "name") || null;

--- a/templates/modular/procedure-call.eta
+++ b/templates/modular/procedure-call.eta
@@ -55,7 +55,8 @@ const requestContentKind = {
 const responseContentKind = {
     "JSON": '"json"',
     "IMAGE": '"blob"',
-    "FORM_DATA": isFetchTemplate ? '"formData"' : '"document"'
+    "FORM_DATA": isFetchTemplate ? '"formData"' : '"document"',
+    "OCTET_STREAM": '"arraybuffer"',
 }
 
 const bodyTmpl = _.get(payload, "name") || null;

--- a/tests/spec/templates/spec_templates/procedure-call.eta
+++ b/tests/spec/templates/spec_templates/procedure-call.eta
@@ -55,7 +55,8 @@ const requestContentKind = {
 const responseContentKind = {
     "JSON": '"json"',
     "IMAGE": '"blob"',
-    "FORM_DATA": isFetchTemplate ? '"formData"' : '"document"'
+    "FORM_DATA": isFetchTemplate ? '"formData"' : '"document"',
+    "OCTET_STREAM": '"arraybuffer"',
 }
 
 const bodyTmpl = _.get(payload, "name") || null;


### PR DESCRIPTION
Hi. Thanks for the very useful generator. We had some issues where the generated code was slightly wrong in the case of binary payloads when using Axios though. This PR contains some fixes which were useful for our specific needs:

- fix missing `responseFormat` for requests which have an octet-stream content-type response
- use ArrayBuffer type instead of File for both browser and node compatibility

Let me known if you are interested in merging some of these fixes - with or without additional code changes. Thanks!
 
 Example section (used for sending protobuf responses):
 
 ```
       requestBody:
        content:
          application/octet-stream:
            schema:
              type: string
              format: binary
        required: true
 ```
 