### PR TITLE
Fix regex to match numbers in path parameters

### DIFF
--- a/src/schema-routes/schema-routes.js
+++ b/src/schema-routes/schema-routes.js
@@ -97,7 +97,7 @@ class SchemaRoutes {
     const routeName = this.config.hooks.onPreBuildRoutePath(originalRouteName) || originalRouteName;
 
     const pathParamMatches = (routeName || "").match(
-      /({(([a-zA-Z]-?_?\.?){1,})([0-9]{1,})?})|(:(([a-zA-Z]-?_?\.?){1,})([0-9]{1,})?:?)/g,
+      /({(([A-z]){1}([a-zA-Z0-9]-?_?\.?){1,})([0-9]{1,})?})|(:(([A-z]){1}([a-zA-Z0-9]-?_?\.?){1,})([0-9]{1,})?:?)/g,
     );
 
     // used in case when path parameters is not declared in requestInfo.parameters ("in": "path")


### PR DESCRIPTION
Fix regex failure to match path parameters such as /api/store/{2dId}