### PR TITLE
Fix usage with typescript >=4.8.0 

### DIFF
--- a/src/formatFileContent.js
+++ b/src/formatFileContent.js
@@ -4,6 +4,8 @@ const { config } = require("./config");
 const ts = require("typescript");
 
 class LanguageServiceHost {
+  fileExists = ts.sys.fileExists;
+  
   constructor(fileName, content) {
     const tsconfig = ts.findConfigFile(fileName, ts.sys.fileExists);
 


### PR DESCRIPTION
Hi,

this pr fixes the following issue: https://github.com/acacode/swagger-typescript-api/issues/370

The languageServiceHost needs to implement `fileExists` with typescript 4.8x. 

I have taken the code from the following example from the typescript wiki: https://github.com/Microsoft/TypeScript/wiki/Using-the-Compiler-API