### PR TITLE
Fix types

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "main": "./dist/lib.cjs",
   "module": "./dist/lib.js",
-  "types": "./dist/index.d.cts",
+  "types": "./dist/types.d.cts",
   "bin": {
     "sta": "./dist/cli.js",
     "swagger-typescript-api": "./dist/cli.js"


### PR DESCRIPTION
Follow on from: https://github.com/acacode/swagger-typescript-api/pull/812

To fix the incorrect type file reference which was causing an issue with my usage of the library:

```
Could not find a declaration file for module 'swagger-typescript-api'. '<path>/node_modules/swagger-typescript-api/dist/lib.cjs' implicitly has an 'any' type.
  Try `npm i --save-dev @types/swagger-typescript-api` if it exists or add a new declaration (.d.ts) file containing `declare module 'swagger-typescript-api';`

1 import { generateApi, GenerateApiParams } from 'swagger-typescript-api';
```