### PR TITLE
apiClassname missing in .d.ts file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,9 @@ interface GenerateApiParamsBase {
    */
   name?: string;
 
+  /** name of the api class (default: "Api")*/
+  apiClassName?: string;
+
   /**
    * path to folder where will be located the created api module.
    *


### PR DESCRIPTION
Add `apiClassname` to `index.d.ts` file