### PR TITLE
Fix route param parsing when the param begins with just one letter

### DIFF
--- a/src/schema-routes/schema-routes.js
+++ b/src/schema-routes/schema-routes.js
@@ -110,7 +110,7 @@ class SchemaRoutes {
       originalRouteName;
 
     const pathParamMatches = (routeName || "").match(
-      /({[a-zA-Z]([a-zA-Z0-9-_.])*})|(:[a-zA-Z]([-_.]?[a-zA-Z0-9-_.])*:?)/g,
+      /({[a-zA-Z]([-_.]*[a-zA-Z0-9])*})|(:[a-zA-Z]([-_.]*[a-zA-Z0-9])*:?)/g,
     );
 
     // used in case when path parameters is not declared in requestInfo.parameters ("in": "path")

--- a/src/schema-routes/schema-routes.js
+++ b/src/schema-routes/schema-routes.js
@@ -110,7 +110,7 @@ class SchemaRoutes {
       originalRouteName;
 
     const pathParamMatches = (routeName || "").match(
-      /({(([A-z]){1}([a-zA-Z0-9-_.]-?_?\.?)+)([0-9]+)?})|(:(([A-z]){1}([a-zA-Z0-9-_.]-?_?\.?)+)([0-9]+)?:?)/g,
+      /({[a-zA-Z]([a-zA-Z0-9-_.])*})|(:[a-zA-Z]([-_.]?[a-zA-Z0-9-_.])*:?)/g,
     );
 
     // used in case when path parameters is not declared in requestInfo.parameters ("in": "path")

--- a/src/schema-routes/schema-routes.js
+++ b/src/schema-routes/schema-routes.js
@@ -110,7 +110,7 @@ class SchemaRoutes {
       originalRouteName;
 
     const pathParamMatches = (routeName || "").match(
-      /({(([A-z]){1}([a-zA-Z0-9]-?_?\.?)+)([0-9]+)?})|(:(([A-z]){1}([a-zA-Z0-9]-?_?\.?)+)([0-9]+)?:?)/g,
+      /({(([A-z]){1}([a-zA-Z0-9-_.]-?_?\.?)+)([0-9]+)?})|(:(([A-z]){1}([a-zA-Z0-9-_.]-?_?\.?)+)([0-9]+)?:?)/g,
     );
 
     // used in case when path parameters is not declared in requestInfo.parameters ("in": "path")

--- a/tests/spec/extractRequestParams/expected.ts
+++ b/tests/spec/extractRequestParams/expected.ts
@@ -472,6 +472,31 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         ...params,
       }),
   };
