### PR TITLE
Fix #671 -  Content-Type: "multipart/form-data" is ignored (when using axios)

### DIFF
--- a/templates/base/http-clients/axios-http-client.ejs
+++ b/templates/base/http-clients/axios-http-client.ejs
@@ -127,7 +127,7 @@ export class HttpClient<SecurityDataType = unknown> {
             ...requestParams,
             headers: {
                 ...(requestParams.headers || {}),
-                ...(type && type !== ContentType.FormData ? { "Content-Type": type } : {}),
+                ...(type ? { "Content-Type": type } : {}),
             },
             params: query,
             responseType: responseFormat,

--- a/tests/spec/axios/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/axios/__snapshots__/basic.test.ts.snap
@@ -2034,7 +2034,7 @@ export class HttpClient<SecurityDataType = unknown> {
       ...requestParams,
       headers: {
         ...(requestParams.headers || {}),
-        ...(type && type !== ContentType.FormData ? { "Content-Type": type } : {}),
+        ...(type ? { "Content-Type": type } : {}),
       },
       params: query,
       responseType: responseFormat,

--- a/tests/spec/axiosSingleHttpClient/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/axiosSingleHttpClient/__snapshots__/basic.test.ts.snap
@@ -2034,7 +2034,7 @@ export class HttpClient<SecurityDataType = unknown> {
       ...requestParams,
       headers: {
         ...(requestParams.headers || {}),
-        ...(type && type !== ContentType.FormData ? { "Content-Type": type } : {}),
+        ...(type ? { "Content-Type": type } : {}),
       },
       params: query,
       responseType: responseFormat,

--- a/tests/spec/js/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/js/__snapshots__/basic.test.ts.snap
@@ -87,7 +87,7 @@ export class HttpClient {
       ...requestParams,
       headers: {
         ...(requestParams.headers || {}),
-        ...(type && type !== ContentType.FormData ? { "Content-Type": type } : {}),
+        ...(type ? { "Content-Type": type } : {}),
       },
       params: query,
       responseType: responseFormat,


### PR DESCRIPTION
This MR reverts [Don't set multipart/form-data content-type #173](https://github.com/acacode/swagger-typescript-api/pull/173) for the [`axios-http-client.ejs`](https://github.com/acacode/swagger-typescript-api/blob/c166ca8060bb956c25a4bc936513b323f404c385/templates/base/http-clients/axios-http-client.ejs#L130) template since axios doesn't automatically add this header.

This fixes issue #671.