### PR TITLE
chore(deps): make sure transitive dependency installed: node-fetch-h2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "swagger-typescript-api",
-      "version": "13.0.2",
+      "version": "13.0.3",
       "license": "MIT",
       "dependencies": {
         "@types/swagger-schema-official": "2.0.22",
@@ -19,6 +19,7 @@
         "nanoid": "3.3.6",
         "node-emoji": "2.1.0",
         "node-fetch": "^3.3.1",
+        "node-fetch-h2": "^2.3.0",
         "prettier": "3.0.0",
         "swagger-schema-official": "2.0.0-bab6bed",
         "swagger2openapi": "7.0.8",

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "nanoid": "3.3.6",
     "node-emoji": "2.1.0",
     "node-fetch": "^3.3.1",
+    "node-fetch-h2": "^2.3.0",
     "prettier": "3.0.0",
     "swagger-schema-official": "2.0.0-bab6bed",
     "swagger2openapi": "7.0.8",


### PR DESCRIPTION
## Purpose
This PR fixes #518.

## Background
swagger-typescript-api "requires" node-fetch-h2, which is installed via other dependencies like swagger2openapi. However, node-fetch-h2- is not specified in any of dependencies. So when I tried to install and "requires" swagger-typescript-api, my package manager couldn't find node-fetch-h2 for swagger-typescript-api.

The following shows node-fetch-h2 is not installed as deps but installed by other deps.

```sh
% date; git fetch swagger-typescript-api master
Sat Apr 20 18:01:58 KST 2024
From https://github.com/acacode/swagger-typescript-api
 * branch            master     -> FETCH_HEAD

% date; git checkout swagger-typescript-api/master
Sat Apr 20 18:02:02 KST 2024
HEAD is now at 2b6db23 Merge pull request #581 from acacode/next

% date; ag node-fetch-h2
Sat Apr 20 18:02:09 KST 2024
package-lock.json
2750:    "node_modules/node-fetch-h2": {
2752:      "resolved": "https://registry.npmjs.org/node-fetch-h2/-/node-fetch-h2-2.3.0.tgz",
2807:        "node-fetch-h2": "^2.3.0",
3757:        "node-fetch-h2": "^2.3.0",

src/util/request.js
3:const fetch = require('node-fetch-h2');

% date; npm why node-fetch-h2
Sat Apr 20 18:05:19 KST 2024
node-fetch-h2@2.3.0
node_modules/node-fetch-h2
  node-fetch-h2@"^2.3.0" from oas-resolver@2.5.6
  node_modules/oas-resolver
    oas-resolver@"^2.5.6" from oas-validator@5.0.8
    node_modules/oas-validator
      oas-validator@"^5.0.8" from swagger2openapi@7.0.8
      node_modules/swagger2openapi
        swagger2openapi@"7.0.8" from the root project
    oas-resolver@"^2.5.6" from swagger2openapi@7.0.8
    node_modules/swagger2openapi
      swagger2openapi@"7.0.8" from the root project
  node-fetch-h2@"^2.3.0" from swagger2openapi@7.0.8
  node_modules/swagger2openapi
    swagger2openapi@"7.0.8" from the root project
```