### PR TITLE
Release 13.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # next release  
 
+## 13.0.3  
+
+fix: problem with type `any` as base type of discriminator schema (cases when schema without discriminator is empty)  
+
 ## 13.0.2  
 
 fix: problem with incorrect settings type suffix for internal discriminator mappings

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-typescript-api",
-  "version": "13.0.2",
+  "version": "13.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-typescript-api",
-  "version": "13.0.2",
+  "version": "13.0.3",
   "description": "Generate typescript/javascript api from swagger schema",
   "scripts": {
     "update-deps-to-latest": "npx --yes npm-check-updates && npm i",

--- a/src/schema-parser/base-schema-parsers/discriminator.js
+++ b/src/schema-parser/base-schema-parsers/discriminator.js
@@ -259,9 +259,12 @@ class DiscriminatorSchemaParser extends MonoSchemaParser {
     const { discriminator, ...noDiscriminatorSchema } = this.schema;
     const complexSchemaKeys = _.keys(this.schemaParser._complexSchemaParsers);
     const schema = _.omit(_.clone(noDiscriminatorSchema), complexSchemaKeys);
+    const schemaIsAny =
+      this.schemaParserFabric.getInlineParseContent(_.cloneDeep(schema)) ===
+      this.config.Ts.Keyword.Any;
     const schemaIsEmpty = !_.keys(schema).length;
 
-    if (schemaIsEmpty) return null;
+    if (schemaIsEmpty || schemaIsAny) return null;
 
     const typeName = this.schemaUtils.resolveTypeName(this.typeName, {
       prefixes: this.config.extractingOptions.discriminatorAbstractPrefix,

--- a/tests/spec/discriminator/expected.ts
+++ b/tests/spec/discriminator/expected.ts
@@ -113,6 +113,77 @@ export type InvalidDiscriminatorPropertyName = BaseInvalidDiscriminatorPropertyN
     | BaseInvalidDiscriminatorPropertyNameTypeMapping<"str", string>
   );
 
+/** kek pek */
+export type Variant =
+  | ({
+      type: "update";
+    } & VariantUpdate)
+  | ({
+      type: "undo";
+    } & VariantUndo)
+  | ({
+      type: "rollback";
+    } & VariantRollback)
+  | ({
+      type: "scale";
+    } & VariantScale)
+  | ({
+      type: "resources";
+    } & VariantResources)
+  | ({
+      type: "firewall";
+    } & VariantFirewall)
+  | ({
+      type: "gateway";
+    } & VariantGateway);
+
+/** Proposal to change firewall rules for deployment. */
+export interface VariantFirewall {
+  /** asdasdasdasdasdsad added to deployment. If not set, no rules are added. */
+  rules_added?: string[];
+  /** asdasdasdasdasdsad removed from deployment. If not set, no rules were removed. */
+  rules_removed?: string[];
+}
+
+/** asdasdasdasdasd */
+export interface VariantScale {
+  /**
+   * asdasdasdasdasdsad
+   * @example 3
+   */
+  replicas: number;
+}
+
+/** asdasdasdasdasd */
+export interface VariantResources {
+  resources: string;
+}
+
+/** asdasdasdasdasd */
+export interface VariantGateway {
+  /** asdasdasdasdasdsad */
+  port?: string;
+  /** asdasdasdasdasdsad */
+  name?: string;
+  /** asdasdasdasdasdsad */
+  domain?: string;
+}
+
+/** Pasdasdasdasdasd. */
+export type VariantUpdate = object;
+
+/** asdasdasdasdasd */
+export interface VariantRollback {
+  /**
+   * asdasdasdasdasdsad
+   * @example 42
+   */
+  revision_id: number;
+}
+
+/** asdasdasdasdasdn */
+export type VariantUndo = object;
+
 interface BaseBlockDtoWithEnum {
   title: string;
   type: BlockDTOEnum;

--- a/tests/spec/discriminator/schema.json
+++ b/tests/spec/discriminator/schema.json
@@ -377,6 +377,130 @@
           }
         }
       }
+    },
+    "Variant": {
+      "description": "kek pek",
+      "discriminator": {
+        "propertyName": "type",
+        "mapping": {
+          "update": "#/components/schemas/VariantUpdate",
+          "undo": "#/components/schemas/VariantUndo",
+          "rollback": "#/components/schemas/VariantRollback",
+          "scale": "#/components/schemas/VariantScale",
+          "resources": "#/components/schemas/VariantResources",
+          "firewall": "#/components/schemas/VariantFirewall",
+          "gateway": "#/components/schemas/VariantGateway"
+        }
+      },
+      "oneOf": [
+        {
+          "$ref": "#/components/schemas/VariantUpdate"
+        },
+        {
+          "$ref": "#/components/schemas/VariantUndo"
+        },
+        {
+          "$ref": "#/components/schemas/VariantRollback"
+        },
+        {
+          "$ref": "#/components/schemas/VariantScale"
+        },
+        {
+          "$ref": "#/components/schemas/VariantResources"
+        },
+        {
+          "$ref": "#/components/schemas/VariantFirewall"
+        },
+        {
+          "$ref": "#/components/schemas/VariantGateway"
+        }
+      ]
+    },
+    "VariantFirewall": {
+      "type": "object",
+      "description": "Proposal to change firewall rules for deployment.",
+      "properties": {
+        "rules_added": {
+          "type": "array",
+          "description": "asdasdasdasdasdsad added to deployment. If not set, no rules are added.\n",
+          "items": {
+            "type": "string"
+          }
+        },
+        "rules_removed": {
+          "type": "array",
+          "description": "asdasdasdasdasdsad removed from deployment. If not set, no rules were removed.\n",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "VariantScale": {
+      "type": "object",
+      "description": "asdasdasdasdasd",
+      "required": [
+        "replicas"
+      ],
+      "properties": {
+        "replicas": {
+          "type": "integer",
+          "description": "asdasdasdasdasdsad",
+          "example": 3
+        }
+      }
+    },
+    "VariantResources": {
+      "type": "object",
+      "description": "asdasdasdasdasd",
+      "required": [
+        "resources"
+      ],
+      "properties": {
+        "resources": {
+          "type": "string"
+        }
+      }
+    },
+    "VariantGateway": {
+      "type": "object",
+      "description": "asdasdasdasdasd",
+      "properties": {
+        "port": {
+          "type": "string",
+          "description": "asdasdasdasdasdsad"
+        },
+        "name": {
+          "type": "string",
+          "description": "asdasdasdasdasdsad"
+        },
+        "domain": {
+          "type": "string",
+          "description": "asdasdasdasdasdsad"
+        }
+      }
+    },
+    "VariantUpdate": {
+      "type": "object",
+      "description": "Pasdasdasdasdasd."
+    },
+    "VariantRollback": {
+      "type": "object",
+      "description": "asdasdasdasdasd",
+      "required": [
+        "revision_id"
+      ],
+      "properties": {
+        "revision_id": {
+          "type": "integer",
+          "description": "asdasdasdasdasdsad",
+          "example": 42
+        }
+      }
+    },
+    "VariantUndo": {
+      "type": "object",
+      "description": "asdasdasdasdasdn"
     }
   }
 }

--- a/tests/spec/discriminator/schema.ts
+++ b/tests/spec/discriminator/schema.ts
@@ -113,6 +113,77 @@ export type InvalidDiscriminatorPropertyName = BaseInvalidDiscriminatorPropertyN
     | BaseInvalidDiscriminatorPropertyNameTypeMapping<"str", string>
   );
 
