### PR TITLE
fix: change COMPLEX_NOT_OF to COMPLEX_NOT

### DIFF
--- a/src/schema.js
+++ b/src/schema.js
@@ -211,7 +211,7 @@ const complexSchemaParsers = {
     );
   },
   // TODO
-  [SCHEMA_TYPES.COMPLEX_NOT_OF]: (schema) => {
+  [SCHEMA_TYPES.COMPLEX_NOT]: (schema) => {
     // TODO
     return TS_KEYWORDS.ANY;
   },


### PR DESCRIPTION
COMPLEX_NOT_OF does not exist on SCHEMA_TYPES.

This caused a failure when generating TypeScript types from a schema for myself. Changing to COMPLEX_NOT fixed it.