### PR TITLE
Custom config: handle default export

### DIFF
--- a/index.js
+++ b/index.js
@@ -296,14 +296,18 @@ const main = async () => {
   const { command, options } = await program.execute({ args: process.argv });
 
   let customConfig = null;
+  let customConfigPath;
 
   if (options.customConfig) {
     try {
-      const customConfigPath = resolve(process.cwd(), options.customConfig);
-      console.log(`✨ found custom config at: ${customConfigPath}`);
+      customConfigPath = resolve(process.cwd(), options.customConfig);
       customConfig = await import(customConfigPath);
+      customConfig = customConfig.default || customConfig;
     } catch (e) {
-      /* empty */
+      console.error("Error loading custom config", e);
+    }
+    if (customConfig) {
+      console.log(`✨ found custom config at: ${customConfigPath}`);
     }
   }
 


### PR DESCRIPTION
It should finally fix #806

Added interop default, because currently importing of custom config with `export default` is not working properly.

Also reorganized custom config logs a bit:
- logging "found custom config" only if it really loads
- otherwise showing error, instead of silently ignoring custom config