### PR TITLE
remove leading zeros of enum Number types

### DIFF
--- a/src/configuration.js
+++ b/src/configuration.js
@@ -237,7 +237,13 @@ class CodeGenConfig {
     /**
      * $A
      */
-    NumberValue: (content) => `${content}`,
+    NumberValue: (content) => {
+      if (typeof content === 'string') {
+        return /^0*$/.test(content) ? `0` : `${content.replace(/^0+/, '')}`;
+      } else {
+        return `${content}`;
+      }
+    },
     /**
      * $A
      */

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -252,7 +252,10 @@ class CodeGenConfig {
      * $A1 | $A2
      */
     UnionType: (contents) =>
-      _.join(_.uniq(contents), ` ${this.Ts.Keyword.Union} `),
+      _.join(
+        _.uniq(contents.map((entry) => entry.replace(/\\/g, '\\\\'))),
+        ` ${this.Ts.Keyword.Union} `,
+      ),
     /**
      * ($A1)
      */

--- a/tests/generated/v3.0/full-swagger-scheme.ts
+++ b/tests/generated/v3.0/full-swagger-scheme.ts
@@ -21342,10 +21342,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       data: {
         /**
          * The reason for locking the issue or pull request conversation. Lock will fail if you don't use one of these reasons:
-         * \* `off-topic`
-         * \* `too heated`
-         * \* `resolved`
-         * \* `spam`
+         * \\* `off-topic`
+         * \\* `too heated`
+         * \\* `resolved`
+         * \\* `spam`
          */
         lock_reason?: "off-topic" | "too heated" | "resolved" | "spam";
       } | null,

--- a/tests/spec/enums-2.0/expected.ts
+++ b/tests/spec/enums-2.0/expected.ts
@@ -91,6 +91,15 @@ export enum SomeInterestEnum {
   HSDFDS = "HSDFDS",
 }
 
+export enum EnumLeadingZeros {
+  Value0 = 0,
+  Value1 = 1,
+  Value2 = 2,
+  Value3 = 3,
+  Value4 = 4,
+  Value5 = 5,
+}
+
 export interface PostFooPayload {
   someTypeId?: 1 | 2 | 3 | 4 | 5;
 }

--- a/tests/spec/enums-2.0/schema.json
+++ b/tests/spec/enums-2.0/schema.json
@@ -79,6 +79,10 @@
         "ASDds",
         "HSDFDS"
       ]
+    },
+    "enum-leading-zeros": {
+      "type": "integer",
+      "enum": [ 00, 01, 02, 03, 04, 05 ]
     }
   },
   "paths": {

--- a/tests/spec/enums-2.0/schema.ts
+++ b/tests/spec/enums-2.0/schema.ts
@@ -91,6 +91,15 @@ export enum SomeInterestEnum {
   HSDFDS = "HSDFDS",
 }
 
+export enum EnumLeadingZeros {
+  Value0 = 0,
+  Value1 = 1,
+  Value2 = 2,
+  Value3 = 3,
+  Value4 = 4,
+  Value5 = 5,
+}
+
 export interface PostFooPayload {
   someTypeId?: 1 | 2 | 3 | 4 | 5;
 }

--- a/tests/spec/unionEnums/expected.ts
+++ b/tests/spec/unionEnums/expected.ts
@@ -21,6 +21,8 @@ export type BooleanEnum = true | false;
  */
 export type IntEnumWithNames = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
 
+export type EnumBackslash = "\\" | "" | "/";
+
 export type QueryParamsType = Record<string | number, any>;
 export type ResponseFormat = keyof Omit<Body, "body" | "bodyUsed">;
 

--- a/tests/spec/unionEnums/schema.json
+++ b/tests/spec/unionEnums/schema.json
@@ -35,6 +35,10 @@
           "Tess44",
           "BooFar"
         ]
+      },
+      "enum-backslash": {
+        "type": "string",
+        "enum": [ "\\", "", "\/"]
       }
     },
     "securitySchemes": {}

--- a/tests/spec/unionEnums/schema.ts
+++ b/tests/spec/unionEnums/schema.ts
@@ -21,6 +21,8 @@ export type BooleanEnum = true | false;
  */
 export type IntEnumWithNames = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
 
+export type EnumBackslash = "\\" | "" | "/";
+
 export type QueryParamsType = Record<string | number, any>;
 export type ResponseFormat = keyof Omit<Body, "body" | "bodyUsed">;
 


### PR DESCRIPTION
hi all, first of all i want to say that i LOVE this framework!!!!
Now my suggestion: we have to deal with some strange openapi specs that have enum values as a number that contain leading zeros. 
To make the endresult more resilliant for these strange definitions i suggest to stripe away leading zeros for number enum values.
That's a very simple change but it helps for "strange" open api specs. 
Also added a test for it that doesn't break anything.