### PR TITLE
Checking if instanceof FormData before creating one

### DIFF
--- a/templates/base/http-clients/axios-http-client.ejs
+++ b/templates/base/http-clients/axios-http-client.ejs
@@ -79,6 +79,9 @@ export class HttpClient<SecurityDataType = unknown> {
     }
 
     protected createFormData(input: Record<string, unknown>): FormData {
+      if (input instanceof FormData) {
+        return input;
+      }
       return Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
         const propertyContent: any[] = (property instanceof Array) ? property : [property]

--- a/tests/spec/axios/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/axios/__snapshots__/basic.test.ts.snap
@@ -1989,6 +1989,9 @@ export class HttpClient<SecurityDataType = unknown> {
   }
 
   protected createFormData(input: Record<string, unknown>): FormData {
+    if (input instanceof FormData) {
+      return input;
+    }
     return Object.keys(input || {}).reduce((formData, key) => {
       const property = input[key];
       const propertyContent: any[] = property instanceof Array ? property : [property];

--- a/tests/spec/axiosSingleHttpClient/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/axiosSingleHttpClient/__snapshots__/basic.test.ts.snap
@@ -1989,6 +1989,9 @@ export class HttpClient<SecurityDataType = unknown> {
   }
 
   protected createFormData(input: Record<string, unknown>): FormData {
+    if (input instanceof FormData) {
+      return input;
+    }
     return Object.keys(input || {}).reduce((formData, key) => {
       const property = input[key];
       const propertyContent: any[] = property instanceof Array ? property : [property];

--- a/tests/spec/js/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/js/__snapshots__/basic.test.ts.snap
@@ -56,6 +56,9 @@ export class HttpClient {
     }
   }
   createFormData(input) {
+    if (input instanceof FormData) {
+      return input;
+    }
     return Object.keys(input || {}).reduce((formData, key) => {
       const property = input[key];
       const propertyContent = property instanceof Array ? property : [property];


### PR DESCRIPTION
When in createFormData in axios-http-client, first check if the input is of type FormData and if so, return it.