### PR TITLE
Fix naming of disableStrictSSL to disableStrictSsl

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -80,7 +80,7 @@ interface GenerateApiParamsBase {
   /**
    * disabled SSL check
    */
-  disableStrictSSL?: boolean;
+  disableStrictSsl?: boolean;
   /**
    * disabled Proxy
    */
@@ -539,7 +539,7 @@ export interface GenerateApiConfiguration {
     moduleNameIndex: number;
     moduleNameFirstTag: boolean;
     extraTemplates: { name: string; path: string }[];
-    disableStrictSSL: boolean;
+    disableStrictSsl: boolean;
     disableProxy: boolean;
     extractRequestParams: boolean;
     unwrapResponseData: boolean;

--- a/index.js
+++ b/index.js
@@ -136,7 +136,7 @@ const program = cli({
     {
       flags: "--disableStrictSSL",
       description: "disabled strict SSL",
-      default: codeGenBaseConfig.disableStrictSSL,
+      default: codeGenBaseConfig.disableStrictSsl,
       internal: { formatter: Boolean },
     },
     {

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -67,7 +67,7 @@ class CodeGenConfig {
 
   /** use the first tag for the module name */
   moduleNameFirstTag = false;
-  disableStrictSSL = false;
+  disableStrictSsl = false;
   disableProxy = false;
   extractRequestParams = false;
   extractRequestBody = false;

--- a/src/swagger-schema-resolver.js
+++ b/src/swagger-schema-resolver.js
@@ -33,7 +33,7 @@ class SwaggerSchemaResolver {
    * @returns {Promise<{usageSchema: Record<string, *>, originalSchema: Record<string, *>}>}
    */
   async create() {
-    const { spec, patch, input, url, disableStrictSSL, disableProxy, authorizationToken } = this.config;
+    const { spec, patch, input, url, disableStrictSsl, disableProxy, authorizationToken } = this.config;
 
     if (this.config.spec) {
       return await this.convertSwaggerObject(spec, { patch });
@@ -42,7 +42,7 @@ class SwaggerSchemaResolver {
     const swaggerSchemaFile = await this.fetchSwaggerSchemaFile(
       input,
       url,
-      disableStrictSSL,
+      disableStrictSsl,
       disableProxy,
       authorizationToken,
     );
@@ -104,14 +104,14 @@ class SwaggerSchemaResolver {
     return this.fileSystem.getFileContent(pathToSwagger);
   };
 
-  async fetchSwaggerSchemaFile(pathToSwagger, urlToSwagger, disableStrictSSL, disableProxy, authToken) {
+  async fetchSwaggerSchemaFile(pathToSwagger, urlToSwagger, disableStrictSsl, disableProxy, authToken) {
     if (this.fileSystem.pathIsExist(pathToSwagger)) {
       return this.getSwaggerSchemaByPath(pathToSwagger);
     } else {
       this.logger.log(`try to get swagger by URL "${urlToSwagger}"`);
       return await this.request.download({
         url: urlToSwagger,
-        disableStrictSSL,
+        disableStrictSsl,
         authToken,
         disableProxy,
       });

--- a/src/util/request.js
+++ b/src/util/request.js
@@ -20,18 +20,18 @@ class Request {
   /**
    *
    * @param url {string}
-   * @param disableStrictSSL
+   * @param disableStrictSsl
    * @param authToken
    * @param options {Partial<import("node-fetch").RequestInit>}
    * @return {Promise<string>}
    */
-  async download({ url, disableStrictSSL, authToken, ...options }) {
+  async download({ url, disableStrictSsl, authToken, ...options }) {
     /**
      * @type {Partial<import("node-fetch").RequestInit>}
      */
     const requestOptions = {};
 
-    if (disableStrictSSL && !_.startsWith(url, "http://")) {
+    if (disableStrictSsl && !_.startsWith(url, "http://")) {
       requestOptions.agent = new https.Agent({
         rejectUnauthorized: false,
       });


### PR DESCRIPTION
I recently upgraded from 9.3.1 to 12.0.2 and ran into the problem that the request to our swagger couldn't fulfill.

I found out it was because the `--disableStrictSSL` flag didn't work as intended so I debugged a little and could narrow the issue down to the fact that the `--disableStrictSSL` arrives as `disableStrictSsl` after processing the args.