### PR TITLE
feat(query-params): add an option to use brackets convention with arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Options:
   --another-array-type          generate array types as Array<Type> (by default Type[]) (default: false)
   --sort-types                  sort fields and types (default: false)
   --extract-enums               extract all enums from inline interface\type content to typescript enum construction (default: false)
+  --query-params-with-brackets use the `brackets` convention for array in query params: `?a[]=foo&a[]=bar` instead of `repeat` convention: `?a=foo&a=bar`
   -h, --help                    display help for command
 
 Commands:

--- a/index.d.ts
+++ b/index.d.ts
@@ -554,6 +554,7 @@ export interface GenerateApiConfiguration {
     cleanOutput: boolean;
     debug: boolean;
     anotherArrayType: boolean;
+    queryParamsWithBrackets: false;
     extractRequestBody: boolean;
     httpClientType: "axios" | "fetch";
     addReadonly: boolean;

--- a/index.js
+++ b/index.js
@@ -230,6 +230,12 @@ const program = cli({
       description: "sort routes in alphabetical order",
       default: codeGenBaseConfig.sortRoutes,
     },
+    {
+      flags: "--query-params-with-brackets",
+      description:
+        'use the brackets convention for array in query params: "?a[]=foo&a[]=bar" instead of repeat convention: "?a=foo&a=bar"',
+      default: codeGenBaseConfig.queryParamsWithBrackets,
+    },
   ],
 });
 

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "test:extract-enums": "node tests/spec/extract-enums/test.js",
     "test:discriminator": "node tests/spec/discriminator/test.js",
     "test:sort-types": "node tests/spec/sortTypes/test.js",
