### PR TITLE
feature: add --prefer-types-over-interfaces options

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Options:
   -r, --responses               generate additional information about request responses
                                 also add typings for bad responses (default: false)
   --union-enums                 generate all "enum" types as union types (T1 | T2 | TN) (default: false)
+  --prefer-types-over-interface generate types instead of interfaces for DTOs (default: false)
   --add-readonly                generate readonly properties (default: false)
   --route-types                 generate type definitions for API routes (default: false)
   --no-client                   do not generate an API class
@@ -136,7 +137,8 @@ generateApi({
   singleHttpClient: true,
   cleanOutput: false,
   enumNamesAsValues: false,
-  moduleNameFirstTag: false,
+  moduleNameFirstTag: false, 
+  preferTypesOverInterface: false,
   generateUnionEnums: false,
   typePrefix: "",
   typeSuffix: "",

--- a/index.d.ts
+++ b/index.d.ts
@@ -32,6 +32,11 @@ interface GenerateApiParamsBase {
   generateUnionEnums?: boolean;
 
   /**
+   * generate with types instead of interface
+   */
+  preferTypesOverInterface?: boolean;
+
+  /**
    * generate type definitions for API routes (default: false)
    */
   generateRouteTypes?: boolean;
@@ -613,6 +618,7 @@ export interface GenerateApiConfiguration {
     generateRouteTypes: boolean;
     generateClient: boolean;
     generateUnionEnums: boolean;
+    preferTypesOverInterface: boolean;
     swaggerSchema: object;
     originalSchema: object;
     componentsMap: Record<string, SchemaComponent>;

--- a/index.js
+++ b/index.js
@@ -68,6 +68,12 @@ const program = cli({
       internal: { name: "generateUnionEnums" },
     },
     {
+      flags: "--prefer-types-over-interface",
+      description: "prefer types over interfaces",
+      default: codeGenBaseConfig.preferTypesOverInterface,
+      internal: { name: "preferTypesOverInterface" },
+    },
+    {
       flags: "--add-readonly",
       description: "generate readonly properties",
       default: codeGenBaseConfig.addReadonly,

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "test:--templates": "node tests/spec/templates/test.js",
     "test:--type-suffix--type-prefix": "node tests/spec/typeSuffixPrefix/test.js",
     "test:--union-enums": "node tests/spec/unionEnums/test.js",
+    "test:--prefer-types-over-interface": "node tests/spec/preferTypesOverInterface/test.js",
     "test:additionalProperties2.0": "node tests/spec/additional-properties-2.0/test.js",
     "test:another-query-params": "node tests/spec/another-query-params/test.js",
     "test:const-keyword": "node tests/spec/const-keyword/test.js",

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -49,6 +49,8 @@ class CodeGenConfig {
   /** CLI flag */
   generateUnionEnums = false;
   /** CLI flag */
+  preferTypesOverInterface = false;
+  /** CLI flag */
   addReadonly = false;
   enumNamesAsValues = false;
   /** parsed swagger schema from getSwaggerObject() */

--- a/templates/base/data-contracts.ejs
+++ b/templates/base/data-contracts.ejs
@@ -20,6 +20,10 @@ const dataContractTemplates = {
     return `enum ${contract.name} {\r\n${contract.content} \r\n }`;
   },
   interface: (contract) => {
+    if (config.preferTypesOverInterface) {
+        return `type ${contract.name}${buildGenerics(contract)} = {\r\n${contract.content}}`;
+    }
+
     return `interface ${contract.name}${buildGenerics(contract)} {\r\n${contract.content}}`;
   },
   type: (contract) => {

--- a/tests/spec/preferTypesOverInterface/expected.ts
+++ b/tests/spec/preferTypesOverInterface/expected.ts
@@ -1,0 +1,18 @@
+/* eslint-disable */
+/* tslint:disable */
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+export type Pet = {
+  /** @format int64 */
+  readonly id: number;
+  readonly name: string;
+  readonly tag?: string;
+  readonly multiple?: string | number;
+};

--- a/tests/spec/preferTypesOverInterface/schema.json
+++ b/tests/spec/preferTypesOverInterface/schema.json
@@ -1,0 +1,64 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "description": "A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "name": "Swagger API Team"
+    },
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/api",
+  "schemes": ["http"],
+  "consumes": ["application/json"],
+  "produces": ["application/json"],
+  "paths": {
+    "/pets": {
+      "get": {
+        "description": "Returns all pets from the system that the user has access to",
+        "produces": ["application/json"],
+        "responses": {
+          "200": {
+            "description": "A list of pets.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Pet"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Pet": {
+      "type": "object",
+      "required": ["id", "name"],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "readOnly": true,
+          "format": "int64"
+        },
+        "name": {
+          "type": "string",
+          "readOnly": true
+        },
+        "tag": {
+          "type": "string",
+          "readOnly": true
+        },
+        "multiple": {
+          "type": ["string", "number"],
+          "readOnly": true
+        }
+      }
+    }
+  }
+}

--- a/tests/spec/preferTypesOverInterface/schema.ts
+++ b/tests/spec/preferTypesOverInterface/schema.ts
@@ -1,0 +1,18 @@
+/* eslint-disable */
+/* tslint:disable */
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+export type Pet = {
+  /** @format int64 */
+  readonly id: number;
+  readonly name: string;
+  readonly tag?: string;
+  readonly multiple?: string | number;
+};

--- a/tests/spec/preferTypesOverInterface/test.js
+++ b/tests/spec/preferTypesOverInterface/test.js
@@ -1,0 +1,28 @@
+const { generateApiForTest } = require("../../helpers/generateApiForTest");
+const { resolve } = require("node:path");
+const validateGeneratedModule = require("../../helpers/validateGeneratedModule");
+const createSchemaInfos = require("../../helpers/createSchemaInfos");
+const assertGeneratedModule = require("../../helpers/assertGeneratedModule");
+
+const schemas = createSchemaInfos({
+  absolutePathToSchemas: resolve(__dirname, "./"),
+});
+
+schemas.forEach(({ absolutePath, apiFileName }) => {
+  generateApiForTest({
+    testName: "prefer types over interface test",
+    silent: true,
+    name: apiFileName,
+    input: absolutePath,
+    output: resolve(__dirname, "./"),
+    addReadonly: true,
+    generateClient: false,
+    preferTypesOverInterface: true,
+  }).then(() => {
+    validateGeneratedModule(resolve(__dirname, `./${apiFileName}`));
+    assertGeneratedModule(
+      resolve(__dirname, `./${apiFileName}`),
+      resolve(__dirname, "./expected.ts"),
+    );
+  });
+});


### PR DESCRIPTION
Hello,

We have implemented this feature, with two reasons : 

- We prefer use types over interfaces for our domain
- In our project we have a french named domain named "Document" and the name clash with the "Document" from MDN. https://developer.mozilla.org/en-US/docs/Web/API/Document