+/** kek pek */
+export type Variant =
+  | ({
+      type: "update";
+    } & VariantUpdate)
+  | ({
+      type: "undo";
+    } & VariantUndo)
+  | ({
+      type: "rollback";
+    } & VariantRollback)
+  | ({
+      type: "scale";
+    } & VariantScale)
+  | ({
+      type: "resources";
+    } & VariantResources)
+  | ({
+      type: "firewall";
+    } & VariantFirewall)
+  | ({
+      type: "gateway";
+    } & VariantGateway);
+
+/** Proposal to change firewall rules for deployment. */
+export interface VariantFirewall {
+  /** asdasdasdasdasdsad added to deployment. If not set, no rules are added. */
+  rules_added?: string[];
+  /** asdasdasdasdasdsad removed from deployment. If not set, no rules were removed. */
+  rules_removed?: string[];
+}
+
+/** asdasdasdasdasd */
+export interface VariantScale {
+  /**
+   * asdasdasdasdasdsad
+   * @example 3
+   */
+  replicas: number;
+}
+
+/** asdasdasdasdasd */
+export interface VariantResources {
+  resources: string;
+}
+
+/** asdasdasdasdasd */
+export interface VariantGateway {
+  /** asdasdasdasdasdsad */
+  port?: string;
+  /** asdasdasdasdasdsad */
+  name?: string;
+  /** asdasdasdasdasdsad */
+  domain?: string;
+}
+
+/** Pasdasdasdasdasd. */
+export type VariantUpdate = object;
+
+/** asdasdasdasdasd */
+export interface VariantRollback {
+  /**
+   * asdasdasdasdasdsad
+   * @example 42
+   */
+  revision_id: number;
+}
+
+/** asdasdasdasdasdn */
+export type VariantUndo = object;
+
 interface BaseBlockDtoWithEnum {
   title: string;
   type: BlockDTOEnum;


### PR DESCRIPTION
fix: problem with type `any` as base type of discriminator schema (cases when schema without discriminator is empty)  