-    "test:sort-types(false)": "node tests/spec/sortTypes(false)/test.js"
+    "test:sort-types(false)": "node tests/spec/sortTypes(false)/test.js",
+    "test:--query-params-with-brackets": "node tests/spec/queryParamsWithBrackets/test.js"
   },
   "author": "acacode",
   "license": "MIT",

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -142,6 +142,7 @@ class CodeGenConfig {
   apiClassName = "Api";
   debug = false;
   anotherArrayType = false;
+  queryParamsWithBrackets = false;
   internalTemplateOptions = {
     addUtilRequiredKeysType: false,
   };

--- a/templates/base/http-clients/fetch-http-client.ejs
+++ b/templates/base/http-clients/fetch-http-client.ejs
@@ -70,9 +70,9 @@ export class HttpClient<SecurityDataType = unknown> {
         this.securityData = data;
     }
 
-    protected encodeQueryParam(key: string, value: any) {
+    protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
         const encodedKey = encodeURIComponent(key);
-        return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+        return `${encodedKey}${withBrackets ? '[]' : ''}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
     }
 
     protected addQueryParam(query: QueryParamsType, key: string) {
@@ -81,7 +81,11 @@ export class HttpClient<SecurityDataType = unknown> {
 
     protected addArrayQueryParam(query: QueryParamsType, key: string) {
         const value = query[key];
+<% if (config.queryParamsWithBrackets) { %>
+        return value.map((v: any) => this.encodeQueryParam(key, v, true)).join("&");
+<% } else { %>
         return value.map((v: any) => this.encodeQueryParam(key, v)).join("&");
+<% } %>
     }
 
     protected toQueryString(rawQuery?: QueryParamsType): string {

--- a/tests/generated/v2.0/adafruit.ts
+++ b/tests/generated/v2.0/adafruit.ts
@@ -233,9 +233,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/generated/v2.0/another-example.ts
+++ b/tests/generated/v2.0/another-example.ts
@@ -209,9 +209,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/generated/v2.0/another-schema.ts
+++ b/tests/generated/v2.0/another-schema.ts
@@ -97,9 +97,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/generated/v2.0/api-with-examples.ts
+++ b/tests/generated/v2.0/api-with-examples.ts
@@ -76,9 +76,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/generated/v2.0/authentiq.ts
+++ b/tests/generated/v2.0/authentiq.ts
@@ -116,9 +116,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/generated/v2.0/enums.ts
+++ b/tests/generated/v2.0/enums.ts
@@ -135,9 +135,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/generated/v2.0/example1.ts
+++ b/tests/generated/v2.0/example1.ts
@@ -113,9 +113,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/generated/v2.0/file-formdata-example.ts
+++ b/tests/generated/v2.0/file-formdata-example.ts
@@ -76,9 +76,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/generated/v2.0/giphy.ts
+++ b/tests/generated/v2.0/giphy.ts
@@ -333,9 +333,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/generated/v2.0/github-swagger.ts
+++ b/tests/generated/v2.0/github-swagger.ts
@@ -1974,9 +1974,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/generated/v2.0/path-args.ts
+++ b/tests/generated/v2.0/path-args.ts
@@ -76,9 +76,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/generated/v2.0/petstore-expanded.ts
+++ b/tests/generated/v2.0/petstore-expanded.ts
@@ -112,9 +112,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/generated/v2.0/petstore-minimal.ts
+++ b/tests/generated/v2.0/petstore-minimal.ts
@@ -84,9 +84,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/generated/v2.0/petstore-simple.ts
+++ b/tests/generated/v2.0/petstore-simple.ts
@@ -100,9 +100,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/generated/v2.0/petstore-swagger-io.ts
+++ b/tests/generated/v2.0/petstore-swagger-io.ts
@@ -137,9 +137,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/generated/v2.0/petstore-with-external-docs.ts
+++ b/tests/generated/v2.0/petstore-with-external-docs.ts
@@ -92,9 +92,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/generated/v2.0/petstore.ts
+++ b/tests/generated/v2.0/petstore.ts
@@ -91,9 +91,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/generated/v2.0/query-path-param.ts
+++ b/tests/generated/v2.0/query-path-param.ts
@@ -76,9 +76,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/generated/v2.0/uber.ts
+++ b/tests/generated/v2.0/uber.ts
@@ -155,9 +155,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/generated/v3.0/additional-properties.ts
+++ b/tests/generated/v3.0/additional-properties.ts
@@ -83,9 +83,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/generated/v3.0/additional-properties2.ts
+++ b/tests/generated/v3.0/additional-properties2.ts
@@ -80,9 +80,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/generated/v3.0/allof-example.ts
+++ b/tests/generated/v3.0/allof-example.ts
@@ -90,9 +90,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/generated/v3.0/anyof-example.ts
+++ b/tests/generated/v3.0/anyof-example.ts
@@ -86,9 +86,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/generated/v3.0/api-with-examples.ts
+++ b/tests/generated/v3.0/api-with-examples.ts
@@ -76,9 +76,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/generated/v3.0/callback-example.ts
+++ b/tests/generated/v3.0/callback-example.ts
@@ -76,9 +76,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/generated/v3.0/components-responses.ts
+++ b/tests/generated/v3.0/components-responses.ts
@@ -76,9 +76,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/generated/v3.0/explode-param-3.0.1.ts
+++ b/tests/generated/v3.0/explode-param-3.0.1.ts
@@ -95,9 +95,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/generated/v3.0/full-swagger-scheme.ts
+++ b/tests/generated/v3.0/full-swagger-scheme.ts
@@ -8700,9 +8700,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/generated/v3.0/link-example.ts
+++ b/tests/generated/v3.0/link-example.ts
@@ -93,9 +93,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/generated/v3.0/no-definitions-schema.ts
+++ b/tests/generated/v3.0/no-definitions-schema.ts
@@ -90,9 +90,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/generated/v3.0/oneof-example.ts
+++ b/tests/generated/v3.0/oneof-example.ts
@@ -86,9 +86,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/generated/v3.0/personal-api-example.ts
+++ b/tests/generated/v3.0/personal-api-example.ts
@@ -261,9 +261,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/generated/v3.0/petstore-expanded.ts
+++ b/tests/generated/v3.0/petstore-expanded.ts
@@ -92,9 +92,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/generated/v3.0/petstore.ts
+++ b/tests/generated/v3.0/petstore.ts
@@ -93,9 +93,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/generated/v3.0/recursive-schema.ts
+++ b/tests/generated/v3.0/recursive-schema.ts
@@ -87,9 +87,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/generated/v3.0/responses.ts
+++ b/tests/generated/v3.0/responses.ts
@@ -76,9 +76,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/generated/v3.0/swaggerhub-template.ts
+++ b/tests/generated/v3.0/swaggerhub-template.ts
@@ -76,9 +76,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/generated/v3.0/tsoa-odd-types-3.0.2.ts
+++ b/tests/generated/v3.0/tsoa-odd-types-3.0.2.ts
@@ -187,9 +187,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/generated/v3.0/up-banking.ts
+++ b/tests/generated/v3.0/up-banking.ts
@@ -818,9 +818,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/generated/v3.0/uspto.ts
+++ b/tests/generated/v3.0/uspto.ts
@@ -108,9 +108,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/generated/v3.0/wrong-enum-subtypes.ts
+++ b/tests/generated/v3.0/wrong-enum-subtypes.ts
@@ -82,9 +82,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/generated/v3.0/wrong-schema-names.ts
+++ b/tests/generated/v3.0/wrong-schema-names.ts
@@ -100,9 +100,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/another-query-params/expected.ts
+++ b/tests/spec/another-query-params/expected.ts
@@ -104,9 +104,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/another-query-params/schema.ts
+++ b/tests/spec/another-query-params/schema.ts
@@ -104,9 +104,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/cli/expected.ts
+++ b/tests/spec/cli/expected.ts
@@ -221,9 +221,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/cli/schema.ts
+++ b/tests/spec/cli/schema.ts
@@ -221,9 +221,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/defaultAsSuccess/expected.ts
+++ b/tests/spec/defaultAsSuccess/expected.ts
@@ -116,9 +116,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/defaultAsSuccess/schema.ts
+++ b/tests/spec/defaultAsSuccess/schema.ts
@@ -116,9 +116,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/defaultResponse/expected.ts
+++ b/tests/spec/defaultResponse/expected.ts
@@ -76,9 +76,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/defaultResponse/schema.ts
+++ b/tests/spec/defaultResponse/schema.ts
@@ -76,9 +76,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/deprecated/expected.ts
+++ b/tests/spec/deprecated/expected.ts
@@ -76,9 +76,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/deprecated/schema.ts
+++ b/tests/spec/deprecated/schema.ts
@@ -76,9 +76,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/dot-path-params/expected.ts
+++ b/tests/spec/dot-path-params/expected.ts
@@ -78,9 +78,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/dot-path-params/schema.ts
+++ b/tests/spec/dot-path-params/schema.ts
@@ -78,9 +78,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/enumNamesAsValues/expected.ts
+++ b/tests/spec/enumNamesAsValues/expected.ts
@@ -268,9 +268,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/enumNamesAsValues/schema.ts
+++ b/tests/spec/enumNamesAsValues/schema.ts
@@ -268,9 +268,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/extractRequestBody/expected.ts
+++ b/tests/spec/extractRequestBody/expected.ts
@@ -229,9 +229,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/extractRequestBody/schema.ts
+++ b/tests/spec/extractRequestBody/schema.ts
@@ -229,9 +229,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/extractRequestParams/expected.ts
+++ b/tests/spec/extractRequestParams/expected.ts
@@ -151,9 +151,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/extractRequestParams/schema.ts
+++ b/tests/spec/extractRequestParams/schema.ts
@@ -151,9 +151,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/extractResponseBody/expected.ts
+++ b/tests/spec/extractResponseBody/expected.ts
@@ -231,9 +231,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/extractResponseBody/schema.ts
+++ b/tests/spec/extractResponseBody/schema.ts
@@ -231,9 +231,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/extractResponseError/expected.ts
+++ b/tests/spec/extractResponseError/expected.ts
@@ -226,9 +226,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/extractResponseError/schema.ts
+++ b/tests/spec/extractResponseError/schema.ts
@@ -226,9 +226,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/js/schema.d.ts
+++ b/tests/spec/js/schema.d.ts
@@ -1828,7 +1828,7 @@ export declare class HttpClient<SecurityDataType = unknown> {
   private baseApiParams;
   constructor(apiConfig?: ApiConfig<SecurityDataType>);
   setSecurityData: (data: SecurityDataType | null) => void;
-  protected encodeQueryParam(key: string, value: any): string;
+  protected encodeQueryParam(key: string, value: any, withBrackets?: boolean): string;
   protected addQueryParam(query: QueryParamsType, key: string): string;
   protected addArrayQueryParam(query: QueryParamsType, key: string): any;
   protected toQueryString(rawQuery?: QueryParamsType): string;

--- a/tests/spec/js/schema.js
+++ b/tests/spec/js/schema.js
@@ -34,9 +34,11 @@ export class HttpClient {
   setSecurityData = (data) => {
     this.securityData = data;
   };
-  encodeQueryParam(key, value) {
+  encodeQueryParam(key, value, withBrackets = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
   addQueryParam(query, key) {
     return this.encodeQueryParam(key, query[key]);

--- a/tests/spec/jsSingleHttpClientModular/expected/http-client.d.ts
+++ b/tests/spec/jsSingleHttpClientModular/expected/http-client.d.ts
@@ -56,7 +56,7 @@ export declare class HttpClient<SecurityDataType = unknown> {
   private baseApiParams;
   constructor(apiConfig?: ApiConfig<SecurityDataType>);
   setSecurityData: (data: SecurityDataType | null) => void;
-  protected encodeQueryParam(key: string, value: any): string;
+  protected encodeQueryParam(key: string, value: any, withBrackets?: boolean): string;
   protected addQueryParam(query: QueryParamsType, key: string): string;
   protected addArrayQueryParam(query: QueryParamsType, key: string): any;
   protected toQueryString(rawQuery?: QueryParamsType): string;

--- a/tests/spec/jsSingleHttpClientModular/expected/http-client.js
+++ b/tests/spec/jsSingleHttpClientModular/expected/http-client.js
@@ -34,9 +34,11 @@ export class HttpClient {
   setSecurityData = (data) => {
     this.securityData = data;
   };
-  encodeQueryParam(key, value) {
+  encodeQueryParam(key, value, withBrackets = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
   addQueryParam(query, key) {
     return this.encodeQueryParam(key, query[key]);

--- a/tests/spec/jsSingleHttpClientModular/generated/http-client.d.ts
+++ b/tests/spec/jsSingleHttpClientModular/generated/http-client.d.ts
@@ -56,7 +56,7 @@ export declare class HttpClient<SecurityDataType = unknown> {
   private baseApiParams;
   constructor(apiConfig?: ApiConfig<SecurityDataType>);
   setSecurityData: (data: SecurityDataType | null) => void;
-  protected encodeQueryParam(key: string, value: any): string;
+  protected encodeQueryParam(key: string, value: any, withBrackets?: boolean): string;
   protected addQueryParam(query: QueryParamsType, key: string): string;
   protected addArrayQueryParam(query: QueryParamsType, key: string): any;
   protected toQueryString(rawQuery?: QueryParamsType): string;

--- a/tests/spec/jsSingleHttpClientModular/generated/http-client.js
+++ b/tests/spec/jsSingleHttpClientModular/generated/http-client.js
@@ -34,9 +34,11 @@ export class HttpClient {
   setSecurityData = (data) => {
     this.securityData = data;
   };
-  encodeQueryParam(key, value) {
+  encodeQueryParam(key, value, withBrackets = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
   addQueryParam(query, key) {
     return this.encodeQueryParam(key, query[key]);

--- a/tests/spec/modular/expected/http-client.ts
+++ b/tests/spec/modular/expected/http-client.ts
@@ -76,9 +76,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/modular/generated/http-client.ts
+++ b/tests/spec/modular/generated/http-client.ts
@@ -76,9 +76,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/moduleNameFirstTag/expected.ts
+++ b/tests/spec/moduleNameFirstTag/expected.ts
@@ -201,9 +201,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/moduleNameFirstTag/schema.ts
+++ b/tests/spec/moduleNameFirstTag/schema.ts
@@ -201,9 +201,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/moduleNameIndex/expected.ts
+++ b/tests/spec/moduleNameIndex/expected.ts
@@ -201,9 +201,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/moduleNameIndex/schema.ts
+++ b/tests/spec/moduleNameIndex/schema.ts
@@ -201,9 +201,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/on-insert-path-param/expected.ts
+++ b/tests/spec/on-insert-path-param/expected.ts
@@ -76,9 +76,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/on-insert-path-param/schema.ts
+++ b/tests/spec/on-insert-path-param/schema.ts
@@ -76,9 +76,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/partialBaseTemplate/expected.ts
+++ b/tests/spec/partialBaseTemplate/expected.ts
@@ -88,9 +88,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/partialBaseTemplate/schema.ts
+++ b/tests/spec/partialBaseTemplate/schema.ts
@@ -88,9 +88,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/partialDefaultTemplate/expected.ts
+++ b/tests/spec/partialDefaultTemplate/expected.ts
@@ -84,9 +84,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/partialDefaultTemplate/schema.ts
+++ b/tests/spec/partialDefaultTemplate/schema.ts
@@ -84,9 +84,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/patch/expected.ts
+++ b/tests/spec/patch/expected.ts
@@ -1833,9 +1833,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/patch/schema.ts
+++ b/tests/spec/patch/schema.ts
@@ -1833,9 +1833,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/queryParamsWithBrackets/expected.ts
+++ b/tests/spec/queryParamsWithBrackets/expected.ts
@@ -9,79 +9,6 @@
  * ---------------------------------------------------------------
  */
 
-export interface Step {
-  /** address of the stop */
-  address?: string;
-  /**
-   * arrival at the stop in its local timezone as YYYY-MM-DDThh:mm
-   * @format date-time
-   */
-  arrival?: string;
-  /** geographical coordinates of the stop */
-  coordinates?: {
-    /**
-     * latitude
-     * @format float
-     */
-    lat?: number;
-    /**
-     * longitude
-     * @format float
-     */
-    lon?: number;
-  };
-  /**
-   * departure from the stop in its local timezone as YYYY-MM-DDThh:mm
-   * @format date-time
-   */
-  departure?: string;
-  /** name of the stop */
-  name?: string;
-  /**
-   * number of nights
-   * @format int64
-   */
-  nights?: number;
-  /** route leading to the stop */
-  route?: {
-    /**
-     * route distance in meters
-     * @format int64
-     */
-    distance?: number;
-    /**
-     * route duration in seconds
-     * @format int64
-     */
-    duration?: number;
-    /** travel mode */
-    mode?: "car" | "motorcycle" | "bicycle" | "walk" | "other";
-    /** route path compatible with Google polyline encoding algorithm */
-    polyline?: string;
-  };
-  /** url of the page with more information about the stop */
-  url?: string;
-}
-
-export interface Trip {
-  /**
-   * begin of the trip in its local timezone as YYYY-MM-DDThh:mm
-   * @format date-time
-   */
-  begin?: string;
-  /** description of the trip (truncated to 200 characters) */
-  description?: string;
-  /**
-   * end of the trip in its local timezone as YYYY-MM-DDThh:mm
-   * @format date-time
-   */
-  end?: string;
-  /** Unique ID of the trip */
-  id?: string;
-  /** name of the trip */
-  name?: string;
-}
-
 export type QueryParamsType = Record<string | number, any>;
 export type ResponseFormat = keyof Omit<Body, "body" | "bodyUsed">;
 
@@ -128,7 +55,7 @@ export enum ContentType {
 }
 
 export class HttpClient<SecurityDataType = unknown> {
-  public baseUrl: string = "https://trips.furkot.com/pub/api";
+  public baseUrl: string = "http://petstore.swagger.io/api";
   private securityData: SecurityDataType | null = null;
   private securityWorker?: ApiConfig<SecurityDataType>["securityWorker"];
   private abortControllers = new Map<CancelToken, AbortController>();
@@ -162,7 +89,7 @@ export class HttpClient<SecurityDataType = unknown> {
 
   protected addArrayQueryParam(query: QueryParamsType, key: string) {
     const value = query[key];
-    return value.map((v: any) => this.encodeQueryParam(key, v)).join("&");
+    return value.map((v: any) => this.encodeQueryParam(key, v, true)).join("&");
   }
 
   protected toQueryString(rawQuery?: QueryParamsType): string {
@@ -295,47 +222,39 @@ export class HttpClient<SecurityDataType = unknown> {
 }
 
 /**
- * @title Furkot Trips
+ * @title Swagger Petstore
  * @version 1.0.0
- * @baseUrl https://trips.furkot.com/pub/api
- * @externalDocs https://help.furkot.com/widgets/furkot-api.html
- * @contact <trips@furkot.com>
+ * @license Apache 2.0 (https://www.apache.org/licenses/LICENSE-2.0.html)
+ * @termsOfService http://swagger.io/terms/
+ * @baseUrl http://petstore.swagger.io/api
+ * @contact Swagger API Team <apiteam@swagger.io> (http://swagger.io)
  *
- * Furkot provides Rest API to access user trip data.
- * Using Furkot API an application can list user trips and display stops for a specific trip.
- * Furkot API uses OAuth2 protocol to authorize applications to access data on behalf of users.
+ * A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification
  */
 export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDataType> {
-  trip = {
+  pets = {
     /**
-     * @description list user's trips
+     * @description Returns all pets from the system that the user has access to Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia. Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.
      *
-     * @name TripList
-     * @request GET:/trip
-     * @secure
+     * @name FindPets
+     * @request GET:/pets
      */
-    tripList: (params: RequestParams = {}) =>
-      this.request<Trip[], any>({
-        path: `/trip`,
+    findPets: (
+      query?: {
+        /** tags to filter by */
+        tags?: string[];
+        /**
+         * maximum number of results to return
+         * @format int32
+         */
+        limit?: number;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<void, void>({
+        path: `/pets`,
         method: "GET",
-        secure: true,
-        format: "json",
-        ...params,
-      }),
-
-    /**
-     * @description list stops for a trip identified by {trip_id}
-     *
-     * @name StopDetail
-     * @request GET:/trip/{trip_id}/stop
-     * @secure
-     */
-    stopDetail: (tripId: string, params: RequestParams = {}) =>
-      this.request<Step[], any>({
-        path: `/trip/${tripId}/stop`,
-        method: "GET",
-        secure: true,
-        format: "json",
+        query: query,
         ...params,
       }),
   };

--- a/tests/spec/queryParamsWithBrackets/schema.json
+++ b/tests/spec/queryParamsWithBrackets/schema.json
@@ -1,0 +1,57 @@
+{
+    "swagger": "2.0",
+    "info": {
+      "version": "1.0.0",
+      "title": "Swagger Petstore",
+      "description": "A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification",
+      "termsOfService": "http://swagger.io/terms/",
+      "contact": {
+        "name": "Swagger API Team",
+        "email": "apiteam@swagger.io",
+        "url": "http://swagger.io"
+      },
+      "license": {
+        "name": "Apache 2.0",
+        "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+      }
+    },
+    "host": "petstore.swagger.io",
+    "basePath": "/api",
+    "schemes": ["http"],
+    "consumes": ["application/json"],
+    "produces": ["application/json"],
+    "paths": {
+      "/pets": {
+        "get": {
+          "description": "Returns all pets from the system that the user has access to\nNam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.\n\nSed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.\n",
+          "operationId": "findPets",
+          "parameters": [
+            {
+              "name": "tags",
+              "in": "query",
+              "description": "tags to filter by",
+              "required": false,
+              "type": "array",
+              "collectionFormat": "csv",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "limit",
+              "in": "query",
+              "description": "maximum number of results to return",
+              "required": false,
+              "type": "integer",
+              "format": "int32"
+            }
+          ],
+          "responses": {
+            "200": {},
+            "default": {}
+          }
+        }
+      }
+    },
+    "definitions": {}
+  }

--- a/tests/spec/queryParamsWithBrackets/schema.ts
+++ b/tests/spec/queryParamsWithBrackets/schema.ts
@@ -9,79 +9,6 @@
  * ---------------------------------------------------------------
  */
 
-export interface Step {
-  /** address of the stop */
-  address?: string;
-  /**
-   * arrival at the stop in its local timezone as YYYY-MM-DDThh:mm
-   * @format date-time
-   */
-  arrival?: string;
-  /** geographical coordinates of the stop */
-  coordinates?: {
-    /**
-     * latitude
-     * @format float
-     */
-    lat?: number;
-    /**
-     * longitude
-     * @format float
-     */
-    lon?: number;
-  };
-  /**
-   * departure from the stop in its local timezone as YYYY-MM-DDThh:mm
-   * @format date-time
-   */
-  departure?: string;
-  /** name of the stop */
-  name?: string;
-  /**
-   * number of nights
-   * @format int64
-   */
-  nights?: number;
-  /** route leading to the stop */
-  route?: {
-    /**
-     * route distance in meters
-     * @format int64
-     */
-    distance?: number;
-    /**
-     * route duration in seconds
-     * @format int64
-     */
-    duration?: number;
-    /** travel mode */
-    mode?: "car" | "motorcycle" | "bicycle" | "walk" | "other";
-    /** route path compatible with Google polyline encoding algorithm */
-    polyline?: string;
-  };
-  /** url of the page with more information about the stop */
-  url?: string;
-}
-
-export interface Trip {
-  /**
-   * begin of the trip in its local timezone as YYYY-MM-DDThh:mm
-   * @format date-time
-   */
-  begin?: string;
-  /** description of the trip (truncated to 200 characters) */
-  description?: string;
-  /**
-   * end of the trip in its local timezone as YYYY-MM-DDThh:mm
-   * @format date-time
-   */
-  end?: string;
-  /** Unique ID of the trip */
-  id?: string;
-  /** name of the trip */
-  name?: string;
-}
-
 export type QueryParamsType = Record<string | number, any>;
 export type ResponseFormat = keyof Omit<Body, "body" | "bodyUsed">;
 
@@ -128,7 +55,7 @@ export enum ContentType {
 }
 
 export class HttpClient<SecurityDataType = unknown> {
-  public baseUrl: string = "https://trips.furkot.com/pub/api";
+  public baseUrl: string = "http://petstore.swagger.io/api";
   private securityData: SecurityDataType | null = null;
   private securityWorker?: ApiConfig<SecurityDataType>["securityWorker"];
   private abortControllers = new Map<CancelToken, AbortController>();
@@ -162,7 +89,7 @@ export class HttpClient<SecurityDataType = unknown> {
 
   protected addArrayQueryParam(query: QueryParamsType, key: string) {
     const value = query[key];
-    return value.map((v: any) => this.encodeQueryParam(key, v)).join("&");
+    return value.map((v: any) => this.encodeQueryParam(key, v, true)).join("&");
   }
 
   protected toQueryString(rawQuery?: QueryParamsType): string {
@@ -295,47 +222,39 @@ export class HttpClient<SecurityDataType = unknown> {
 }
 
 /**
- * @title Furkot Trips
+ * @title Swagger Petstore
  * @version 1.0.0
- * @baseUrl https://trips.furkot.com/pub/api
- * @externalDocs https://help.furkot.com/widgets/furkot-api.html
- * @contact <trips@furkot.com>
+ * @license Apache 2.0 (https://www.apache.org/licenses/LICENSE-2.0.html)
+ * @termsOfService http://swagger.io/terms/
+ * @baseUrl http://petstore.swagger.io/api
+ * @contact Swagger API Team <apiteam@swagger.io> (http://swagger.io)
  *
- * Furkot provides Rest API to access user trip data.
- * Using Furkot API an application can list user trips and display stops for a specific trip.
- * Furkot API uses OAuth2 protocol to authorize applications to access data on behalf of users.
+ * A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification
  */
 export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDataType> {
-  trip = {
+  pets = {
     /**
-     * @description list user's trips
+     * @description Returns all pets from the system that the user has access to Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia. Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.
      *
-     * @name TripList
-     * @request GET:/trip
-     * @secure
+     * @name FindPets
+     * @request GET:/pets
      */
-    tripList: (params: RequestParams = {}) =>
-      this.request<Trip[], any>({
-        path: `/trip`,
+    findPets: (
+      query?: {
+        /** tags to filter by */
+        tags?: string[];
+        /**
+         * maximum number of results to return
+         * @format int32
+         */
+        limit?: number;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<void, void>({
+        path: `/pets`,
         method: "GET",
-        secure: true,
-        format: "json",
-        ...params,
-      }),
-
-    /**
-     * @description list stops for a trip identified by {trip_id}
-     *
-     * @name StopDetail
-     * @request GET:/trip/{trip_id}/stop
-     * @secure
-     */
-    stopDetail: (tripId: string, params: RequestParams = {}) =>
-      this.request<Step[], any>({
-        path: `/trip/${tripId}/stop`,
-        method: "GET",
-        secure: true,
-        format: "json",
+        query: query,
         ...params,
       }),
   };

--- a/tests/spec/queryParamsWithBrackets/test.js
+++ b/tests/spec/queryParamsWithBrackets/test.js
@@ -8,11 +8,12 @@ const schemas = createSchemaInfos({ absolutePathToSchemas: resolve(__dirname, ".
 
 schemas.forEach(({ absolutePath, apiFileName }) => {
   generateApiForTest({
-    testName: "@deprecated test",
+    testName: "--query-params-with-brackets option test",
     silent: true,
     name: apiFileName,
     spec: require(absolutePath),
     output: resolve(__dirname, "./"),
+    queryParamsWithBrackets: true,
   }).then(() => {
     validateGeneratedModule(resolve(__dirname, `./${apiFileName}`));
     assertGeneratedModule(resolve(__dirname, `./${apiFileName}`), resolve(__dirname, `./expected.ts`));

--- a/tests/spec/responses/expected.ts
+++ b/tests/spec/responses/expected.ts
@@ -116,9 +116,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/responses/schema.ts
+++ b/tests/spec/responses/schema.ts
@@ -116,9 +116,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/singleHttpClient/expected.ts
+++ b/tests/spec/singleHttpClient/expected.ts
@@ -76,9 +76,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/singleHttpClient/schema.ts
+++ b/tests/spec/singleHttpClient/schema.ts
@@ -76,9 +76,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/sortTypes(false)/expected.ts
+++ b/tests/spec/sortTypes(false)/expected.ts
@@ -1833,9 +1833,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/sortTypes(false)/schema.ts
+++ b/tests/spec/sortTypes(false)/schema.ts
@@ -1833,9 +1833,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/sortTypes/expected.ts
+++ b/tests/spec/sortTypes/expected.ts
@@ -1833,9 +1833,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/sortTypes/schema.ts
+++ b/tests/spec/sortTypes/schema.ts
@@ -1833,9 +1833,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/templates/expected.ts
+++ b/tests/spec/templates/expected.ts
@@ -1982,9 +1982,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/templates/schema.ts
+++ b/tests/spec/templates/schema.ts
@@ -1982,9 +1982,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/typeSuffixPrefix/expected.ts
+++ b/tests/spec/typeSuffixPrefix/expected.ts
@@ -1833,9 +1833,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/typeSuffixPrefix/schema.ts
+++ b/tests/spec/typeSuffixPrefix/schema.ts
@@ -1833,9 +1833,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/unionEnums/expected.ts
+++ b/tests/spec/unionEnums/expected.ts
@@ -88,9 +88,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {

--- a/tests/spec/unionEnums/schema.ts
+++ b/tests/spec/unionEnums/schema.ts
@@ -88,9 +88,11 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data;
   };
 
-  protected encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any, withBrackets: boolean = false) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    return `${encodedKey}${withBrackets ? "[]" : ""}=${encodeURIComponent(
+      typeof value === "number" ? value : `${value}`,
+    )}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {


### PR DESCRIPTION
**NB: It's a repost of #420 which (I suppose) has been closed automatically!**

Hello :wave:

Currently the generated API encode query params arrays like: `?a=foo&a=bar&a=baz` with the `repeat` convention.
But all the backends don't follow this convention, and some use the `brackets` one: `?a[]=foo&a[]=bar&a[]=baz`.

So, this PR adds a new option `--query-params-with-brackets` which allow the use of the `brackets` convention instead of the `repeat` (only applicable when the query param is an array).