### PR TITLE
fix: define generateRouteTypes correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -322,7 +322,7 @@ const main = async () => {
           ...options,
           name: options.name,
           url: options.path,
-          generateRouteTypes: options.routeTypes,
+          generateRouteTypes: options.generateRouteTypes,
           generateClient: !!(options.axios || options.client),
           httpClientType: options.axios ? HTTP_CLIENT.AXIOS : HTTP_CLIENT.FETCH,
           input: resolve(process.cwd(), options.path),


### PR DESCRIPTION
The `--route-types` flag was being ignored, since the wrong option name from `program.execute` was being passed into the `generateApi` function.
