### PR TITLE
Add text values to `RequestParams["format"]`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "swagger-typescript-api",
-      "version": "13.0.2",
+      "version": "13.0.3",
       "license": "MIT",
       "dependencies": {
         "@types/swagger-schema-official": "2.0.22",

--- a/templates/default/procedure-call.ejs
+++ b/templates/default/procedure-call.ejs
@@ -56,7 +56,8 @@ const requestContentKind = {
 const responseContentKind = {
     "JSON": '"json"',
     "IMAGE": '"blob"',
-    "FORM_DATA": isFetchTemplate ? '"formData"' : '"document"'
+    "FORM_DATA": isFetchTemplate ? '"formData"' : '"document"',
+    "TEXT": '"text"'
 }
 
 const bodyTmpl = _.get(payload, "name") || null;

--- a/templates/modular/procedure-call.ejs
+++ b/templates/modular/procedure-call.ejs
@@ -56,7 +56,8 @@ const requestContentKind = {
 const responseContentKind = {
     "JSON": '"json"',
     "IMAGE": '"blob"',
-    "FORM_DATA": isFetchTemplate ? '"formData"' : '"document"'
+    "FORM_DATA": isFetchTemplate ? '"formData"' : '"document"',
+    "TEXT": '"text"'
 }
 
 const bodyTmpl = _.get(payload, "name") || null;

--- a/tests/spec/templates/spec_templates/procedure-call.eta
+++ b/tests/spec/templates/spec_templates/procedure-call.eta
@@ -55,7 +55,8 @@ const requestContentKind = {
 const responseContentKind = {
     "JSON": '"json"',
     "IMAGE": '"blob"',
-    "FORM_DATA": isFetchTemplate ? '"formData"' : '"document"'
+    "FORM_DATA": isFetchTemplate ? '"formData"' : '"document"',
+    "TEXT": '"text"',
 }
 
 const bodyTmpl = _.get(payload, "name") || null;

--- a/tests/spec/templates/spec_templates/procedure-call.eta
+++ b/tests/spec/templates/spec_templates/procedure-call.eta
@@ -56,7 +56,7 @@ const responseContentKind = {
     "JSON": '"json"',
     "IMAGE": '"blob"',
     "FORM_DATA": isFetchTemplate ? '"formData"' : '"document"',
-    "TEXT": '"text"',
+    "TEXT": '"text"'
 }
 
 const bodyTmpl = _.get(payload, "name") || null;


### PR DESCRIPTION
I have found a bug while trying to work with an endpoint that produces text/plain where the format value for the `format` parameter of the fetch http client isn't generated for text. Manually adding `format: "text"` to the generated `api.ts` file fixes this.