### PR TITLE
Use type-only import for axios types

### DIFF
--- a/templates/base/http-clients/axios-http-client.ejs
+++ b/templates/base/http-clients/axios-http-client.ejs
@@ -2,7 +2,7 @@
 const { apiConfig, generateResponses, config } = it;
 %>
 
-import type { AxiosInstance, AxiosRequestConfig, HeadersDefaults, ResponseType } from "axios";
+import type { AxiosInstance, AxiosRequestConfig, HeadersDefaults, ResponseType, AxiosResponse } from "axios";
 import axios from "axios";
 
 export type QueryParamsType = Record<string | number, any>;

--- a/templates/default/api.ejs
+++ b/templates/default/api.ejs
@@ -26,7 +26,7 @@ const descriptionLines = _.compact([
 
 %>
 
-<% if (config.httpClientType === config.constants.HTTP_CLIENT.AXIOS) { %> import { AxiosRequestConfig, AxiosResponse } from "axios"; <% } %>
+<% if (config.httpClientType === config.constants.HTTP_CLIENT.AXIOS) { %> import type { AxiosRequestConfig, AxiosResponse } from "axios"; <% } %>
 
 <% if (descriptionLines.length) { %>
 /**

--- a/templates/modular/api.ejs
+++ b/templates/modular/api.ejs
@@ -6,7 +6,7 @@ const routes = route.routes;
 const dataContracts = _.map(modelTypes, "name");
 %>
 
-<% if (config.httpClientType === config.constants.HTTP_CLIENT.AXIOS) { %> import { AxiosRequestConfig, AxiosResponse } from "axios"; <% } %>
+<% if (config.httpClientType === config.constants.HTTP_CLIENT.AXIOS) { %> import type { AxiosRequestConfig, AxiosResponse } from "axios"; <% } %>
 
 import { HttpClient, RequestParams, ContentType, HttpResponse } from "./<%~ config.fileNames.httpClient %>";
 <% if (dataContracts.length) { %>

--- a/tests/spec/axios/expected.ts
+++ b/tests/spec/axios/expected.ts
@@ -1907,7 +1907,8 @@ export interface UserUpdate {
 
 export type Users = User[];
 
-import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse, HeadersDefaults, ResponseType } from "axios";
+import type { AxiosInstance, AxiosRequestConfig, AxiosResponse, HeadersDefaults, ResponseType } from "axios";
+import axios from "axios";
 
 export type QueryParamsType = Record<string | number, any>;
 

--- a/tests/spec/axios/schema.ts
+++ b/tests/spec/axios/schema.ts
@@ -1907,7 +1907,8 @@ export interface UserUpdate {
 
 export type Users = User[];
 
-import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse, HeadersDefaults, ResponseType } from "axios";
+import type { AxiosInstance, AxiosRequestConfig, AxiosResponse, HeadersDefaults, ResponseType } from "axios";
+import axios from "axios";
 
 export type QueryParamsType = Record<string | number, any>;
 

--- a/tests/spec/axiosSingleHttpClient/expected.ts
+++ b/tests/spec/axiosSingleHttpClient/expected.ts
@@ -1907,7 +1907,8 @@ export interface UserUpdate {
 
 export type Users = User[];
 
-import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse, HeadersDefaults, ResponseType } from "axios";
+import type { AxiosInstance, AxiosRequestConfig, AxiosResponse, HeadersDefaults, ResponseType } from "axios";
+import axios from "axios";
 
 export type QueryParamsType = Record<string | number, any>;
 

--- a/tests/spec/axiosSingleHttpClient/schema.ts
+++ b/tests/spec/axiosSingleHttpClient/schema.ts
@@ -1907,7 +1907,8 @@ export interface UserUpdate {
 
 export type Users = User[];
 
-import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse, HeadersDefaults, ResponseType } from "axios";
+import type { AxiosInstance, AxiosRequestConfig, AxiosResponse, HeadersDefaults, ResponseType } from "axios";
+import axios from "axios";
 
 export type QueryParamsType = Record<string | number, any>;
 

--- a/tests/spec/jsAxios/schema.d.ts
+++ b/tests/spec/jsAxios/schema.d.ts
@@ -1781,7 +1781,7 @@ export interface UserUpdate {
   name?: string;
 }
 export declare type Users = User[];
-import { AxiosInstance, AxiosRequestConfig, AxiosResponse, ResponseType } from "axios";
+import type { AxiosInstance, AxiosRequestConfig, AxiosResponse, ResponseType } from "axios";
 export declare type QueryParamsType = Record<string | number, any>;
 export interface FullRequestParams extends Omit<AxiosRequestConfig, "data" | "params" | "url" | "responseType"> {
   /** set parameter to `true` for call `securityWorker` for this request */


### PR DESCRIPTION
### Refactoring the axios imports

The original code was importing both functions and types together from the axios library. 
To make the code more readable **and follow best practices**, I've separated the import statements into two lines. 

The first line now imports only the type definitions, i.e., AxiosInstance, AxiosRequestConfig, HeadersDefaults, and ResponseType from axios.
The second line imports the axios library itself.

Note:

_I've observed that in Vue projects built with Vite, the current approach **does not only** cause issues with the linter but **also leads to build failures**. The build process does not produce runnable code if type imports are not separated from library imports. Although the root cause of this behavior in Vite is unclear for me, these changes address this problem and ensure successful builds._
