### PR TITLE
fix: extracting enums along with extracting request params [#506]

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ generateApi({
   toJS: false,
   extractRequestParams: false,
   extractRequestBody: false,
+  extractEnums: false,
   unwrapResponseData: false,
   prettier: { // By default prettier config is load from your project
     printWidth: 120,

--- a/src/schema-parser/schema-parser.js
+++ b/src/schema-parser/schema-parser.js
@@ -92,7 +92,7 @@ class SchemaParser {
   baseSchemaParsers = {
     [SCHEMA_TYPES.ENUM]: (schema, typeName) => {
       if (this.config.extractEnums && !typeName) {
-        const generatedTypeName = this.config.componentTypeNameResolver.resolve([this.buildTypeNameFromPath()]);
+        const generatedTypeName = this.config.componentTypeNameResolver.resolve([this.buildTypeNameFromPath()], false);
         const schemaComponent = this.schemaComponentsMap.createComponent("schemas", generatedTypeName, { ...schema });
         return this.parseSchema(schemaComponent, generatedTypeName);
       }
@@ -391,9 +391,9 @@ class SchemaParser {
       _.merge(schema, this.config.hooks.onPreParseSchema(schema, typeName, schemaType));
       parsedSchema = this.baseSchemaParsers[schemaType](schema, typeName);
       schema.$parsed = this.config.hooks.onParseSchema(schema, parsedSchema) || parsedSchema;
-    }
 
-    this.$processingSchemaPath.pop();
+      this.$processingSchemaPath.pop();
+    }
 
     return schema.$parsed;
   };

--- a/src/schema-parser/schema-routes.js
+++ b/src/schema-parser/schema-routes.js
@@ -767,7 +767,16 @@ class SchemaRoutes {
       this.extractResponseErrorIfItNeeded(routeInfo, responseBodyInfo, routeName);
     }
 
-    const queryType = routeParams.query.length ? this.schemaParser.getInlineParseContent(queryObjectSchema) : null;
+    const typeName = this.schemaUtils.resolveTypeName(
+      routeName.usage,
+      this.config.extractingOptions.requestParamsSuffix,
+      this.config.extractingOptions.requestParamsNameResolver,
+      false,
+    );
+
+    const queryType = routeParams.query.length
+      ? this.schemaParser.getInlineParseContent(queryObjectSchema, typeName)
+      : null;
     const pathType = routeParams.path.length ? this.schemaParser.getInlineParseContent(pathObjectSchema) : null;
     const headersType = routeParams.header.length ? this.schemaParser.getInlineParseContent(headersObjectSchema) : null;
 

--- a/src/schema-parser/schema-utils.js
+++ b/src/schema-parser/schema-utils.js
@@ -145,7 +145,7 @@ class SchemaUtils {
     return _.uniq(_.filter(contents, (type) => filterFn(type)));
   };
 
-  resolveTypeName = (typeName, suffixes, resolver) => {
+  resolveTypeName = (typeName, suffixes, resolver, shouldReserve = true) => {
     if (resolver) {
       return this.config.componentTypeNameResolver.resolve((reserved) => {
         const variant = resolver(pascalCase(typeName), reserved);
@@ -155,6 +155,7 @@ class SchemaUtils {
     } else {
       return this.config.componentTypeNameResolver.resolve(
         suffixes.map((suffix) => pascalCase(`${typeName} ${suffix}`)),
+        shouldReserve,
       );
     }
   };

--- a/src/util/name-resolver.js
+++ b/src/util/name-resolver.js
@@ -40,7 +40,7 @@ class NameResolver {
    * @param {(string[]) | ((reserved: string[]) => string)} variantsOrResolver
    * @returns {string | null}
    */
-  resolve(variantsOrResolver) {
+  resolve(variantsOrResolver, shouldReserve = true) {
     this.logger.debug("resolving name with using", variantsOrResolver);
     if (Array.isArray(variantsOrResolver)) {
       const variants = variantsOrResolver;
@@ -48,13 +48,13 @@ class NameResolver {
       const uniqVariants = _.uniq(_.compact(variants));
 
       _.forEach(uniqVariants, (variant) => {
-        if (!usageName && !this.isReserved(variant)) {
+        if (!usageName && (!shouldReserve || !this.isReserved(variant))) {
           usageName = variant;
         }
       });
 
       if (usageName) {
-        this.reserve([usageName]);
+        shouldReserve && this.reserve([usageName]);
         return usageName;
       }
 
@@ -74,7 +74,7 @@ class NameResolver {
         }
       }
 
-      this.reserve([usageName]);
+      shouldReserve && this.reserve([usageName]);
       return usageName;
     }
 


### PR DESCRIPTION
https://github.com/acacode/swagger-typescript-api/issues/506

I've fixed two problems:
- extracted enum from query params name resolving (permanent `NameName` in extracted enum)
- incorrect extracted enum name within request type (flaky `NameName` within type request definition)

<details>
  <summary>Swagger to reproduce</summary>
  
```json
{
  "openapi": "3.0.2",
  "info": {
    "title": "Some Public API",
    "version": "0.0.1"
  },
  "paths": {
    "/a/b/c": {
      "get": {
        "tags": [
          "tag1"
        ],
        "summary": "get A",
        "operationId": "get_a_b_c_get",
        "parameters": [
          {
            "required": false,
            "schema": {
              "type": "array",
              "items": {
                "$ref": "#/components/schemas/VmState"
              }
            },
            "name": "statuses",
            "in": "query"
          },
          {
            "required": false,
            "schema": {
              "title": "Order By",
              "enum": [
                "created_time"
              ],
              "type": "string",
              "default": "created_time"
            },
            "name": "order_by",
            "in": "query"
          }
        ]
      }
    },
    "/c/d/e": {
      "get": {
        "tags": [
          "Security Groups"
        ],
        "summary": "Get C",
        "operationId": "get_c_d_e_get",
        "parameters": [
          {
            "required": false,
            "schema": {
              "title": "Tag Ids",
              "type": "array",
              "items": {
                "type": "string",
                "format": "uuid"
              }
            },
            "name": "tag_ids",
            "in": "query"
          },
          {
            "required": false,
            "schema": {
              "title": "Order By",
              "enum": [
                "created_time"
              ],
              "type": "string",
              "default": "created_time"
            },
            "name": "order_by",
            "in": "query"
          }
        ]
      }
    }
  }
}
```
</details>

<details>
  <summary>Config</summary>
  
```text
{
      name: TYPINGS_FILE_NAME,
      output: path.resolve(process.cwd(), `${dir}/${TEMP_DIR}`),
      input: path.resolve(process.cwd(), SWAGGER_FILE_PATH),
      generateClient: false,
      prettier: require('./../prettier.config'),
      generateUnionEnums: false,
      extractResponseBody: false,
      extractResponseError: false,
      sortTypes: true,
      extractEnums: true,
      extractRequestParams: true,
      extractingOptions: {
        requestParamsSuffix: ['Params'],
        requestBodySuffix: ['Request'],
        responseBodySuffix: ['Response'],
      },
      templates: path.resolve(process.cwd(), './templates'),
      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
      // @ts-ignore
      codeGenConstructs: () => ({
        EnumField: (key: string, value: string) => `${pascaleCase(key)} = ${value}`,
      }),
      primitiveTypeConstructs: () =>
        repository.packageJSON.swagger?.transformAllDates
          ? {
              string: {
                $default: 'string',
                'date-time': repository.packageJSON.swagger?.fieldsDateType || DEFAULT_DATE_TYPE,
              },
            }
          : {}
}
```
</details>

