### PR TITLE
Fix nodejs usage on README - field name, writeFile callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,8 +188,9 @@ generateApi({
   }
 })
   .then(({ files, configuration }) => {
-    files.forEach(({ content, name }) => {
-      fs.writeFile(path, content);
+    files.forEach(({ fileContent, fileName, fileExtension }) => {
+      const path = `${PATH_TO_OUTPUT_DIR}/${fileName}${fileExtension}`;
+      fs.writeFile(path, fileContent);
     });
   })
   .catch(e => console.error(e))

--- a/README.md
+++ b/README.md
@@ -190,7 +190,10 @@ generateApi({
   .then(({ files, configuration }) => {
     files.forEach(({ fileContent, fileName, fileExtension }) => {
       const path = `${PATH_TO_OUTPUT_DIR}/${fileName}${fileExtension}`;
-      fs.writeFile(path, fileContent);
+      fs.writeFile(path, fileContent, (err) => {
+        if (err) throw err;
+        console.log(`${path} has been saved!`);
+      });
     });
   })
   .catch(e => console.error(e))


### PR DESCRIPTION
## Goal
Currently nodejs usage on README.md does not work.
It should be executable only by copying and pasting for beginners.

## Todo
- [x] fix: correct files' field to use latest name
- [x] fix: writeFile takes callback  