### PR TITLE
fix: onCreateRoute skip behaviour

### DIFF
--- a/src/schema-routes/schema-routes.js
+++ b/src/schema-routes/schema-routes.js
@@ -892,19 +892,21 @@ class SchemaRoutes {
       _.forEach(routeInfosMap, (routeInfo, method) => {
         const parsedRouteInfo = this.parseRouteInfo(rawRouteName, routeInfo, method, usageSchema, parsedSchemas);
         const processedRouteInfo = this.config.hooks.onCreateRoute(parsedRouteInfo);
-        const route = processedRouteInfo || parsedRouteInfo;
+        if (processedRouteInfo !== false) {
+            const route = processedRouteInfo || parsedRouteInfo;
 
-        if (!this.hasSecurityRoutes && route.security) {
-          this.hasSecurityRoutes = route.security;
-        }
-        if (!this.hasQueryRoutes && route.hasQuery) {
-          this.hasQueryRoutes = route.hasQuery;
-        }
-        if (!this.hasFormDataRoutes && route.hasFormDataParams) {
-          this.hasFormDataRoutes = route.hasFormDataParams;
-        }
+            if (!this.hasSecurityRoutes && route.security) {
+                this.hasSecurityRoutes = route.security;
+            }
+            if (!this.hasQueryRoutes && route.hasQuery) {
+                this.hasQueryRoutes = route.hasQuery;
+            }
+            if (!this.hasFormDataRoutes && route.hasFormDataParams) {
+                this.hasFormDataRoutes = route.hasFormDataParams;
+            }
 
-        this.routes.push(route);
+            this.routes.push(route);
+        }
       });
     });
   };


### PR DESCRIPTION
I appears that the behaviour described in docs to skip the endpoint when `onCreateRoute` hook returns false was removed in v11
[change](https://github.com/acacode/swagger-typescript-api/commit/2d7925e96f87f269402122b00641652078f77d47#diff-481bff25593155cc0695aeb0f112c109e3075ef703d254734ec2a3c5266ee0beL676) -> `src/routes.js`