### PR TITLE
feat: add security in raw route info

### DIFF
--- a/src/schema-routes/schema-routes.js
+++ b/src/schema-routes/schema-routes.js
@@ -917,6 +917,7 @@ class SchemaRoutes {
       produces,
       requestBody,
       consumes,
+      security,
     };
 
     const queryObjectSchema = this.convertRouteParamsIntoObject(


### PR DESCRIPTION
`security` in the original OpenAPI document is not included in `routeInfo.raw`. This PR addes it.