### PR TITLE
Pass through required properties to allOf children

### DIFF
--- a/src/schema.js
+++ b/src/schema.js
@@ -188,7 +188,7 @@ const complexSchemaParsers = {
   },
   [SCHEMA_TYPES.COMPLEX_ALL_OF]: (schema) => {
     // T1 & T2
-    const combined = _.map(schema.allOf, complexTypeGetter);
+    const combined = _.map(schema.allOf.map(s => _.merge({ required: schema.required }, s)), complexTypeGetter);
     return checkAndAddNull(
       schema,
       filterContents(combined, [...JS_EMPTY_TYPES, ...JS_PRIMITIVE_TYPES, TS_KEYWORDS.ANY]).join(

--- a/tests/generated/v3.0/allof-example.ts
+++ b/tests/generated/v3.0/allof-example.ts
@@ -13,7 +13,7 @@ export interface Pet {
   pet_type: string;
 }
 
-export type Dog = Pet & { bark?: boolean; breed?: "Dingo" | "Husky" | "Retriever" | "Shepherd" };
+export type Dog = Pet & { bark?: boolean; breed: "Dingo" | "Husky" | "Retriever" | "Shepherd" };
 
 export type Cat = Pet & { hunts?: boolean; age?: number };
 

--- a/tests/schemas/v3.0/allof-example.yaml
+++ b/tests/schemas/v3.0/allof-example.yaml
@@ -29,7 +29,9 @@ components:
       discriminator:
         propertyName: pet_type
     Dog:     # "Dog" is a value for the pet_type property (the discriminator value)
-      allOf: # Combines the main `Pet` schema with `Dog`-specific properties 
+      required:
+        - breed
+      allOf: # Combines the main `Pet` schema with `Dog`-specific properties
         - $ref: '#/components/schemas/Pet'
         - type: object
           # all other properties specific to a `Dog`


### PR DESCRIPTION
When combining elements using `allOf` the required fields should be passed through so that the ts definitions do not define a required field in the child object as optional.  

I limited the scope of the changes to COMPLEX_ALL_OF as that is my use case, but happy to expand to other complex types for consistency if it makes sense.