### PR TITLE
fix: handling for content-type application/json with a charset parameter

### DIFF
--- a/src/schema-parser/schema-routes.js
+++ b/src/schema-parser/schema-routes.js
@@ -207,7 +207,7 @@ class SchemaRoutes {
 
   getContentKind = (contentTypes) => {
     if (
-      _.includes(contentTypes, "application/json") ||
+      _.some(contentTypes, (contentType) => _.startsWith(contentType, "application/json")) ||
       _.some(contentTypes, (contentType) => _.endsWith(contentType, "+json"))
     ) {
       return CONTENT_KIND.JSON;

--- a/tests/generated/v2.0/api-with-examples.ts
+++ b/tests/generated/v2.0/api-with-examples.ts
@@ -253,4 +253,21 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         ...params,
       }),
   };
+  withCharset = {
+    /**
+     * @description consumes contains charset
+     *
+     * @name WithCharset
+     * @summary consumes contains charset
+     * @request POST:/with-charset/
+     */
+    withCharset: (someParm: string, params: RequestParams = {}) =>
+      this.request<any, void>({
+        path: `/with-charset/`,
+        method: "POST",
+        body: someParm,
+        type: ContentType.Json,
+        ...params,
+      }),
+  };
 }

--- a/tests/schemas/v2.0/api-with-examples.yaml
+++ b/tests/schemas/v2.0/api-with-examples.yaml
@@ -165,5 +165,18 @@ paths:
                       ]
                   }
               }
+  /with-charset/:
+    post:
+      operationId: with-charset
+      summary: consumes contains charset
+      description: consumes contains charset
+      consumes:
+        - application/json;charset=UTF-8
+      produces:
+        - application/json;charset=UTF-8
+      parameters:
+        - in: body
+          name: someParm
+          type: string
 consumes:
 - application/json


### PR DESCRIPTION
Fixes acacode/swagger-typescript-api#440