+  iKey = {
+    /**
+     * @description Get public details of an Authentiq ID.
+     *
+     * @tags key, get
+     * @name IKeyDetail
+     * @request GET:/i_key/{i_PK}
+     */
+    iKeyDetail: (iPk: string, params: RequestParams = {}) =>
+      this.request<
+        {
+          /** @format date-time */
+          since?: string;
+          status?: string;
+          /** base64safe encoded public signing key */
+          sub?: string;
+        },
+        Error
+      >({
+        path: `/i_key/${iPk}`,
+        method: "GET",
+        format: "json",
+        ...params,
+      }),
+  };
   login = {
     /**
      * @description push sign-in request See: https://github.com/skion/authentiq/wiki/JWT-Examples

--- a/tests/spec/extractRequestParams/expected.ts
+++ b/tests/spec/extractRequestParams/expected.ts
@@ -496,6 +496,27 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         format: "json",
         ...params,
       }),
+
+    /**
+     * @description Get public details of an Authentiq ID.
+     *
+     * @tags key, get
+     * @name UnderlinesDetail
+     * @request GET:/i_key/underlines/{i__UK}
+     */
+    underlinesDetail: (iUk: string, params: RequestParams = {}) =>
+      this.request<
+        {
+          /** base64safe encoded public signing key */
+          sub?: string;
+        },
+        Error
+      >({
+        path: `/i_key/underlines/${iUk}`,
+        method: "GET",
+        format: "json",
+        ...params,
+      }),
   };
   login = {
     /**

--- a/tests/spec/extractRequestParams/schema.json
+++ b/tests/spec/extractRequestParams/schema.json
@@ -56,6 +56,13 @@
       "required": true,
       "type": "string"
     },
+    "i_PK": {
+      "description": "Public Signing Key - Authentiq ID (43 chars)",
+      "in": "path",
+      "name": "i_PK",
+      "required": true,
+      "type": "string"
+    },
     "BarBaz": {
       "description": "bar baz",
       "in": "path",
@@ -422,6 +429,55 @@
           }
         },
         "tags": ["key", "put"]
+      }
+    },
+    "/i_key/{i_PK}": {
+      "get": {
+        "description": "Get public details of an Authentiq ID.\n",
+        "parameters": [
+          {
+            "$ref": "#/parameters/i_PK"
+          }
+        ],
+        "produces": ["application/json"],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved",
+            "schema": {
+              "properties": {
+                "since": {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                "status": {
+                  "type": "string"
+                },
+                "sub": {
+                  "description": "base64safe encoded public signing key",
+                  "type": "string"
+                }
+              },
+              "title": "JWT",
+              "type": "object"
+            }
+          },
+          "404": {
+            "description": "Unknown key `unknown-key`",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "410": {
+            "description": "Key is revoked (gone). `revoked-key`",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/ErrorResponse"
+          }
+        },
+        "tags": ["key", "get"]
       }
     },
     "/login": {

--- a/tests/spec/extractRequestParams/schema.json
+++ b/tests/spec/extractRequestParams/schema.json
@@ -56,6 +56,13 @@
       "required": true,
       "type": "string"
     },
+    "i__UK": {
+      "description": "Variable with double __ in it.",
+      "in": "path",
+      "name": "i__UK",
+      "required": true,
+      "type": "string"
+    },
     "i_PK": {
       "description": "Public Signing Key - Authentiq ID (43 chars)",
       "in": "path",
@@ -471,6 +478,36 @@
             "description": "Key is revoked (gone). `revoked-key`",
             "schema": {
               "$ref": "#/definitions/Error"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/ErrorResponse"
+          }
+        },
+        "tags": ["key", "get"]
+      }
+    },
+    "/i_key/underlines/{i__UK}": {
+      "get": {
+        "description": "Get public details of an Authentiq ID.\n",
+        "parameters": [
+          {
+            "$ref": "#/parameters/i__UK"
+          }
+        ],
+        "produces": ["application/json"],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved",
+            "schema": {
+              "properties": {
+                "sub": {
+                  "description": "base64safe encoded public signing key",
+                  "type": "string"
+                }
+              },
+              "title": "JWT",
+              "type": "object"
             }
           },
           "default": {

--- a/tests/spec/extractRequestParams/schema.ts
+++ b/tests/spec/extractRequestParams/schema.ts
@@ -472,6 +472,31 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         ...params,
       }),
   };
+  iKey = {
+    /**
+     * @description Get public details of an Authentiq ID.
+     *
+     * @tags key, get
+     * @name IKeyDetail
+     * @request GET:/i_key/{i_PK}
+     */
+    iKeyDetail: (iPk: string, params: RequestParams = {}) =>
+      this.request<
+        {
+          /** @format date-time */
+          since?: string;
+          status?: string;
+          /** base64safe encoded public signing key */
+          sub?: string;
+        },
+        Error
+      >({
+        path: `/i_key/${iPk}`,
+        method: "GET",
+        format: "json",
+        ...params,
+      }),
+  };
   login = {
     /**
      * @description push sign-in request See: https://github.com/skion/authentiq/wiki/JWT-Examples

--- a/tests/spec/extractRequestParams/schema.ts
+++ b/tests/spec/extractRequestParams/schema.ts
@@ -496,6 +496,27 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         format: "json",
         ...params,
       }),
+
+    /**
+     * @description Get public details of an Authentiq ID.
+     *
+     * @tags key, get
+     * @name UnderlinesDetail
+     * @request GET:/i_key/underlines/{i__UK}
+     */
+    underlinesDetail: (iUk: string, params: RequestParams = {}) =>
+      this.request<
+        {
+          /** base64safe encoded public signing key */
+          sub?: string;
+        },
+        Error
+      >({
+        path: `/i_key/underlines/${iUk}`,
+        method: "GET",
+        format: "json",
+        ...params,
+      }),
   };
   login = {
     /**


### PR DESCRIPTION
For example if the param was i_key the current regex would not find it as a variable. it was only working for the params with more than one letter before either `.` `-` or `_`. the fix should allow to find params with only one letter at begninng.