### PR TITLE
Content kind for application/octet-stream

### DIFF
--- a/src/schema-routes/schema-routes.js
+++ b/src/schema-routes/schema-routes.js
@@ -273,7 +273,10 @@ class SchemaRoutes {
       return CONTENT_KIND.FORM_DATA;
     }
 
-    if (_.some(contentTypes, (contentType) => _.includes(contentType, "image/"))) {
+    if (
+      _.some(contentTypes, (contentType) => _.includes(contentType, "image/")) ||
+      contentTypes.includes("application/octet-stream")
+    ) {
       return CONTENT_KIND.IMAGE;
     }
 


### PR DESCRIPTION
Allow downloading of `File` type which has `application/octet-stream` media type. Will make another PR to rename `CONTENT_KIND.IMAGE` to `CONTENT_KIND.BLOB` as it maps to `blob` eventually.