### PR TITLE
Stop sending 'null' for null values in forms

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "contributors": "all-contributors generate",
     "cli:help": "node index.js -h",
     "test-all": "npm run test-extended && npm run test-simple && npm run test-specific",
-    "test-all(update-snapshots)": "cross-env UPDATE_SNAPSHOTS=true && npm run test-all",
+    "test-all(update-snapshots)": "cross-env UPDATE_SNAPSHOTS=true npm run test-all",
     "test-simple": "node --unhandled-rejections=strict ./scriptsRunner.js generate validate",
     "test-extended": "node --unhandled-rejections=strict ./scriptsRunner.js generate-extended validate",
     "test-specific": "node --unhandled-rejections=strict ./scriptsRunner.js test:*",

--- a/templates/base/http-clients/axios-http-client.ejs
+++ b/templates/base/http-clients/axios-http-client.ejs
@@ -70,7 +70,9 @@ export class HttpClient<SecurityDataType = unknown> {
     }
 
     protected stringifyFormItem(formItem: unknown) {
-      if (typeof formItem === "object" && formItem !== null) {
+      if (formItem == null) {
+        return '';
+      } else if (typeof formItem === "object") {
         return JSON.stringify(formItem);
       } else {
         return `${formItem}`;

--- a/templates/base/http-clients/fetch-http-client.ejs
+++ b/templates/base/http-clients/fetch-http-client.ejs
@@ -101,19 +101,26 @@ export class HttpClient<SecurityDataType = unknown> {
         return queryString ? `?${queryString}` : "";
     }
 
+    protected stringifyFormItem(formItem: unknown) {
+      if (formItem == null) {
+        return '';
+      } else if (typeof formItem === "object") {
+        return JSON.stringify(formItem);
+      } else {
+        return `${formItem}`;
+      }
+    }
+
     private contentFormatters: Record<ContentType, (input: any) => any> = {
         [ContentType.Json]: (input:any) => input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
         [ContentType.Text]: (input:any) => input !== null && typeof input !== "string" ? JSON.stringify(input) : input,
         [ContentType.FormData]: (input: any) =>
             Object.keys(input || {}).reduce((formData, key) => {
                 const property = input[key];
+                const isFileType = property instanceof Blob || property instanceof File;
                 formData.append(
                     key,
-                    property instanceof Blob ?
-                        property :
-                    typeof property === "object" && property !== null ?
-                        JSON.stringify(property) :
-                    `${property}`
+                    isFileType ? property : this.stringifyFormItem(property)
                 );
                 return formData;
             }, new FormData()),

--- a/tests/generated/v2.0/adafruit.ts
+++ b/tests/generated/v2.0/adafruit.ts
@@ -260,6 +260,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -267,14 +277,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/generated/v2.0/another-example.ts
+++ b/tests/generated/v2.0/another-example.ts
@@ -236,6 +236,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -243,14 +253,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/generated/v2.0/another-schema.ts
+++ b/tests/generated/v2.0/another-schema.ts
@@ -124,6 +124,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -131,14 +141,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/generated/v2.0/api-with-examples.ts
+++ b/tests/generated/v2.0/api-with-examples.ts
@@ -103,6 +103,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -110,14 +120,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/generated/v2.0/authentiq.ts
+++ b/tests/generated/v2.0/authentiq.ts
@@ -143,6 +143,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -150,14 +160,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/generated/v2.0/enums.ts
+++ b/tests/generated/v2.0/enums.ts
@@ -162,6 +162,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -169,14 +179,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/generated/v2.0/example1.ts
+++ b/tests/generated/v2.0/example1.ts
@@ -140,6 +140,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -147,14 +157,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/generated/v2.0/file-formdata-example.ts
+++ b/tests/generated/v2.0/file-formdata-example.ts
@@ -103,6 +103,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -110,14 +120,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/generated/v2.0/furkot-example.ts
+++ b/tests/generated/v2.0/furkot-example.ts
@@ -176,6 +176,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -183,14 +193,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/generated/v2.0/giphy.ts
+++ b/tests/generated/v2.0/giphy.ts
@@ -360,6 +360,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -367,14 +377,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/generated/v2.0/github-swagger.ts
+++ b/tests/generated/v2.0/github-swagger.ts
@@ -2001,6 +2001,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -2008,14 +2018,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/generated/v2.0/path-args.ts
+++ b/tests/generated/v2.0/path-args.ts
@@ -103,6 +103,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -110,14 +120,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/generated/v2.0/petstore-expanded.ts
+++ b/tests/generated/v2.0/petstore-expanded.ts
@@ -139,6 +139,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -146,14 +156,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/generated/v2.0/petstore-minimal.ts
+++ b/tests/generated/v2.0/petstore-minimal.ts
@@ -111,6 +111,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -118,14 +128,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/generated/v2.0/petstore-simple.ts
+++ b/tests/generated/v2.0/petstore-simple.ts
@@ -127,6 +127,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -134,14 +144,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/generated/v2.0/petstore-swagger-io.ts
+++ b/tests/generated/v2.0/petstore-swagger-io.ts
@@ -164,6 +164,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -171,14 +181,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/generated/v2.0/petstore-with-external-docs.ts
+++ b/tests/generated/v2.0/petstore-with-external-docs.ts
@@ -119,6 +119,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -126,14 +136,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/generated/v2.0/petstore.ts
+++ b/tests/generated/v2.0/petstore.ts
@@ -118,6 +118,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -125,14 +135,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/generated/v2.0/query-path-param.ts
+++ b/tests/generated/v2.0/query-path-param.ts
@@ -103,6 +103,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -110,14 +120,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/generated/v2.0/uber.ts
+++ b/tests/generated/v2.0/uber.ts
@@ -182,6 +182,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -189,14 +199,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/generated/v3.0/additional-properties.ts
+++ b/tests/generated/v3.0/additional-properties.ts
@@ -110,6 +110,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -117,14 +127,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/generated/v3.0/additional-properties2.ts
+++ b/tests/generated/v3.0/additional-properties2.ts
@@ -107,6 +107,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -114,14 +124,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/generated/v3.0/allof-example.ts
+++ b/tests/generated/v3.0/allof-example.ts
@@ -117,6 +117,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -124,14 +134,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/generated/v3.0/anyof-example.ts
+++ b/tests/generated/v3.0/anyof-example.ts
@@ -113,6 +113,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -120,14 +130,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/generated/v3.0/api-with-examples.ts
+++ b/tests/generated/v3.0/api-with-examples.ts
@@ -103,6 +103,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -110,14 +120,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/generated/v3.0/callback-example.ts
+++ b/tests/generated/v3.0/callback-example.ts
@@ -103,6 +103,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -110,14 +120,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/generated/v3.0/components-responses.ts
+++ b/tests/generated/v3.0/components-responses.ts
@@ -103,6 +103,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -110,14 +120,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/generated/v3.0/explode-param-3.0.1.ts
+++ b/tests/generated/v3.0/explode-param-3.0.1.ts
@@ -122,6 +122,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -129,14 +139,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/generated/v3.0/full-swagger-scheme.ts
+++ b/tests/generated/v3.0/full-swagger-scheme.ts
@@ -8727,6 +8727,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -8734,14 +8744,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/generated/v3.0/link-example.ts
+++ b/tests/generated/v3.0/link-example.ts
@@ -120,6 +120,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -127,14 +137,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/generated/v3.0/no-definitions-schema.ts
+++ b/tests/generated/v3.0/no-definitions-schema.ts
@@ -117,6 +117,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -124,14 +134,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/generated/v3.0/oneof-example.ts
+++ b/tests/generated/v3.0/oneof-example.ts
@@ -113,6 +113,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -120,14 +130,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/generated/v3.0/personal-api-example.ts
+++ b/tests/generated/v3.0/personal-api-example.ts
@@ -288,6 +288,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -295,14 +305,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/generated/v3.0/petstore-expanded.ts
+++ b/tests/generated/v3.0/petstore-expanded.ts
@@ -119,6 +119,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -126,14 +136,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/generated/v3.0/petstore.ts
+++ b/tests/generated/v3.0/petstore.ts
@@ -120,6 +120,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -127,14 +137,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/generated/v3.0/recursive-schema.ts
+++ b/tests/generated/v3.0/recursive-schema.ts
@@ -114,6 +114,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -121,14 +131,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/generated/v3.0/responses.ts
+++ b/tests/generated/v3.0/responses.ts
@@ -103,6 +103,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -110,14 +120,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/generated/v3.0/swaggerhub-template.ts
+++ b/tests/generated/v3.0/swaggerhub-template.ts
@@ -103,6 +103,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -110,14 +120,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/generated/v3.0/tsoa-odd-types-3.0.2.ts
+++ b/tests/generated/v3.0/tsoa-odd-types-3.0.2.ts
@@ -214,6 +214,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -221,14 +231,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/generated/v3.0/up-banking.ts
+++ b/tests/generated/v3.0/up-banking.ts
@@ -845,6 +845,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -852,14 +862,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/generated/v3.0/uspto.ts
+++ b/tests/generated/v3.0/uspto.ts
@@ -135,6 +135,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -142,14 +152,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/generated/v3.0/wrong-enum-subtypes.ts
+++ b/tests/generated/v3.0/wrong-enum-subtypes.ts
@@ -109,6 +109,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -116,14 +126,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/generated/v3.0/wrong-schema-names.ts
+++ b/tests/generated/v3.0/wrong-schema-names.ts
@@ -127,6 +127,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -134,14 +144,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/another-query-params/expected.ts
+++ b/tests/spec/another-query-params/expected.ts
@@ -131,6 +131,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -138,14 +148,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/another-query-params/schema.ts
+++ b/tests/spec/another-query-params/schema.ts
@@ -131,6 +131,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -138,14 +148,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/axios/expected.ts
+++ b/tests/spec/axios/expected.ts
@@ -1977,7 +1977,9 @@ export class HttpClient<SecurityDataType = unknown> {
   }
 
   protected stringifyFormItem(formItem: unknown) {
-    if (typeof formItem === "object" && formItem !== null) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
       return JSON.stringify(formItem);
     } else {
       return `${formItem}`;

--- a/tests/spec/axios/schema.ts
+++ b/tests/spec/axios/schema.ts
@@ -1977,7 +1977,9 @@ export class HttpClient<SecurityDataType = unknown> {
   }
 
   protected stringifyFormItem(formItem: unknown) {
-    if (typeof formItem === "object" && formItem !== null) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
       return JSON.stringify(formItem);
     } else {
       return `${formItem}`;

--- a/tests/spec/axiosSingleHttpClient/expected.ts
+++ b/tests/spec/axiosSingleHttpClient/expected.ts
@@ -1977,7 +1977,9 @@ export class HttpClient<SecurityDataType = unknown> {
   }
 
   protected stringifyFormItem(formItem: unknown) {
-    if (typeof formItem === "object" && formItem !== null) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
       return JSON.stringify(formItem);
     } else {
       return `${formItem}`;

--- a/tests/spec/axiosSingleHttpClient/schema.ts
+++ b/tests/spec/axiosSingleHttpClient/schema.ts
@@ -1977,7 +1977,9 @@ export class HttpClient<SecurityDataType = unknown> {
   }
 
   protected stringifyFormItem(formItem: unknown) {
-    if (typeof formItem === "object" && formItem !== null) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
       return JSON.stringify(formItem);
     } else {
       return `${formItem}`;

--- a/tests/spec/cli/expected.ts
+++ b/tests/spec/cli/expected.ts
@@ -248,6 +248,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -255,14 +265,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/cli/schema.ts
+++ b/tests/spec/cli/schema.ts
@@ -248,6 +248,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -255,14 +265,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/defaultAsSuccess/expected.ts
+++ b/tests/spec/defaultAsSuccess/expected.ts
@@ -143,6 +143,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -150,14 +160,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/defaultAsSuccess/schema.ts
+++ b/tests/spec/defaultAsSuccess/schema.ts
@@ -143,6 +143,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -150,14 +160,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/defaultResponse/expected.ts
+++ b/tests/spec/defaultResponse/expected.ts
@@ -103,6 +103,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -110,14 +120,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/defaultResponse/schema.ts
+++ b/tests/spec/defaultResponse/schema.ts
@@ -103,6 +103,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -110,14 +120,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/deprecated/expected.ts
+++ b/tests/spec/deprecated/expected.ts
@@ -103,6 +103,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -110,14 +120,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/deprecated/schema.ts
+++ b/tests/spec/deprecated/schema.ts
@@ -103,6 +103,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -110,14 +120,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/dot-path-params/expected.ts
+++ b/tests/spec/dot-path-params/expected.ts
@@ -105,6 +105,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -112,14 +122,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/dot-path-params/schema.ts
+++ b/tests/spec/dot-path-params/schema.ts
@@ -105,6 +105,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -112,14 +122,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/enumNamesAsValues/expected.ts
+++ b/tests/spec/enumNamesAsValues/expected.ts
@@ -295,6 +295,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -302,14 +312,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/enumNamesAsValues/schema.ts
+++ b/tests/spec/enumNamesAsValues/schema.ts
@@ -295,6 +295,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -302,14 +312,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/extractRequestBody/expected.ts
+++ b/tests/spec/extractRequestBody/expected.ts
@@ -256,6 +256,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -263,14 +273,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/extractRequestBody/schema.ts
+++ b/tests/spec/extractRequestBody/schema.ts
@@ -256,6 +256,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -263,14 +273,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/extractRequestParams/expected.ts
+++ b/tests/spec/extractRequestParams/expected.ts
@@ -178,6 +178,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -185,14 +195,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/extractRequestParams/schema.ts
+++ b/tests/spec/extractRequestParams/schema.ts
@@ -178,6 +178,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -185,14 +195,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/extractResponseBody/expected.ts
+++ b/tests/spec/extractResponseBody/expected.ts
@@ -258,6 +258,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -265,14 +275,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/extractResponseBody/schema.ts
+++ b/tests/spec/extractResponseBody/schema.ts
@@ -258,6 +258,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -265,14 +275,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/extractResponseError/expected.ts
+++ b/tests/spec/extractResponseError/expected.ts
@@ -253,6 +253,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -260,14 +270,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/extractResponseError/schema.ts
+++ b/tests/spec/extractResponseError/schema.ts
@@ -253,6 +253,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -260,14 +270,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/js/schema.d.ts
+++ b/tests/spec/js/schema.d.ts
@@ -1833,6 +1833,7 @@ export declare class HttpClient<SecurityDataType = unknown> {
   protected addArrayQueryParam(query: QueryParamsType, key: string): any;
   protected toQueryString(rawQuery?: QueryParamsType): string;
   protected addQueryParams(rawQuery?: QueryParamsType): string;
+  protected stringifyFormItem(formItem: unknown): string;
   private contentFormatters;
   protected mergeRequestParams(params1: RequestParams, params2?: RequestParams): RequestParams;
   protected createAbortSignal: (cancelToken: CancelToken) => AbortSignal | undefined;

--- a/tests/spec/js/schema.js
+++ b/tests/spec/js/schema.js
@@ -56,6 +56,15 @@ export class HttpClient {
     const queryString = this.toQueryString(rawQuery);
     return queryString ? `?${queryString}` : "";
   }
+  stringifyFormItem(formItem) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
   contentFormatters = {
     [ContentType.Json]: (input) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -63,14 +72,8 @@ export class HttpClient {
     [ContentType.FormData]: (input) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input) => this.toQueryString(input),

--- a/tests/spec/jsAxios/schema.js
+++ b/tests/spec/jsAxios/schema.js
@@ -46,7 +46,9 @@ export class HttpClient {
     };
   }
   stringifyFormItem(formItem) {
-    if (typeof formItem === "object" && formItem !== null) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
       return JSON.stringify(formItem);
     } else {
       return `${formItem}`;

--- a/tests/spec/jsSingleHttpClientModular/expected/http-client.d.ts
+++ b/tests/spec/jsSingleHttpClientModular/expected/http-client.d.ts
@@ -61,6 +61,7 @@ export declare class HttpClient<SecurityDataType = unknown> {
   protected addArrayQueryParam(query: QueryParamsType, key: string): any;
   protected toQueryString(rawQuery?: QueryParamsType): string;
   protected addQueryParams(rawQuery?: QueryParamsType): string;
+  protected stringifyFormItem(formItem: unknown): string;
   private contentFormatters;
   protected mergeRequestParams(params1: RequestParams, params2?: RequestParams): RequestParams;
   protected createAbortSignal: (cancelToken: CancelToken) => AbortSignal | undefined;

--- a/tests/spec/jsSingleHttpClientModular/expected/http-client.js
+++ b/tests/spec/jsSingleHttpClientModular/expected/http-client.js
@@ -56,6 +56,15 @@ export class HttpClient {
     const queryString = this.toQueryString(rawQuery);
     return queryString ? `?${queryString}` : "";
   }
+  stringifyFormItem(formItem) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
   contentFormatters = {
     [ContentType.Json]: (input) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -63,14 +72,8 @@ export class HttpClient {
     [ContentType.FormData]: (input) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input) => this.toQueryString(input),

--- a/tests/spec/jsSingleHttpClientModular/generated/http-client.d.ts
+++ b/tests/spec/jsSingleHttpClientModular/generated/http-client.d.ts
@@ -61,6 +61,7 @@ export declare class HttpClient<SecurityDataType = unknown> {
   protected addArrayQueryParam(query: QueryParamsType, key: string): any;
   protected toQueryString(rawQuery?: QueryParamsType): string;
   protected addQueryParams(rawQuery?: QueryParamsType): string;
+  protected stringifyFormItem(formItem: unknown): string;
   private contentFormatters;
   protected mergeRequestParams(params1: RequestParams, params2?: RequestParams): RequestParams;
   protected createAbortSignal: (cancelToken: CancelToken) => AbortSignal | undefined;

--- a/tests/spec/jsSingleHttpClientModular/generated/http-client.js
+++ b/tests/spec/jsSingleHttpClientModular/generated/http-client.js
@@ -56,6 +56,15 @@ export class HttpClient {
     const queryString = this.toQueryString(rawQuery);
     return queryString ? `?${queryString}` : "";
   }
+  stringifyFormItem(formItem) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
   contentFormatters = {
     [ContentType.Json]: (input) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -63,14 +72,8 @@ export class HttpClient {
     [ContentType.FormData]: (input) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input) => this.toQueryString(input),

--- a/tests/spec/modular/expected/http-client.ts
+++ b/tests/spec/modular/expected/http-client.ts
@@ -103,6 +103,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -110,14 +120,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/modular/generated/http-client.ts
+++ b/tests/spec/modular/generated/http-client.ts
@@ -103,6 +103,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -110,14 +120,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/moduleNameFirstTag/expected.ts
+++ b/tests/spec/moduleNameFirstTag/expected.ts
@@ -228,6 +228,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -235,14 +245,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/moduleNameFirstTag/schema.ts
+++ b/tests/spec/moduleNameFirstTag/schema.ts
@@ -228,6 +228,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -235,14 +245,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/moduleNameIndex/expected.ts
+++ b/tests/spec/moduleNameIndex/expected.ts
@@ -228,6 +228,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -235,14 +245,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/moduleNameIndex/schema.ts
+++ b/tests/spec/moduleNameIndex/schema.ts
@@ -228,6 +228,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -235,14 +245,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/on-insert-path-param/expected.ts
+++ b/tests/spec/on-insert-path-param/expected.ts
@@ -103,6 +103,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -110,14 +120,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/on-insert-path-param/schema.ts
+++ b/tests/spec/on-insert-path-param/schema.ts
@@ -103,6 +103,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -110,14 +120,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/partialBaseTemplate/expected.ts
+++ b/tests/spec/partialBaseTemplate/expected.ts
@@ -115,6 +115,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -122,14 +132,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/partialBaseTemplate/schema.ts
+++ b/tests/spec/partialBaseTemplate/schema.ts
@@ -115,6 +115,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -122,14 +132,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/partialDefaultTemplate/expected.ts
+++ b/tests/spec/partialDefaultTemplate/expected.ts
@@ -111,6 +111,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -118,14 +128,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/partialDefaultTemplate/schema.ts
+++ b/tests/spec/partialDefaultTemplate/schema.ts
@@ -111,6 +111,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -118,14 +128,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/patch/expected.ts
+++ b/tests/spec/patch/expected.ts
@@ -1860,6 +1860,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -1867,14 +1877,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/patch/schema.ts
+++ b/tests/spec/patch/schema.ts
@@ -1860,6 +1860,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -1867,14 +1877,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/responses/expected.ts
+++ b/tests/spec/responses/expected.ts
@@ -143,6 +143,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -150,14 +160,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/responses/schema.ts
+++ b/tests/spec/responses/schema.ts
@@ -143,6 +143,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -150,14 +160,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/singleHttpClient/expected.ts
+++ b/tests/spec/singleHttpClient/expected.ts
@@ -103,6 +103,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -110,14 +120,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/singleHttpClient/schema.ts
+++ b/tests/spec/singleHttpClient/schema.ts
@@ -103,6 +103,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -110,14 +120,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/sortTypes(false)/expected.ts
+++ b/tests/spec/sortTypes(false)/expected.ts
@@ -1860,6 +1860,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -1867,14 +1877,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/sortTypes(false)/schema.ts
+++ b/tests/spec/sortTypes(false)/schema.ts
@@ -1860,6 +1860,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -1867,14 +1877,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/sortTypes/expected.ts
+++ b/tests/spec/sortTypes/expected.ts
@@ -1860,6 +1860,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -1867,14 +1877,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/sortTypes/schema.ts
+++ b/tests/spec/sortTypes/schema.ts
@@ -1860,6 +1860,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -1867,14 +1877,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/templates/expected.ts
+++ b/tests/spec/templates/expected.ts
@@ -2009,6 +2009,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -2016,14 +2026,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/templates/schema.ts
+++ b/tests/spec/templates/schema.ts
@@ -2009,6 +2009,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -2016,14 +2026,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/typeSuffixPrefix/expected.ts
+++ b/tests/spec/typeSuffixPrefix/expected.ts
@@ -1860,6 +1860,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -1867,14 +1877,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/typeSuffixPrefix/schema.ts
+++ b/tests/spec/typeSuffixPrefix/schema.ts
@@ -1860,6 +1860,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -1867,14 +1877,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/unionEnums/expected.ts
+++ b/tests/spec/unionEnums/expected.ts
@@ -115,6 +115,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -122,14 +132,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),

--- a/tests/spec/unionEnums/schema.ts
+++ b/tests/spec/unionEnums/schema.ts
@@ -115,6 +115,16 @@ export class HttpClient<SecurityDataType = unknown> {
     return queryString ? `?${queryString}` : "";
   }
 
+  protected stringifyFormItem(formItem: unknown) {
+    if (formItem == null) {
+      return "";
+    } else if (typeof formItem === "object") {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
       input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
@@ -122,14 +132,8 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-            ? JSON.stringify(property)
-            : `${property}`,
-        );
+        const isFileType = property instanceof Blob || property instanceof File;
+        formData.append(key, isFileType ? property : this.stringifyFormItem(property));
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),


### PR DESCRIPTION
When using a ContentType of FormData, requests will no longer send a string of `'null'` of `'undefined'` for any property in the body object that is null or defined.

The form value will now contain the empty string (`''`) instead.

Updated test snapshots to account for new template change.

The Fetch template now looks closer to the Axios template when it comes to checking for Forms and will also support File uploads, not just Blob uploads in the same manner as the Axios template.

Fixed a small bug in the package.json where the snapshots were not updating.

Fixes #485 