### PR TITLE
[CHG] Support for application/octet-stream

### DIFF
--- a/src/schema-routes/schema-routes.js
+++ b/src/schema-routes/schema-routes.js
@@ -316,7 +316,8 @@ class SchemaRoutes {
     }
 
     if (
-      _.some(contentTypes, (contentType) => _.includes(contentType, 'image/'))
+      _.some(contentTypes, (contentType) => _.includes(contentType, 'image/')) ||
+      _.some(contentTypes, (contentType) => _.includes(contentType, 'application/octet-stream'))
     ) {
       return CONTENT_KIND.IMAGE;
     }


### PR DESCRIPTION
Hello, 
Good job, for all, it's an amazing lib.

In my work, I use application/octet-stream for downloading file, but the parameter format wasn't set to 'blob'.

I can add a content-type image/png, but it's not really good, but it work...

I make this PR to resvolve this.

Best regards, Shaenn