### PR TITLE
Update formatFileContent.js

### DIFF
--- a/src/formatFileContent.js
+++ b/src/formatFileContent.js
@@ -39,6 +39,9 @@ class LanguageServiceHost {
   getScriptSnapshot() {
     return ts.ScriptSnapshot.fromString(this.content);
   }
+  fileExists(filename) {
+    return true;
+  }
 }
 
 const removeUnusedImports = (content) => {


### PR DESCRIPTION
Got missing function for Typescript v4.8.x onwards. fileExists required.