### PR TITLE
Fix route regex pattern in route name generation

### DIFF
--- a/.changeset/orange-dogs-lay.md
+++ b/.changeset/orange-dogs-lay.md
@@ -1,0 +1,5 @@
+---
+"swagger-typescript-api": patch
+---
+
+Fix route regex pattern in route name generation.

--- a/templates/base/route-name.ejs
+++ b/templates/base/route-name.ejs
@@ -23,7 +23,7 @@ const methodAliases = {
 };
 
 const createCustomOperationId = (method, route, moduleName) => {
-  const hasPathInserts = /\{(\w){1,}\}/g.test(route);
+  const hasPathInserts = /\{(\w){1,}\}$/g.test(route);
   const splittedRouteBySlash = _.compact(_.replace(route, /\{(\w){1,}\}/g, "").split("/"));
   const routeParts = (splittedRouteBySlash.length > 1
     ? splittedRouteBySlash.splice(1)

--- a/tests/__snapshots__/extended.test.ts.snap
+++ b/tests/__snapshots__/extended.test.ts.snap
@@ -59295,7 +59295,7 @@ export enum StepModeEnum {
   Other = "other",
 }
 
-export type StopDetailData = Step[];
+export type StopListData = Step[];
 
 export interface Trip {
   /**
@@ -59321,11 +59321,11 @@ export type TripListData = Trip[];
 export namespace Trip {
   /**
    * @description list stops for a trip identified by {trip_id}
-   * @name StopDetail
+   * @name StopList
    * @request GET:/trip/{trip_id}/stop
    * @secure
    */
-  export namespace StopDetail {
+  export namespace StopList {
     export type RequestParams = {
       /** id of the trip */
       tripId: string;
@@ -59333,7 +59333,7 @@ export namespace Trip {
     export type RequestQuery = {};
     export type RequestBody = never;
     export type RequestHeaders = {};
-    export type ResponseBody = StopDetailData;
+    export type ResponseBody = StopListData;
   }
 
   /**
@@ -59577,12 +59577,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description list stops for a trip identified by {trip_id}
      *
-     * @name StopDetail
+     * @name StopList
      * @request GET:/trip/{trip_id}/stop
      * @secure
      */
-    stopDetail: (tripId: string, params: RequestParams = {}) =>
-      this.request<StopDetailData, any>({
+    stopList: (tripId: string, params: RequestParams = {}) =>
+      this.request<StopListData, any>({
         path: \`/trip/\${tripId}/stop\`,
         method: "GET",
         secure: true,
@@ -69761,9 +69761,9 @@ export interface ListWebhooksResponse {
   };
 }
 
-export type LogsDetailData = ListWebhookDeliveryLogsResponse;
+export type LogsListData = ListWebhookDeliveryLogsResponse;
 
-export interface LogsDetailParams {
+export interface LogsListParams {
   /**
    * The number of records to return in each page.
    * @example 30
@@ -70016,7 +70016,57 @@ export enum TransactionStatusEnum {
 
 export type TransactionsDetailData = GetTransactionResponse;
 
-export interface TransactionsDetailParams1 {
+export type TransactionsListData = ListTransactionsResponse;
+
+export interface TransactionsListParams {
+  /**
+   * The category identifier for which to filter transactions.
+   * Both parent and child categories can be filtered through
+   * this parameter. Providing an invalid category identifier
+   * results in a \`404\` response.
+   * @example "good-life"
+   */
+  "filter[category]"?: string;
+  /**
+   * The start date-time from which to return records,
+   * formatted according to rfc-3339. Not to be used for
+   * pagination purposes.
+   * @format date-time
+   * @example "2020-01-01T01:02:03+10:00"
+   */
+  "filter[since]"?: string;
+  /**
+   * The transaction status for which to return records. This
+   * can be used to filter \`HELD\` transactions from those
+   * that are \`SETTLED\`.
+   * @example "HELD"
+   */
+  "filter[status]"?: TransactionStatusEnum;
+  /**
+   * A transaction tag to filter for which to return records.
+   * If the tag does not exist, zero records are returned and
+   * a success response is given.
+   * @example "Holiday"
+   */
+  "filter[tag]"?: string;
+  /**
+   * The end date-time up to which to return records,
+   * formatted according to rfc-3339. Not to be used for
+   * pagination purposes.
+   * @format date-time
+   * @example "2020-02-01T01:02:03+10:00"
+   */
+  "filter[until]"?: string;
+  /**
+   * The number of records to return in each page.
+   * @example 30
+   */
+  "page[size]"?: number;
+  /** Blablabla bla */
+  someEnumName?: SomeEnumName;
+}
+
+export interface TransactionsListParams2 {
   /**
    * The category identifier for which to filter transactions.
    * Both parent and child categories can be filtered through
@@ -70067,57 +70117,7 @@ export interface TransactionsDetailParams1 {
   accountId: string;
 }
 
-export type TransactionsDetailResult = ListTransactionsResponse;
-
-export type TransactionsListData = ListTransactionsResponse;
-
-export interface TransactionsListParams {
-  /**
-   * The category identifier for which to filter transactions.
-   * Both parent and child categories can be filtered through
-   * this parameter. Providing an invalid category identifier
-   * results in a \`404\` response.
-   * @example "good-life"
-   */
-  "filter[category]"?: string;
-  /**
-   * The start date-time from which to return records,
-   * formatted according to rfc-3339. Not to be used for
-   * pagination purposes.
-   * @format date-time
-   * @example "2020-01-01T01:02:03+10:00"
-   */
-  "filter[since]"?: string;
-  /**
-   * The transaction status for which to return records. This
-   * can be used to filter \`HELD\` transactions from those
-   * that are \`SETTLED\`.
-   * @example "HELD"
-   */
-  "filter[status]"?: TransactionStatusEnum;
-  /**
-   * A transaction tag to filter for which to return records.
-   * If the tag does not exist, zero records are returned and
-   * a success response is given.
-   * @example "Holiday"
-   */
-  "filter[tag]"?: string;
-  /**
-   * The end date-time up to which to return records,
-   * formatted according to rfc-3339. Not to be used for
-   * pagination purposes.
-   * @format date-time
-   * @example "2020-02-01T01:02:03+10:00"
-   */
-  "filter[until]"?: string;
-  /**
-   * The number of records to return in each page.
-   * @example 30
-   */
-  "page[size]"?: number;
-  /** Blablabla bla */
-  someEnumName?: SomeEnumName;
-}
+export type TransactionsListResult = ListTransactionsResponse;
 
 /** Request to add or remove tags associated with a transaction. */
 export interface UpdateTransactionTagsRequest {
@@ -70385,12 +70385,12 @@ export namespace Accounts {
   /**
    * @description Retrieve a list of all transactions for a specific account. The returned list is [paginated](#pagination) and can be scrolled by following the \`next\` and \`prev\` links where present. To narrow the results to a specific date range pass one or both of \`filter[since]\` and \`filter[until]\` in the query string. These filter parameters **should not** be used for pagination. Results are ordered newest first to oldest last.
    * @tags Transactions
-   * @name TransactionsDetail
+   * @name TransactionsList
    * @summary List transactions by account
    * @request GET:/accounts/{accountId}/transactions
    * @secure
    */
-  export namespace TransactionsDetail {
+  export namespace TransactionsList {
     export type RequestParams = {
       /**
        * The unique identifier for the account.
@@ -70445,7 +70445,7 @@ export namespace Accounts {
     };
     export type RequestBody = never;
     export type RequestHeaders = {};
-    export type ResponseBody = TransactionsDetailResult;
+    export type ResponseBody = TransactionsListResult;
   }
 }
 
@@ -70673,12 +70673,12 @@ export namespace Webhooks {
   /**
    * @description Retrieve a list of delivery logs for a webhook by providing its unique identifier. This is useful for analysis and debugging purposes. The returned list is [paginated](#pagination) and can be scrolled by following the \`next\` and \`prev\` links where present. Results are ordered newest first to oldest last. Logs may be automatically purged after a period of time.
    * @tags Webhooks
-   * @name LogsDetail
+   * @name LogsList
    * @summary List webhook logs
    * @request GET:/webhooks/{webhookId}/logs
    * @secure
    */
-  export namespace LogsDetail {
+  export namespace LogsList {
     export type RequestParams = {
       /**
        * The unique identifier for the webhook.
@@ -70695,7 +70695,7 @@ export namespace Webhooks {
     };
     export type RequestBody = never;
     export type RequestHeaders = {};
-    export type ResponseBody = LogsDetailData;
+    export type ResponseBody = LogsListData;
   }
 
   /**
@@ -71067,13 +71067,13 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @description Retrieve a list of all transactions for a specific account. The returned list is [paginated](#pagination) and can be scrolled by following the \`next\` and \`prev\` links where present. To narrow the results to a specific date range pass one or both of \`filter[since]\` and \`filter[until]\` in the query string. These filter parameters **should not** be used for pagination. Results are ordered newest first to oldest last.
      *
      * @tags Transactions
-     * @name TransactionsDetail
+     * @name TransactionsList
      * @summary List transactions by account
      * @request GET:/accounts/{accountId}/transactions
      * @secure
      */
-    transactionsDetail: ({ accountId, ...query }: TransactionsDetailParams1, params: RequestParams = {}) =>
-      this.request<TransactionsDetailResult, any>({
+    transactionsList: ({ accountId, ...query }: TransactionsListParams2, params: RequestParams = {}) =>
+      this.request<TransactionsListResult, any>({
         path: \`/accounts/\${accountId}/transactions\`,
         method: "GET",
         query: query,
@@ -71240,13 +71240,13 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @description Retrieve a list of delivery logs for a webhook by providing its unique identifier. This is useful for analysis and debugging purposes. The returned list is [paginated](#pagination) and can be scrolled by following the \`next\` and \`prev\` links where present. Results are ordered newest first to oldest last. Logs may be automatically purged after a period of time.
      *
      * @tags Webhooks
-     * @name LogsDetail
+     * @name LogsList
      * @summary List webhook logs
      * @request GET:/webhooks/{webhookId}/logs
      * @secure
      */
-    logsDetail: ({ webhookId, ...query }: LogsDetailParams, params: RequestParams = {}) =>
-      this.request<LogsDetailData, any>({
+    logsList: ({ webhookId, ...query }: LogsListParams, params: RequestParams = {}) =>
+      this.request<LogsListData, any>({
         path: \`/webhooks/\${webhookId}/logs\`,
         method: "GET",
         query: query,

--- a/tests/__snapshots__/simple.test.ts.snap
+++ b/tests/__snapshots__/simple.test.ts.snap
@@ -36145,11 +36145,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description list stops for a trip identified by {trip_id}
      *
-     * @name StopDetail
+     * @name StopList
      * @request GET:/trip/{trip_id}/stop
      * @secure
      */
-    stopDetail: (tripId: string, params: RequestParams = {}) =>
+    stopList: (tripId: string, params: RequestParams = {}) =>
       this.request<Step[], any>({
         path: \`/trip/\${tripId}/stop\`,
         method: "GET",
@@ -44828,12 +44828,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @description Retrieve a list of all transactions for a specific account. The returned list is [paginated](#pagination) and can be scrolled by following the \`next\` and \`prev\` links where present. To narrow the results to a specific date range pass one or both of \`filter[since]\` and \`filter[until]\` in the query string. These filter parameters **should not** be used for pagination. Results are ordered newest first to oldest last.
      *
      * @tags Transactions
-     * @name TransactionsDetail
+     * @name TransactionsList
      * @summary List transactions by account
      * @request GET:/accounts/{accountId}/transactions
      * @secure
      */
-    transactionsDetail: (
+    transactionsList: (
       accountId: string,
       query?: {
         /**
@@ -45219,12 +45219,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @description Retrieve a list of delivery logs for a webhook by providing its unique identifier. This is useful for analysis and debugging purposes. The returned list is [paginated](#pagination) and can be scrolled by following the \`next\` and \`prev\` links where present. Results are ordered newest first to oldest last. Logs may be automatically purged after a period of time.
      *
      * @tags Webhooks
-     * @name LogsDetail
+     * @name LogsList
      * @summary List webhook logs
      * @request GET:/webhooks/{webhookId}/logs
      * @secure
      */
-    logsDetail: (
+    logsList: (
       webhookId: string,
       query?: {
         /**

--- a/tests/spec/axios/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/axios/__snapshots__/basic.test.ts.snap
@@ -2284,10 +2284,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description List comments on a gist.
      *
-     * @name CommentsDetail
+     * @name CommentsList
      * @request GET:/gists/{id}/comments
      */
-    commentsDetail: (id: number, params: RequestParams = {}) =>
+    commentsList: (id: number, params: RequestParams = {}) =>
       this.request<Comments, void>({
         path: \`/gists/\${id}/comments\`,
         method: "GET",
@@ -2326,12 +2326,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description Get a single comment.
      *
-     * @name CommentsDetail2
+     * @name CommentsDetail
      * @request GET:/gists/{id}/comments/{commentId}
-     * @originalName commentsDetail
-     * @duplicate
      */
-    commentsDetail2: (id: number, commentId: number, params: RequestParams = {}) =>
+    commentsDetail: (id: number, commentId: number, params: RequestParams = {}) =>
       this.request<Comment, void>({
         path: \`/gists/\${id}/comments/\${commentId}\`,
         method: "GET",
@@ -2384,10 +2382,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description Check if a gist is starred.
      *
-     * @name StarDetail
+     * @name StarList
      * @request GET:/gists/{id}/star
      */
-    starDetail: (id: number, params: RequestParams = {}) =>
+    starList: (id: number, params: RequestParams = {}) =>
       this.request<void, void>({
         path: \`/gists/\${id}/star\`,
         method: "GET",
@@ -2623,10 +2621,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description List public events for a network of repositories.
      *
-     * @name EventsDetail
+     * @name EventsList
      * @request GET:/networks/{owner}/{repo}/events
      */
-    eventsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    eventsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Events, void>({
         path: \`/networks/\${owner}/\${repo}/events\`,
         method: "GET",
@@ -2723,10 +2721,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description Get a Thread Subscription.
      *
-     * @name ThreadsSubscriptionDetail
+     * @name ThreadsSubscriptionList
      * @request GET:/notifications/threads/{id}/subscription
      */
-    threadsSubscriptionDetail: (id: number, params: RequestParams = {}) =>
+    threadsSubscriptionList: (id: number, params: RequestParams = {}) =>
       this.request<Subscription, void>({
         path: \`/notifications/threads/\${id}/subscription\`,
         method: "GET",
@@ -2784,10 +2782,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description List public events for an organization.
      *
-     * @name EventsDetail
+     * @name EventsList
      * @request GET:/orgs/{org}/events
      */
-    eventsDetail: (org: string, params: RequestParams = {}) =>
+    eventsList: (org: string, params: RequestParams = {}) =>
       this.request<Events, void>({
         path: \`/orgs/\${org}/events\`,
         method: "GET",
@@ -2798,10 +2796,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description List issues. List all issues for a given organization for the authenticated user.
      *
-     * @name IssuesDetail
+     * @name IssuesList
      * @request GET:/orgs/{org}/issues
      */
-    issuesDetail: (
+    issuesList: (
       org: string,
       query: {
         /**
@@ -2837,10 +2835,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description Members list. List all users who are members of an organization. A member is a user tha belongs to at least 1 team in the organization. If the authenticated user is also an owner of this organization then both concealed and public members will be returned. If the requester is not an owner of the organization the query will be redirected to the public members list.
      *
-     * @name MembersDetail
+     * @name MembersList
      * @request GET:/orgs/{org}/members
      */
-    membersDetail: (org: string, params: RequestParams = {}) =>
+    membersList: (org: string, params: RequestParams = {}) =>
       this.request<Users, void>({
         path: \`/orgs/\${org}/members\`,
         method: "GET",
@@ -2864,12 +2862,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description Check if a user is, publicly or privately, a member of the organization.
      *
-     * @name MembersDetail2
+     * @name MembersDetail
      * @request GET:/orgs/{org}/members/{username}
-     * @originalName membersDetail
-     * @duplicate
      */
-    membersDetail2: (org: string, username: string, params: RequestParams = {}) =>
+    membersDetail: (org: string, username: string, params: RequestParams = {}) =>
       this.request<void, void>({
         path: \`/orgs/\${org}/members/\${username}\`,
         method: "GET",
@@ -2879,10 +2875,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description Public members list. Members of an organization can choose to have their membership publicized or not.
      *
-     * @name PublicMembersDetail
+     * @name PublicMembersList
      * @request GET:/orgs/{org}/public_members
      */
-    publicMembersDetail: (org: string, params: RequestParams = {}) =>
+    publicMembersList: (org: string, params: RequestParams = {}) =>
       this.request<Users, void>({
         path: \`/orgs/\${org}/public_members\`,
         method: "GET",
@@ -2906,12 +2902,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description Check public membership.
      *
-     * @name PublicMembersDetail2
+     * @name PublicMembersDetail
      * @request GET:/orgs/{org}/public_members/{username}
-     * @originalName publicMembersDetail
-     * @duplicate
      */
-    publicMembersDetail2: (org: string, username: string, params: RequestParams = {}) =>
+    publicMembersDetail: (org: string, username: string, params: RequestParams = {}) =>
       this.request<void, void>({
         path: \`/orgs/\${org}/public_members/\${username}\`,
         method: "GET",
@@ -2934,10 +2928,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description List repositories for the specified org.
      *
-     * @name ReposDetail
+     * @name ReposList
      * @request GET:/orgs/{org}/repos
      */
-    reposDetail: (
+    reposList: (
       org: string,
       query?: {
         /** @default "all" */
@@ -2971,10 +2965,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description List teams.
      *
-     * @name TeamsDetail
+     * @name TeamsList
      * @request GET:/orgs/{org}/teams
      */
-    teamsDetail: (org: string, params: RequestParams = {}) =>
+    teamsList: (org: string, params: RequestParams = {}) =>
       this.request<Teams, void>({
         path: \`/orgs/\${org}/teams\`,
         method: "GET",
@@ -3060,10 +3054,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description List assignees. This call lists all the available assignees (owner + collaborators) to which issues may be assigned.
      *
-     * @name AssigneesDetail
+     * @name AssigneesList
      * @request GET:/repos/{owner}/{repo}/assignees
      */
-    assigneesDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    assigneesList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Assignees, void>({
         path: \`/repos/\${owner}/\${repo}/assignees\`,
         method: "GET",
@@ -3074,12 +3068,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description Check assignee. You may also check to see if a particular user is an assignee for a repository.
      *
-     * @name AssigneesDetail2
+     * @name AssigneesDetail
      * @request GET:/repos/{owner}/{repo}/assignees/{assignee}
-     * @originalName assigneesDetail
-     * @duplicate
      */
-    assigneesDetail2: (owner: string, repo: string, assignee: string, params: RequestParams = {}) =>
+    assigneesDetail: (owner: string, repo: string, assignee: string, params: RequestParams = {}) =>
       this.request<void, void>({
         path: \`/repos/\${owner}/\${repo}/assignees/\${assignee}\`,
         method: "GET",
@@ -3089,10 +3081,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description Get list of branches
      *
-     * @name BranchesDetail
+     * @name BranchesList
      * @request GET:/repos/{owner}/{repo}/branches
      */
-    branchesDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    branchesList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Branches, void>({
         path: \`/repos/\${owner}/\${repo}/branches\`,
         method: "GET",
@@ -3103,12 +3095,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description Get Branch
      *
-     * @name BranchesDetail2
+     * @name BranchesDetail
      * @request GET:/repos/{owner}/{repo}/branches/{branch}
-     * @originalName branchesDetail
-     * @duplicate
      */
-    branchesDetail2: (owner: string, repo: string, branch: string, params: RequestParams = {}) =>
+    branchesDetail: (owner: string, repo: string, branch: string, params: RequestParams = {}) =>
       this.request<Branch, void>({
         path: \`/repos/\${owner}/\${repo}/branches/\${branch}\`,
         method: "GET",
@@ -3119,10 +3109,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description List. When authenticating as an organization owner of an organization-owned repository, all organization owners are included in the list of collaborators. Otherwise, only users with access to the repository are returned in the collaborators list.
      *
-     * @name CollaboratorsDetail
+     * @name CollaboratorsList
      * @request GET:/repos/{owner}/{repo}/collaborators
      */
-    collaboratorsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    collaboratorsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Users, void>({
         path: \`/repos/\${owner}/\${repo}/collaborators\`,
         method: "GET",
@@ -3146,12 +3136,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description Check if user is a collaborator
      *
-     * @name CollaboratorsDetail2
+     * @name CollaboratorsDetail
      * @request GET:/repos/{owner}/{repo}/collaborators/{user}
-     * @originalName collaboratorsDetail
-     * @duplicate
      */
-    collaboratorsDetail2: (owner: string, repo: string, user: string, params: RequestParams = {}) =>
+    collaboratorsDetail: (owner: string, repo: string, user: string, params: RequestParams = {}) =>
       this.request<void, void>({
         path: \`/repos/\${owner}/\${repo}/collaborators/\${user}\`,
         method: "GET",
@@ -3174,10 +3162,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description List commit comments for a repository. Comments are ordered by ascending ID.
      *
-     * @name CommentsDetail
+     * @name CommentsList
      * @request GET:/repos/{owner}/{repo}/comments
      */
-    commentsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    commentsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<RepoComments, void>({
         path: \`/repos/\${owner}/\${repo}/comments\`,
         method: "GET",
@@ -3201,12 +3189,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description Get a single commit comment.
      *
-     * @name CommentsDetail2
+     * @name CommentsDetail
      * @request GET:/repos/{owner}/{repo}/comments/{commentId}
-     * @originalName commentsDetail
-     * @duplicate
      */
-    commentsDetail2: (owner: string, repo: string, commentId: number, params: RequestParams = {}) =>
+    commentsDetail: (owner: string, repo: string, commentId: number, params: RequestParams = {}) =>
       this.request<CommitComment, void>({
         path: \`/repos/\${owner}/\${repo}/comments/\${commentId}\`,
         method: "GET",
@@ -3238,10 +3224,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description List commits on a repository.
      *
-     * @name CommitsDetail
+     * @name CommitsList
      * @request GET:/repos/{owner}/{repo}/commits
      */
-    commitsDetail: (
+    commitsList: (
       owner: string,
       repo: string,
       query?: {
@@ -3272,10 +3258,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description Get the combined Status for a specific Ref The Combined status endpoint is currently available for developers to preview. During the preview period, the API may change without advance notice. Please see the blog post for full details. To access this endpoint during the preview period, you must provide a custom media type in the Accept header: application/vnd.github.she-hulk-preview+json
      *
-     * @name CommitsStatusDetail
+     * @name CommitsStatusList
      * @request GET:/repos/{owner}/{repo}/commits/{ref}/status
      */
-    commitsStatusDetail: (owner: string, repo: string, ref: string, params: RequestParams = {}) =>
+    commitsStatusList: (owner: string, repo: string, ref: string, params: RequestParams = {}) =>
       this.request<RefStatus, void>({
         path: \`/repos/\${owner}/\${repo}/commits/\${ref}/status\`,
         method: "GET",
@@ -3286,12 +3272,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description Get a single commit.
      *
-     * @name CommitsDetail2
+     * @name CommitsDetail
      * @request GET:/repos/{owner}/{repo}/commits/{shaCode}
-     * @originalName commitsDetail
-     * @duplicate
      */
-    commitsDetail2: (owner: string, repo: string, shaCode: string, params: RequestParams = {}) =>
+    commitsDetail: (owner: string, repo: string, shaCode: string, params: RequestParams = {}) =>
       this.request<Commit, void>({
         path: \`/repos/\${owner}/\${repo}/commits/\${shaCode}\`,
         method: "GET",
@@ -3302,10 +3286,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description List comments for a single commitList comments for a single commit.
      *
-     * @name CommitsCommentsDetail
+     * @name CommitsCommentsList
      * @request GET:/repos/{owner}/{repo}/commits/{shaCode}/comments
      */
-    commitsCommentsDetail: (owner: string, repo: string, shaCode: string, params: RequestParams = {}) =>
+    commitsCommentsList: (owner: string, repo: string, shaCode: string, params: RequestParams = {}) =>
       this.request<RepoComments, void>({
         path: \`/repos/\${owner}/\${repo}/commits/\${shaCode}/comments\`,
         method: "GET",
@@ -3410,10 +3394,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description Get list of contributors.
      *
-     * @name ContributorsDetail
+     * @name ContributorsList
      * @request GET:/repos/{owner}/{repo}/contributors
      */
-    contributorsDetail: (
+    contributorsList: (
       owner: string,
       repo: string,
       query: {
@@ -3433,10 +3417,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description Users with pull access can view deployments for a repository
      *
-     * @name DeploymentsDetail
+     * @name DeploymentsList
      * @request GET:/repos/{owner}/{repo}/deployments
      */
-    deploymentsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    deploymentsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<RepoDeployments, void>({
         path: \`/repos/\${owner}/\${repo}/deployments\`,
         method: "GET",
@@ -3463,10 +3447,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description Users with pull access can view deployment statuses for a deployment
      *
-     * @name DeploymentsStatusesDetail
+     * @name DeploymentsStatusesList
      * @request GET:/repos/{owner}/{repo}/deployments/{id}/statuses
      */
-    deploymentsStatusesDetail: (owner: string, repo: string, id: number, params: RequestParams = {}) =>
+    deploymentsStatusesList: (owner: string, repo: string, id: number, params: RequestParams = {}) =>
       this.request<DeploymentStatuses, void>({
         path: \`/repos/\${owner}/\${repo}/deployments/\${id}/statuses\`,
         method: "GET",
@@ -3498,11 +3482,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description Deprecated. List downloads for a repository.
      *
-     * @name DownloadsDetail
+     * @name DownloadsList
      * @request GET:/repos/{owner}/{repo}/downloads
      * @deprecated
      */
-    downloadsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    downloadsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Downloads, void>({
         path: \`/repos/\${owner}/\${repo}/downloads\`,
         method: "GET",
@@ -3527,13 +3511,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description Deprecated. Get a single download.
      *
-     * @name DownloadsDetail2
+     * @name DownloadsDetail
      * @request GET:/repos/{owner}/{repo}/downloads/{downloadId}
      * @deprecated
-     * @originalName downloadsDetail
-     * @duplicate
      */
-    downloadsDetail2: (owner: string, repo: string, downloadId: number, params: RequestParams = {}) =>
+    downloadsDetail: (owner: string, repo: string, downloadId: number, params: RequestParams = {}) =>
       this.request<Download, void>({
         path: \`/repos/\${owner}/\${repo}/downloads/\${downloadId}\`,
         method: "GET",
@@ -3544,10 +3526,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description Get list of repository events.
      *
-     * @name EventsDetail
+     * @name EventsList
      * @request GET:/repos/{owner}/{repo}/events
      */
-    eventsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    eventsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Events, void>({
         path: \`/repos/\${owner}/\${repo}/events\`,
         method: "GET",
@@ -3558,10 +3540,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description List forks.
      *
-     * @name ForksDetail
+     * @name ForksList
      * @request GET:/repos/{owner}/{repo}/forks
      */
-    forksDetail: (
+    forksList: (
       owner: string,
       repo: string,
       query?: {
@@ -3657,10 +3639,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description Get all References
      *
-     * @name GitRefsDetail
+     * @name GitRefsList
      * @request GET:/repos/{owner}/{repo}/git/refs
      */
-    gitRefsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    gitRefsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Refs, void>({
         path: \`/repos/\${owner}/\${repo}/git/refs\`,
         method: "GET",
@@ -3700,12 +3682,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description Get a Reference
      *
-     * @name GitRefsDetail2
+     * @name GitRefsDetail
      * @request GET:/repos/{owner}/{repo}/git/refs/{ref}
-     * @originalName gitRefsDetail
-     * @duplicate
      */
-    gitRefsDetail2: (owner: string, repo: string, ref: string, params: RequestParams = {}) =>
+    gitRefsDetail: (owner: string, repo: string, ref: string, params: RequestParams = {}) =>
       this.request<HeadBranch, void>({
         path: \`/repos/\${owner}/\${repo}/git/refs/\${ref}\`,
         method: "GET",
@@ -3802,10 +3782,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description Get list of hooks.
      *
-     * @name HooksDetail
+     * @name HooksList
      * @request GET:/repos/{owner}/{repo}/hooks
      */
-    hooksDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    hooksList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Hook, void>({
         path: \`/repos/\${owner}/\${repo}/hooks\`,
         method: "GET",
@@ -3844,12 +3824,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description Get single hook.
      *
-     * @name HooksDetail2
+     * @name HooksDetail
      * @request GET:/repos/{owner}/{repo}/hooks/{hookId}
-     * @originalName hooksDetail
-     * @duplicate
      */
-    hooksDetail2: (owner: string, repo: string, hookId: number, params: RequestParams = {}) =>
+    hooksDetail: (owner: string, repo: string, hookId: number, params: RequestParams = {}) =>
       this.request<Hook, void>({
         path: \`/repos/\${owner}/\${repo}/hooks/\${hookId}\`,
         method: "GET",
@@ -3888,10 +3866,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description List issues for a repository.
      *
-     * @name IssuesDetail
+     * @name IssuesList
      * @request GET:/repos/{owner}/{repo}/issues
      */
-    issuesDetail: (
+    issuesList: (
       owner: string,
       repo: string,
       query: {
@@ -3943,10 +3921,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description List comments in a repository.
      *
-     * @name IssuesCommentsDetail
+     * @name IssuesCommentsList
      * @request GET:/repos/{owner}/{repo}/issues/comments
      */
-    issuesCommentsDetail: (
+    issuesCommentsList: (
       owner: string,
       repo: string,
       query?: {
@@ -3985,12 +3963,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description Get a single comment.
      *
-     * @name IssuesCommentsDetail2
+     * @name IssuesCommentsDetail
      * @request GET:/repos/{owner}/{repo}/issues/comments/{commentId}
-     * @originalName issuesCommentsDetail
-     * @duplicate
      */
-    issuesCommentsDetail2: (owner: string, repo: string, commentId: number, params: RequestParams = {}) =>
+    issuesCommentsDetail: (owner: string, repo: string, commentId: number, params: RequestParams = {}) =>
       this.request<IssuesComment, void>({
         path: \`/repos/\${owner}/\${repo}/issues/comments/\${commentId}\`,
         method: "GET",
@@ -4022,10 +3998,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description List issue events for a repository.
      *
-     * @name IssuesEventsDetail
+     * @name IssuesEventsList
      * @request GET:/repos/{owner}/{repo}/issues/events
      */
-    issuesEventsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    issuesEventsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<IssueEvents, void>({
         path: \`/repos/\${owner}/\${repo}/issues/events\`,
         method: "GET",
@@ -4036,12 +4012,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description Get a single event.
      *
-     * @name IssuesEventsDetail2
+     * @name IssuesEventsDetail
      * @request GET:/repos/{owner}/{repo}/issues/events/{eventId}
-     * @originalName issuesEventsDetail
-     * @duplicate
      */
-    issuesEventsDetail2: (owner: string, repo: string, eventId: number, params: RequestParams = {}) =>
+    issuesEventsDetail: (owner: string, repo: string, eventId: number, params: RequestParams = {}) =>
       this.request<IssueEvent, void>({
         path: \`/repos/\${owner}/\${repo}/issues/events/\${eventId}\`,
         method: "GET",
@@ -4052,12 +4026,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description Get a single issue
      *
-     * @name IssuesDetail2
+     * @name IssuesDetail
      * @request GET:/repos/{owner}/{repo}/issues/{number}
-     * @originalName issuesDetail
-     * @duplicate
      */
-    issuesDetail2: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    issuesDetail: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<Issue, void>({
         path: \`/repos/\${owner}/\${repo}/issues/\${number}\`,
         method: "GET",
@@ -4083,12 +4055,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description List comments on an issue.
      *
-     * @name IssuesCommentsDetail3
+     * @name IssuesCommentsList2
      * @request GET:/repos/{owner}/{repo}/issues/{number}/comments
-     * @originalName issuesCommentsDetail
+     * @originalName issuesCommentsList
      * @duplicate
      */
-    issuesCommentsDetail3: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    issuesCommentsList2: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<IssuesComments, void>({
         path: \`/repos/\${owner}/\${repo}/issues/\${number}/comments\`,
         method: "GET",
@@ -4120,12 +4092,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description List events for an issue.
      *
-     * @name IssuesEventsDetail3
+     * @name IssuesEventsList2
      * @request GET:/repos/{owner}/{repo}/issues/{number}/events
-     * @originalName issuesEventsDetail
+     * @originalName issuesEventsList
      * @duplicate
      */
-    issuesEventsDetail3: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    issuesEventsList2: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<IssueEvents, void>({
         path: \`/repos/\${owner}/\${repo}/issues/\${number}/events\`,
         method: "GET",
@@ -4149,10 +4121,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description List labels on an issue.
      *
-     * @name IssuesLabelsDetail
+     * @name IssuesLabelsList
      * @request GET:/repos/{owner}/{repo}/issues/{number}/labels
      */
-    issuesLabelsDetail: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    issuesLabelsList: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<Labels, void>({
         path: \`/repos/\${owner}/\${repo}/issues/\${number}/labels\`,
         method: "GET",
@@ -4208,10 +4180,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description Get list of keys.
      *
-     * @name KeysDetail
+     * @name KeysList
      * @request GET:/repos/{owner}/{repo}/keys
      */
-    keysDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    keysList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Keys, void>({
         path: \`/repos/\${owner}/\${repo}/keys\`,
         method: "GET",
@@ -4250,12 +4222,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description Get a key
      *
-     * @name KeysDetail2
+     * @name KeysDetail
      * @request GET:/repos/{owner}/{repo}/keys/{keyId}
-     * @originalName keysDetail
-     * @duplicate
      */
-    keysDetail2: (owner: string, repo: string, keyId: number, params: RequestParams = {}) =>
+    keysDetail: (owner: string, repo: string, keyId: number, params: RequestParams = {}) =>
       this.request<UserKeysKeyId, void>({
         path: \`/repos/\${owner}/\${repo}/keys/\${keyId}\`,
         method: "GET",
@@ -4266,10 +4236,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description List all labels for this repository.
      *
-     * @name LabelsDetail
+     * @name LabelsList
      * @request GET:/repos/{owner}/{repo}/labels
      */
-    labelsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    labelsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Labels, void>({
         path: \`/repos/\${owner}/\${repo}/labels\`,
         method: "GET",
@@ -4308,12 +4278,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description Get a single label.
      *
-     * @name LabelsDetail2
+     * @name LabelsDetail
      * @request GET:/repos/{owner}/{repo}/labels/{name}
-     * @originalName labelsDetail
-     * @duplicate
      */
-    labelsDetail2: (owner: string, repo: string, name: string, params: RequestParams = {}) =>
+    labelsDetail: (owner: string, repo: string, name: string, params: RequestParams = {}) =>
       this.request<Label, void>({
         path: \`/repos/\${owner}/\${repo}/labels/\${name}\`,
         method: "GET",
@@ -4339,10 +4307,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description List languages. List languages for the specified repository. The value on the right of a language is the number of bytes of code written in that language.
      *
-     * @name LanguagesDetail
+     * @name LanguagesList
      * @request GET:/repos/{owner}/{repo}/languages
      */
-    languagesDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    languagesList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Languages, void>({
         path: \`/repos/\${owner}/\${repo}/languages\`,
         method: "GET",
@@ -4369,10 +4337,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description List milestones for a repository.
      *
-     * @name MilestonesDetail
+     * @name MilestonesList
      * @request GET:/repos/{owner}/{repo}/milestones
      */
-    milestonesDetail: (
+    milestonesList: (
       owner: string,
       repo: string,
       query?: {
@@ -4427,12 +4395,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description Get a single milestone.
      *
-     * @name MilestonesDetail2
+     * @name MilestonesDetail
      * @request GET:/repos/{owner}/{repo}/milestones/{number}
-     * @originalName milestonesDetail
-     * @duplicate
      */
-    milestonesDetail2: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    milestonesDetail: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<Milestone, void>({
         path: \`/repos/\${owner}/\${repo}/milestones/\${number}\`,
         method: "GET",
@@ -4464,10 +4430,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description Get labels for every issue in a milestone.
      *
-     * @name MilestonesLabelsDetail
+     * @name MilestonesLabelsList
      * @request GET:/repos/{owner}/{repo}/milestones/{number}/labels
      */
-    milestonesLabelsDetail: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    milestonesLabelsList: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<Labels, void>({
         path: \`/repos/\${owner}/\${repo}/milestones/\${number}/labels\`,
         method: "GET",
@@ -4478,10 +4444,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description List your notifications in a repository List all notifications for the current user.
      *
-     * @name NotificationsDetail
+     * @name NotificationsList
      * @request GET:/repos/{owner}/{repo}/notifications
      */
-    notificationsDetail: (
+    notificationsList: (
       owner: string,
       repo: string,
       query?: {
@@ -4525,10 +4491,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description List pull requests.
      *
-     * @name PullsDetail
+     * @name PullsList
      * @request GET:/repos/{owner}/{repo}/pulls
      */
-    pullsDetail: (
+    pullsList: (
       owner: string,
       repo: string,
       query?: {
@@ -4574,10 +4540,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description List comments in a repository. By default, Review Comments are ordered by ascending ID.
      *
-     * @name PullsCommentsDetail
+     * @name PullsCommentsList
      * @request GET:/repos/{owner}/{repo}/pulls/comments
      */
-    pullsCommentsDetail: (
+    pullsCommentsList: (
       owner: string,
       repo: string,
       query?: {
@@ -4616,12 +4582,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description Get a single comment.
      *
-     * @name PullsCommentsDetail2
+     * @name PullsCommentsDetail
      * @request GET:/repos/{owner}/{repo}/pulls/comments/{commentId}
-     * @originalName pullsCommentsDetail
-     * @duplicate
      */
-    pullsCommentsDetail2: (owner: string, repo: string, commentId: number, params: RequestParams = {}) =>
+    pullsCommentsDetail: (owner: string, repo: string, commentId: number, params: RequestParams = {}) =>
       this.request<PullsComment, void>({
         path: \`/repos/\${owner}/\${repo}/pulls/comments/\${commentId}\`,
         method: "GET",
@@ -4653,12 +4617,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description Get a single pull request.
      *
-     * @name PullsDetail2
+     * @name PullsDetail
      * @request GET:/repos/{owner}/{repo}/pulls/{number}
-     * @originalName pullsDetail
-     * @duplicate
      */
-    pullsDetail2: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    pullsDetail: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<PullRequest, void>({
         path: \`/repos/\${owner}/\${repo}/pulls/\${number}\`,
         method: "GET",
@@ -4685,12 +4647,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description List comments on a pull request.
      *
-     * @name PullsCommentsDetail3
+     * @name PullsCommentsList2
      * @request GET:/repos/{owner}/{repo}/pulls/{number}/comments
-     * @originalName pullsCommentsDetail
+     * @originalName pullsCommentsList
      * @duplicate
      */
-    pullsCommentsDetail3: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    pullsCommentsList2: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<PullsComment, void>({
         path: \`/repos/\${owner}/\${repo}/pulls/\${number}/comments\`,
         method: "GET",
@@ -4723,10 +4685,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description List commits on a pull request.
      *
-     * @name PullsCommitsDetail
+     * @name PullsCommitsList
      * @request GET:/repos/{owner}/{repo}/pulls/{number}/commits
      */
-    pullsCommitsDetail: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    pullsCommitsList: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<Commits, void>({
         path: \`/repos/\${owner}/\${repo}/pulls/\${number}/commits\`,
         method: "GET",
@@ -4737,10 +4699,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description List pull requests files.
      *
-     * @name PullsFilesDetail
+     * @name PullsFilesList
      * @request GET:/repos/{owner}/{repo}/pulls/{number}/files
      */
-    pullsFilesDetail: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    pullsFilesList: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<Pulls, void>({
         path: \`/repos/\${owner}/\${repo}/pulls/\${number}/files\`,
         method: "GET",
@@ -4751,10 +4713,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description Get if a pull request has been merged.
      *
-     * @name PullsMergeDetail
+     * @name PullsMergeList
      * @request GET:/repos/{owner}/{repo}/pulls/{number}/merge
      */
-    pullsMergeDetail: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    pullsMergeList: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<void, void>({
         path: \`/repos/\${owner}/\${repo}/pulls/\${number}/merge\`,
         method: "GET",
@@ -4780,10 +4742,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description Get the README. This method returns the preferred README for a repository.
      *
-     * @name ReadmeDetail
+     * @name ReadmeList
      * @request GET:/repos/{owner}/{repo}/readme
      */
-    readmeDetail: (
+    readmeList: (
       owner: string,
       repo: string,
       query?: {
@@ -4803,10 +4765,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description Users with push access to the repository will receive all releases (i.e., published releases and draft releases). Users with pull access will receive published releases only
      *
-     * @name ReleasesDetail
+     * @name ReleasesList
      * @request GET:/repos/{owner}/{repo}/releases
      */
-    releasesDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    releasesList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Releases, void>({
         path: \`/repos/\${owner}/\${repo}/releases\`,
         method: "GET",
@@ -4894,12 +4856,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description Get a single release
      *
-     * @name ReleasesDetail2
+     * @name ReleasesDetail
      * @request GET:/repos/{owner}/{repo}/releases/{id}
-     * @originalName releasesDetail
-     * @duplicate
      */
-    releasesDetail2: (owner: string, repo: string, id: string, params: RequestParams = {}) =>
+    releasesDetail: (owner: string, repo: string, id: string, params: RequestParams = {}) =>
       this.request<Release, void>({
         path: \`/repos/\${owner}/\${repo}/releases/\${id}\`,
         method: "GET",
@@ -4925,12 +4885,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description List assets for a release
      *
-     * @name ReleasesAssetsDetail2
+     * @name ReleasesAssetsList
      * @request GET:/repos/{owner}/{repo}/releases/{id}/assets
-     * @originalName releasesAssetsDetail
-     * @duplicate
      */
-    releasesAssetsDetail2: (owner: string, repo: string, id: string, params: RequestParams = {}) =>
+    releasesAssetsList: (owner: string, repo: string, id: string, params: RequestParams = {}) =>
       this.request<Assets, void>({
         path: \`/repos/\${owner}/\${repo}/releases/\${id}/assets\`,
         method: "GET",
@@ -4941,10 +4899,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description List Stargazers.
      *
-     * @name StargazersDetail
+     * @name StargazersList
      * @request GET:/repos/{owner}/{repo}/stargazers
      */
-    stargazersDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    stargazersList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Users, void>({
         path: \`/repos/\${owner}/\${repo}/stargazers\`,
         method: "GET",
@@ -4955,10 +4913,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description Get the number of additions and deletions per week. Returns a weekly aggregate of the number of additions and deletions pushed to a repository.
      *
-     * @name StatsCodeFrequencyDetail
+     * @name StatsCodeFrequencyList
      * @request GET:/repos/{owner}/{repo}/stats/code_frequency
      */
-    statsCodeFrequencyDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    statsCodeFrequencyList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<CodeFrequencyStats, void>({
         path: \`/repos/\${owner}/\${repo}/stats/code_frequency\`,
         method: "GET",
@@ -4969,10 +4927,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description Get the last year of commit activity data. Returns the last year of commit activity grouped by week. The days array is a group of commits per day, starting on Sunday.
      *
-     * @name StatsCommitActivityDetail
+     * @name StatsCommitActivityList
      * @request GET:/repos/{owner}/{repo}/stats/commit_activity
      */
-    statsCommitActivityDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    statsCommitActivityList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<CommitActivityStats, void>({
         path: \`/repos/\${owner}/\${repo}/stats/commit_activity\`,
         method: "GET",
@@ -4983,10 +4941,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description Get contributors list with additions, deletions, and commit counts.
      *
-     * @name StatsContributorsDetail
+     * @name StatsContributorsList
      * @request GET:/repos/{owner}/{repo}/stats/contributors
      */
-    statsContributorsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    statsContributorsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<ContributorsStats, void>({
         path: \`/repos/\${owner}/\${repo}/stats/contributors\`,
         method: "GET",
@@ -4997,10 +4955,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description Get the weekly commit count for the repo owner and everyone else.
      *
-     * @name StatsParticipationDetail
+     * @name StatsParticipationList
      * @request GET:/repos/{owner}/{repo}/stats/participation
      */
-    statsParticipationDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    statsParticipationList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<ParticipationStats, void>({
         path: \`/repos/\${owner}/\${repo}/stats/participation\`,
         method: "GET",
@@ -5011,10 +4969,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description Get the number of commits per hour in each day. Each array contains the day number, hour number, and number of commits 0-6 Sunday - Saturday 0-23 Hour of day Number of commits For example, [2, 14, 25] indicates that there were 25 total commits, during the 2.00pm hour on Tuesdays. All times are based on the time zone of individual commits.
      *
-     * @name StatsPunchCardDetail
+     * @name StatsPunchCardList
      * @request GET:/repos/{owner}/{repo}/stats/punch_card
      */
-    statsPunchCardDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    statsPunchCardList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<CodeFrequencyStats, void>({
         path: \`/repos/\${owner}/\${repo}/stats/punch_card\`,
         method: "GET",
@@ -5055,10 +5013,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description List watchers.
      *
-     * @name SubscribersDetail
+     * @name SubscribersList
      * @request GET:/repos/{owner}/{repo}/subscribers
      */
-    subscribersDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    subscribersList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Users, void>({
         path: \`/repos/\${owner}/\${repo}/subscribers\`,
         method: "GET",
@@ -5082,10 +5040,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description Get a Repository Subscription.
      *
-     * @name SubscriptionDetail
+     * @name SubscriptionList
      * @request GET:/repos/{owner}/{repo}/subscription
      */
-    subscriptionDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    subscriptionList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Subscription, void>({
         path: \`/repos/\${owner}/\${repo}/subscription\`,
         method: "GET",
@@ -5112,10 +5070,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description Get list of tags.
      *
-     * @name TagsDetail
+     * @name TagsList
      * @request GET:/repos/{owner}/{repo}/tags
      */
-    tagsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    tagsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Tags, void>({
         path: \`/repos/\${owner}/\${repo}/tags\`,
         method: "GET",
@@ -5126,10 +5084,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description Get list of teams
      *
-     * @name TeamsDetail
+     * @name TeamsList
      * @request GET:/repos/{owner}/{repo}/teams
      */
-    teamsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    teamsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Teams, void>({
         path: \`/repos/\${owner}/\${repo}/teams\`,
         method: "GET",
@@ -5140,10 +5098,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description List Stargazers. New implementation.
      *
-     * @name WatchersDetail
+     * @name WatchersList
      * @request GET:/repos/{owner}/{repo}/watchers
      */
-    watchersDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    watchersList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Users, void>({
         path: \`/repos/\${owner}/\${repo}/watchers\`,
         method: "GET",
@@ -5402,10 +5360,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description List team members. In order to list members in a team, the authenticated user must be a member of the team.
      *
-     * @name MembersDetail
+     * @name MembersList
      * @request GET:/teams/{teamId}/members
      */
-    membersDetail: (teamId: number, params: RequestParams = {}) =>
+    membersList: (teamId: number, params: RequestParams = {}) =>
       this.request<Users, void>({
         path: \`/teams/\${teamId}/members\`,
         method: "GET",
@@ -5430,13 +5388,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description The "Get team member" API is deprecated and is scheduled for removal in the next major version of the API. We recommend using the Get team membership API instead. It allows you to get both active and pending memberships. Get team member. In order to get if a user is a member of a team, the authenticated user mus be a member of the team.
      *
-     * @name MembersDetail2
+     * @name MembersDetail
      * @request GET:/teams/{teamId}/members/{username}
      * @deprecated
-     * @originalName membersDetail
-     * @duplicate
      */
-    membersDetail2: (teamId: number, username: string, params: RequestParams = {}) =>
+    membersDetail: (teamId: number, username: string, params: RequestParams = {}) =>
       this.request<void, void>({
         path: \`/teams/\${teamId}/members/\${username}\`,
         method: "GET",
@@ -5501,10 +5457,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description List team repos
      *
-     * @name ReposDetail
+     * @name ReposList
      * @request GET:/teams/{teamId}/repos
      */
-    reposDetail: (teamId: number, params: RequestParams = {}) =>
+    reposList: (teamId: number, params: RequestParams = {}) =>
       this.request<TeamRepos, void>({
         path: \`/teams/\${teamId}/repos\`,
         method: "GET",
@@ -5528,12 +5484,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description Check if a team manages a repository
      *
-     * @name ReposDetail2
+     * @name ReposDetail
      * @request GET:/teams/{teamId}/repos/{owner}/{repo}
-     * @originalName reposDetail
-     * @duplicate
      */
-    reposDetail2: (teamId: number, owner: string, repo: string, params: RequestParams = {}) =>
+    reposDetail: (teamId: number, owner: string, repo: string, params: RequestParams = {}) =>
       this.request<any, void>({
         path: \`/teams/\${teamId}/repos/\${owner}/\${repo}\`,
         method: "GET",
@@ -6008,10 +5962,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description If you are authenticated as the given user, you will see your private events. Otherwise, you'll only see public events.
      *
-     * @name EventsDetail
+     * @name EventsList
      * @request GET:/users/{username}/events
      */
-    eventsDetail: (username: string, params: RequestParams = {}) =>
+    eventsList: (username: string, params: RequestParams = {}) =>
       this.request<any, void>({
         path: \`/users/\${username}/events\`,
         method: "GET",
@@ -6034,10 +5988,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description List a user's followers
      *
-     * @name FollowersDetail
+     * @name FollowersList
      * @request GET:/users/{username}/followers
      */
-    followersDetail: (username: string, params: RequestParams = {}) =>
+    followersList: (username: string, params: RequestParams = {}) =>
       this.request<Users, void>({
         path: \`/users/\${username}/followers\`,
         method: "GET",
@@ -6061,10 +6015,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description List a users gists.
      *
-     * @name GistsDetail
+     * @name GistsList
      * @request GET:/users/{username}/gists
      */
-    gistsDetail: (
+    gistsList: (
       username: string,
       query?: {
         /**
@@ -6086,10 +6040,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description List public keys for a user. Lists the verified public keys for a user. This is accessible by anyone.
      *
-     * @name KeysDetail
+     * @name KeysList
      * @request GET:/users/{username}/keys
      */
-    keysDetail: (username: string, params: RequestParams = {}) =>
+    keysList: (username: string, params: RequestParams = {}) =>
       this.request<Gitignore, void>({
         path: \`/users/\${username}/keys\`,
         method: "GET",
@@ -6100,10 +6054,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description List all public organizations for a user.
      *
-     * @name OrgsDetail
+     * @name OrgsList
      * @request GET:/users/{username}/orgs
      */
-    orgsDetail: (username: string, params: RequestParams = {}) =>
+    orgsList: (username: string, params: RequestParams = {}) =>
       this.request<Gitignore, void>({
         path: \`/users/\${username}/orgs\`,
         method: "GET",
@@ -6114,10 +6068,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description These are events that you'll only see public events.
      *
-     * @name ReceivedEventsDetail
+     * @name ReceivedEventsList
      * @request GET:/users/{username}/received_events
      */
-    receivedEventsDetail: (username: string, params: RequestParams = {}) =>
+    receivedEventsList: (username: string, params: RequestParams = {}) =>
       this.request<any, void>({
         path: \`/users/\${username}/received_events\`,
         method: "GET",
@@ -6127,10 +6081,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description List public events that a user has received
      *
-     * @name ReceivedEventsPublicDetail
+     * @name ReceivedEventsPublicList
      * @request GET:/users/{username}/received_events/public
      */
-    receivedEventsPublicDetail: (username: string, params: RequestParams = {}) =>
+    receivedEventsPublicList: (username: string, params: RequestParams = {}) =>
       this.request<any, void>({
         path: \`/users/\${username}/received_events/public\`,
         method: "GET",
@@ -6140,10 +6094,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description List public repositories for the specified user.
      *
-     * @name ReposDetail
+     * @name ReposList
      * @request GET:/users/{username}/repos
      */
-    reposDetail: (
+    reposList: (
       username: string,
       query?: {
         /** @default "all" */
@@ -6162,10 +6116,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description List repositories being starred by a user.
      *
-     * @name StarredDetail
+     * @name StarredList
      * @request GET:/users/{username}/starred
      */
-    starredDetail: (username: string, params: RequestParams = {}) =>
+    starredList: (username: string, params: RequestParams = {}) =>
       this.request<any, void>({
         path: \`/users/\${username}/starred\`,
         method: "GET",
@@ -6175,10 +6129,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description List repositories being watched by a user.
      *
-     * @name SubscriptionsDetail
+     * @name SubscriptionsList
      * @request GET:/users/{username}/subscriptions
      */
-    subscriptionsDetail: (username: string, params: RequestParams = {}) =>
+    subscriptionsList: (username: string, params: RequestParams = {}) =>
       this.request<any, void>({
         path: \`/users/\${username}/subscriptions\`,
         method: "GET",

--- a/tests/spec/axiosSingleHttpClient/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/axiosSingleHttpClient/__snapshots__/basic.test.ts.snap
@@ -2290,10 +2290,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description List comments on a gist.
      *
-     * @name CommentsDetail
+     * @name CommentsList
      * @request GET:/gists/{id}/comments
      */
-    commentsDetail: (id: number, params: RequestParams = {}) =>
+    commentsList: (id: number, params: RequestParams = {}) =>
       this.http.request<Comments, void>({
         path: \`/gists/\${id}/comments\`,
         method: "GET",
@@ -2332,12 +2332,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description Get a single comment.
      *
-     * @name CommentsDetail2
+     * @name CommentsDetail
      * @request GET:/gists/{id}/comments/{commentId}
-     * @originalName commentsDetail
-     * @duplicate
      */
-    commentsDetail2: (id: number, commentId: number, params: RequestParams = {}) =>
+    commentsDetail: (id: number, commentId: number, params: RequestParams = {}) =>
       this.http.request<Comment, void>({
         path: \`/gists/\${id}/comments/\${commentId}\`,
         method: "GET",
@@ -2390,10 +2388,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description Check if a gist is starred.
      *
-     * @name StarDetail
+     * @name StarList
      * @request GET:/gists/{id}/star
      */
-    starDetail: (id: number, params: RequestParams = {}) =>
+    starList: (id: number, params: RequestParams = {}) =>
       this.http.request<void, void>({
         path: \`/gists/\${id}/star\`,
         method: "GET",
@@ -2629,10 +2627,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description List public events for a network of repositories.
      *
-     * @name EventsDetail
+     * @name EventsList
      * @request GET:/networks/{owner}/{repo}/events
      */
-    eventsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    eventsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.http.request<Events, void>({
         path: \`/networks/\${owner}/\${repo}/events\`,
         method: "GET",
@@ -2729,10 +2727,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description Get a Thread Subscription.
      *
-     * @name ThreadsSubscriptionDetail
+     * @name ThreadsSubscriptionList
      * @request GET:/notifications/threads/{id}/subscription
      */
-    threadsSubscriptionDetail: (id: number, params: RequestParams = {}) =>
+    threadsSubscriptionList: (id: number, params: RequestParams = {}) =>
       this.http.request<Subscription, void>({
         path: \`/notifications/threads/\${id}/subscription\`,
         method: "GET",
@@ -2790,10 +2788,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description List public events for an organization.
      *
-     * @name EventsDetail
+     * @name EventsList
      * @request GET:/orgs/{org}/events
      */
-    eventsDetail: (org: string, params: RequestParams = {}) =>
+    eventsList: (org: string, params: RequestParams = {}) =>
       this.http.request<Events, void>({
         path: \`/orgs/\${org}/events\`,
         method: "GET",
@@ -2804,10 +2802,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description List issues. List all issues for a given organization for the authenticated user.
      *
-     * @name IssuesDetail
+     * @name IssuesList
      * @request GET:/orgs/{org}/issues
      */
-    issuesDetail: (
+    issuesList: (
       org: string,
       query: {
         /**
@@ -2843,10 +2841,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description Members list. List all users who are members of an organization. A member is a user tha belongs to at least 1 team in the organization. If the authenticated user is also an owner of this organization then both concealed and public members will be returned. If the requester is not an owner of the organization the query will be redirected to the public members list.
      *
-     * @name MembersDetail
+     * @name MembersList
      * @request GET:/orgs/{org}/members
      */
-    membersDetail: (org: string, params: RequestParams = {}) =>
+    membersList: (org: string, params: RequestParams = {}) =>
       this.http.request<Users, void>({
         path: \`/orgs/\${org}/members\`,
         method: "GET",
@@ -2870,12 +2868,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description Check if a user is, publicly or privately, a member of the organization.
      *
-     * @name MembersDetail2
+     * @name MembersDetail
      * @request GET:/orgs/{org}/members/{username}
-     * @originalName membersDetail
-     * @duplicate
      */
-    membersDetail2: (org: string, username: string, params: RequestParams = {}) =>
+    membersDetail: (org: string, username: string, params: RequestParams = {}) =>
       this.http.request<void, void>({
         path: \`/orgs/\${org}/members/\${username}\`,
         method: "GET",
@@ -2885,10 +2881,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description Public members list. Members of an organization can choose to have their membership publicized or not.
      *
-     * @name PublicMembersDetail
+     * @name PublicMembersList
      * @request GET:/orgs/{org}/public_members
      */
-    publicMembersDetail: (org: string, params: RequestParams = {}) =>
+    publicMembersList: (org: string, params: RequestParams = {}) =>
       this.http.request<Users, void>({
         path: \`/orgs/\${org}/public_members\`,
         method: "GET",
@@ -2912,12 +2908,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description Check public membership.
      *
-     * @name PublicMembersDetail2
+     * @name PublicMembersDetail
      * @request GET:/orgs/{org}/public_members/{username}
-     * @originalName publicMembersDetail
-     * @duplicate
      */
-    publicMembersDetail2: (org: string, username: string, params: RequestParams = {}) =>
+    publicMembersDetail: (org: string, username: string, params: RequestParams = {}) =>
       this.http.request<void, void>({
         path: \`/orgs/\${org}/public_members/\${username}\`,
         method: "GET",
@@ -2940,10 +2934,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description List repositories for the specified org.
      *
-     * @name ReposDetail
+     * @name ReposList
      * @request GET:/orgs/{org}/repos
      */
-    reposDetail: (
+    reposList: (
       org: string,
       query?: {
         /** @default "all" */
@@ -2977,10 +2971,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description List teams.
      *
-     * @name TeamsDetail
+     * @name TeamsList
      * @request GET:/orgs/{org}/teams
      */
-    teamsDetail: (org: string, params: RequestParams = {}) =>
+    teamsList: (org: string, params: RequestParams = {}) =>
       this.http.request<Teams, void>({
         path: \`/orgs/\${org}/teams\`,
         method: "GET",
@@ -3066,10 +3060,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description List assignees. This call lists all the available assignees (owner + collaborators) to which issues may be assigned.
      *
-     * @name AssigneesDetail
+     * @name AssigneesList
      * @request GET:/repos/{owner}/{repo}/assignees
      */
-    assigneesDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    assigneesList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.http.request<Assignees, void>({
         path: \`/repos/\${owner}/\${repo}/assignees\`,
         method: "GET",
@@ -3080,12 +3074,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description Check assignee. You may also check to see if a particular user is an assignee for a repository.
      *
-     * @name AssigneesDetail2
+     * @name AssigneesDetail
      * @request GET:/repos/{owner}/{repo}/assignees/{assignee}
-     * @originalName assigneesDetail
-     * @duplicate
      */
-    assigneesDetail2: (owner: string, repo: string, assignee: string, params: RequestParams = {}) =>
+    assigneesDetail: (owner: string, repo: string, assignee: string, params: RequestParams = {}) =>
       this.http.request<void, void>({
         path: \`/repos/\${owner}/\${repo}/assignees/\${assignee}\`,
         method: "GET",
@@ -3095,10 +3087,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description Get list of branches
      *
-     * @name BranchesDetail
+     * @name BranchesList
      * @request GET:/repos/{owner}/{repo}/branches
      */
-    branchesDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    branchesList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.http.request<Branches, void>({
         path: \`/repos/\${owner}/\${repo}/branches\`,
         method: "GET",
@@ -3109,12 +3101,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description Get Branch
      *
-     * @name BranchesDetail2
+     * @name BranchesDetail
      * @request GET:/repos/{owner}/{repo}/branches/{branch}
-     * @originalName branchesDetail
-     * @duplicate
      */
-    branchesDetail2: (owner: string, repo: string, branch: string, params: RequestParams = {}) =>
+    branchesDetail: (owner: string, repo: string, branch: string, params: RequestParams = {}) =>
       this.http.request<Branch, void>({
         path: \`/repos/\${owner}/\${repo}/branches/\${branch}\`,
         method: "GET",
@@ -3125,10 +3115,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description List. When authenticating as an organization owner of an organization-owned repository, all organization owners are included in the list of collaborators. Otherwise, only users with access to the repository are returned in the collaborators list.
      *
-     * @name CollaboratorsDetail
+     * @name CollaboratorsList
      * @request GET:/repos/{owner}/{repo}/collaborators
      */
-    collaboratorsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    collaboratorsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.http.request<Users, void>({
         path: \`/repos/\${owner}/\${repo}/collaborators\`,
         method: "GET",
@@ -3152,12 +3142,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description Check if user is a collaborator
      *
-     * @name CollaboratorsDetail2
+     * @name CollaboratorsDetail
      * @request GET:/repos/{owner}/{repo}/collaborators/{user}
-     * @originalName collaboratorsDetail
-     * @duplicate
      */
-    collaboratorsDetail2: (owner: string, repo: string, user: string, params: RequestParams = {}) =>
+    collaboratorsDetail: (owner: string, repo: string, user: string, params: RequestParams = {}) =>
       this.http.request<void, void>({
         path: \`/repos/\${owner}/\${repo}/collaborators/\${user}\`,
         method: "GET",
@@ -3180,10 +3168,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description List commit comments for a repository. Comments are ordered by ascending ID.
      *
-     * @name CommentsDetail
+     * @name CommentsList
      * @request GET:/repos/{owner}/{repo}/comments
      */
-    commentsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    commentsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.http.request<RepoComments, void>({
         path: \`/repos/\${owner}/\${repo}/comments\`,
         method: "GET",
@@ -3207,12 +3195,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description Get a single commit comment.
      *
-     * @name CommentsDetail2
+     * @name CommentsDetail
      * @request GET:/repos/{owner}/{repo}/comments/{commentId}
-     * @originalName commentsDetail
-     * @duplicate
      */
-    commentsDetail2: (owner: string, repo: string, commentId: number, params: RequestParams = {}) =>
+    commentsDetail: (owner: string, repo: string, commentId: number, params: RequestParams = {}) =>
       this.http.request<CommitComment, void>({
         path: \`/repos/\${owner}/\${repo}/comments/\${commentId}\`,
         method: "GET",
@@ -3244,10 +3230,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description List commits on a repository.
      *
-     * @name CommitsDetail
+     * @name CommitsList
      * @request GET:/repos/{owner}/{repo}/commits
      */
-    commitsDetail: (
+    commitsList: (
       owner: string,
       repo: string,
       query?: {
@@ -3278,10 +3264,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description Get the combined Status for a specific Ref The Combined status endpoint is currently available for developers to preview. During the preview period, the API may change without advance notice. Please see the blog post for full details. To access this endpoint during the preview period, you must provide a custom media type in the Accept header: application/vnd.github.she-hulk-preview+json
      *
-     * @name CommitsStatusDetail
+     * @name CommitsStatusList
      * @request GET:/repos/{owner}/{repo}/commits/{ref}/status
      */
-    commitsStatusDetail: (owner: string, repo: string, ref: string, params: RequestParams = {}) =>
+    commitsStatusList: (owner: string, repo: string, ref: string, params: RequestParams = {}) =>
       this.http.request<RefStatus, void>({
         path: \`/repos/\${owner}/\${repo}/commits/\${ref}/status\`,
         method: "GET",
@@ -3292,12 +3278,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description Get a single commit.
      *
-     * @name CommitsDetail2
+     * @name CommitsDetail
      * @request GET:/repos/{owner}/{repo}/commits/{shaCode}
-     * @originalName commitsDetail
-     * @duplicate
      */
-    commitsDetail2: (owner: string, repo: string, shaCode: string, params: RequestParams = {}) =>
+    commitsDetail: (owner: string, repo: string, shaCode: string, params: RequestParams = {}) =>
       this.http.request<Commit, void>({
         path: \`/repos/\${owner}/\${repo}/commits/\${shaCode}\`,
         method: "GET",
@@ -3308,10 +3292,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description List comments for a single commitList comments for a single commit.
      *
-     * @name CommitsCommentsDetail
+     * @name CommitsCommentsList
      * @request GET:/repos/{owner}/{repo}/commits/{shaCode}/comments
      */
-    commitsCommentsDetail: (owner: string, repo: string, shaCode: string, params: RequestParams = {}) =>
+    commitsCommentsList: (owner: string, repo: string, shaCode: string, params: RequestParams = {}) =>
       this.http.request<RepoComments, void>({
         path: \`/repos/\${owner}/\${repo}/commits/\${shaCode}/comments\`,
         method: "GET",
@@ -3416,10 +3400,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description Get list of contributors.
      *
-     * @name ContributorsDetail
+     * @name ContributorsList
      * @request GET:/repos/{owner}/{repo}/contributors
      */
-    contributorsDetail: (
+    contributorsList: (
       owner: string,
       repo: string,
       query: {
@@ -3439,10 +3423,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description Users with pull access can view deployments for a repository
      *
-     * @name DeploymentsDetail
+     * @name DeploymentsList
      * @request GET:/repos/{owner}/{repo}/deployments
      */
-    deploymentsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    deploymentsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.http.request<RepoDeployments, void>({
         path: \`/repos/\${owner}/\${repo}/deployments\`,
         method: "GET",
@@ -3469,10 +3453,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description Users with pull access can view deployment statuses for a deployment
      *
-     * @name DeploymentsStatusesDetail
+     * @name DeploymentsStatusesList
      * @request GET:/repos/{owner}/{repo}/deployments/{id}/statuses
      */
-    deploymentsStatusesDetail: (owner: string, repo: string, id: number, params: RequestParams = {}) =>
+    deploymentsStatusesList: (owner: string, repo: string, id: number, params: RequestParams = {}) =>
       this.http.request<DeploymentStatuses, void>({
         path: \`/repos/\${owner}/\${repo}/deployments/\${id}/statuses\`,
         method: "GET",
@@ -3504,11 +3488,11 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description Deprecated. List downloads for a repository.
      *
-     * @name DownloadsDetail
+     * @name DownloadsList
      * @request GET:/repos/{owner}/{repo}/downloads
      * @deprecated
      */
-    downloadsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    downloadsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.http.request<Downloads, void>({
         path: \`/repos/\${owner}/\${repo}/downloads\`,
         method: "GET",
@@ -3533,13 +3517,11 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description Deprecated. Get a single download.
      *
-     * @name DownloadsDetail2
+     * @name DownloadsDetail
      * @request GET:/repos/{owner}/{repo}/downloads/{downloadId}
      * @deprecated
-     * @originalName downloadsDetail
-     * @duplicate
      */
-    downloadsDetail2: (owner: string, repo: string, downloadId: number, params: RequestParams = {}) =>
+    downloadsDetail: (owner: string, repo: string, downloadId: number, params: RequestParams = {}) =>
       this.http.request<Download, void>({
         path: \`/repos/\${owner}/\${repo}/downloads/\${downloadId}\`,
         method: "GET",
@@ -3550,10 +3532,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description Get list of repository events.
      *
-     * @name EventsDetail
+     * @name EventsList
      * @request GET:/repos/{owner}/{repo}/events
      */
-    eventsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    eventsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.http.request<Events, void>({
         path: \`/repos/\${owner}/\${repo}/events\`,
         method: "GET",
@@ -3564,10 +3546,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description List forks.
      *
-     * @name ForksDetail
+     * @name ForksList
      * @request GET:/repos/{owner}/{repo}/forks
      */
-    forksDetail: (
+    forksList: (
       owner: string,
       repo: string,
       query?: {
@@ -3663,10 +3645,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description Get all References
      *
-     * @name GitRefsDetail
+     * @name GitRefsList
      * @request GET:/repos/{owner}/{repo}/git/refs
      */
-    gitRefsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    gitRefsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.http.request<Refs, void>({
         path: \`/repos/\${owner}/\${repo}/git/refs\`,
         method: "GET",
@@ -3706,12 +3688,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description Get a Reference
      *
-     * @name GitRefsDetail2
+     * @name GitRefsDetail
      * @request GET:/repos/{owner}/{repo}/git/refs/{ref}
-     * @originalName gitRefsDetail
-     * @duplicate
      */
-    gitRefsDetail2: (owner: string, repo: string, ref: string, params: RequestParams = {}) =>
+    gitRefsDetail: (owner: string, repo: string, ref: string, params: RequestParams = {}) =>
       this.http.request<HeadBranch, void>({
         path: \`/repos/\${owner}/\${repo}/git/refs/\${ref}\`,
         method: "GET",
@@ -3808,10 +3788,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description Get list of hooks.
      *
-     * @name HooksDetail
+     * @name HooksList
      * @request GET:/repos/{owner}/{repo}/hooks
      */
-    hooksDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    hooksList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.http.request<Hook, void>({
         path: \`/repos/\${owner}/\${repo}/hooks\`,
         method: "GET",
@@ -3850,12 +3830,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description Get single hook.
      *
-     * @name HooksDetail2
+     * @name HooksDetail
      * @request GET:/repos/{owner}/{repo}/hooks/{hookId}
-     * @originalName hooksDetail
-     * @duplicate
      */
-    hooksDetail2: (owner: string, repo: string, hookId: number, params: RequestParams = {}) =>
+    hooksDetail: (owner: string, repo: string, hookId: number, params: RequestParams = {}) =>
       this.http.request<Hook, void>({
         path: \`/repos/\${owner}/\${repo}/hooks/\${hookId}\`,
         method: "GET",
@@ -3894,10 +3872,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description List issues for a repository.
      *
-     * @name IssuesDetail
+     * @name IssuesList
      * @request GET:/repos/{owner}/{repo}/issues
      */
-    issuesDetail: (
+    issuesList: (
       owner: string,
       repo: string,
       query: {
@@ -3949,10 +3927,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description List comments in a repository.
      *
-     * @name IssuesCommentsDetail
+     * @name IssuesCommentsList
      * @request GET:/repos/{owner}/{repo}/issues/comments
      */
-    issuesCommentsDetail: (
+    issuesCommentsList: (
       owner: string,
       repo: string,
       query?: {
@@ -3991,12 +3969,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description Get a single comment.
      *
-     * @name IssuesCommentsDetail2
+     * @name IssuesCommentsDetail
      * @request GET:/repos/{owner}/{repo}/issues/comments/{commentId}
-     * @originalName issuesCommentsDetail
-     * @duplicate
      */
-    issuesCommentsDetail2: (owner: string, repo: string, commentId: number, params: RequestParams = {}) =>
+    issuesCommentsDetail: (owner: string, repo: string, commentId: number, params: RequestParams = {}) =>
       this.http.request<IssuesComment, void>({
         path: \`/repos/\${owner}/\${repo}/issues/comments/\${commentId}\`,
         method: "GET",
@@ -4028,10 +4004,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description List issue events for a repository.
      *
-     * @name IssuesEventsDetail
+     * @name IssuesEventsList
      * @request GET:/repos/{owner}/{repo}/issues/events
      */
-    issuesEventsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    issuesEventsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.http.request<IssueEvents, void>({
         path: \`/repos/\${owner}/\${repo}/issues/events\`,
         method: "GET",
@@ -4042,12 +4018,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description Get a single event.
      *
-     * @name IssuesEventsDetail2
+     * @name IssuesEventsDetail
      * @request GET:/repos/{owner}/{repo}/issues/events/{eventId}
-     * @originalName issuesEventsDetail
-     * @duplicate
      */
-    issuesEventsDetail2: (owner: string, repo: string, eventId: number, params: RequestParams = {}) =>
+    issuesEventsDetail: (owner: string, repo: string, eventId: number, params: RequestParams = {}) =>
       this.http.request<IssueEvent, void>({
         path: \`/repos/\${owner}/\${repo}/issues/events/\${eventId}\`,
         method: "GET",
@@ -4058,12 +4032,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description Get a single issue
      *
-     * @name IssuesDetail2
+     * @name IssuesDetail
      * @request GET:/repos/{owner}/{repo}/issues/{number}
-     * @originalName issuesDetail
-     * @duplicate
      */
-    issuesDetail2: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    issuesDetail: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.http.request<Issue, void>({
         path: \`/repos/\${owner}/\${repo}/issues/\${number}\`,
         method: "GET",
@@ -4089,12 +4061,12 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description List comments on an issue.
      *
-     * @name IssuesCommentsDetail3
+     * @name IssuesCommentsList2
      * @request GET:/repos/{owner}/{repo}/issues/{number}/comments
-     * @originalName issuesCommentsDetail
+     * @originalName issuesCommentsList
      * @duplicate
      */
-    issuesCommentsDetail3: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    issuesCommentsList2: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.http.request<IssuesComments, void>({
         path: \`/repos/\${owner}/\${repo}/issues/\${number}/comments\`,
         method: "GET",
@@ -4126,12 +4098,12 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description List events for an issue.
      *
-     * @name IssuesEventsDetail3
+     * @name IssuesEventsList2
      * @request GET:/repos/{owner}/{repo}/issues/{number}/events
-     * @originalName issuesEventsDetail
+     * @originalName issuesEventsList
      * @duplicate
      */
-    issuesEventsDetail3: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    issuesEventsList2: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.http.request<IssueEvents, void>({
         path: \`/repos/\${owner}/\${repo}/issues/\${number}/events\`,
         method: "GET",
@@ -4155,10 +4127,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description List labels on an issue.
      *
-     * @name IssuesLabelsDetail
+     * @name IssuesLabelsList
      * @request GET:/repos/{owner}/{repo}/issues/{number}/labels
      */
-    issuesLabelsDetail: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    issuesLabelsList: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.http.request<Labels, void>({
         path: \`/repos/\${owner}/\${repo}/issues/\${number}/labels\`,
         method: "GET",
@@ -4214,10 +4186,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description Get list of keys.
      *
-     * @name KeysDetail
+     * @name KeysList
      * @request GET:/repos/{owner}/{repo}/keys
      */
-    keysDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    keysList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.http.request<Keys, void>({
         path: \`/repos/\${owner}/\${repo}/keys\`,
         method: "GET",
@@ -4256,12 +4228,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description Get a key
      *
-     * @name KeysDetail2
+     * @name KeysDetail
      * @request GET:/repos/{owner}/{repo}/keys/{keyId}
-     * @originalName keysDetail
-     * @duplicate
      */
-    keysDetail2: (owner: string, repo: string, keyId: number, params: RequestParams = {}) =>
+    keysDetail: (owner: string, repo: string, keyId: number, params: RequestParams = {}) =>
       this.http.request<UserKeysKeyId, void>({
         path: \`/repos/\${owner}/\${repo}/keys/\${keyId}\`,
         method: "GET",
@@ -4272,10 +4242,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description List all labels for this repository.
      *
-     * @name LabelsDetail
+     * @name LabelsList
      * @request GET:/repos/{owner}/{repo}/labels
      */
-    labelsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    labelsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.http.request<Labels, void>({
         path: \`/repos/\${owner}/\${repo}/labels\`,
         method: "GET",
@@ -4314,12 +4284,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description Get a single label.
      *
-     * @name LabelsDetail2
+     * @name LabelsDetail
      * @request GET:/repos/{owner}/{repo}/labels/{name}
-     * @originalName labelsDetail
-     * @duplicate
      */
-    labelsDetail2: (owner: string, repo: string, name: string, params: RequestParams = {}) =>
+    labelsDetail: (owner: string, repo: string, name: string, params: RequestParams = {}) =>
       this.http.request<Label, void>({
         path: \`/repos/\${owner}/\${repo}/labels/\${name}\`,
         method: "GET",
@@ -4345,10 +4313,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description List languages. List languages for the specified repository. The value on the right of a language is the number of bytes of code written in that language.
      *
-     * @name LanguagesDetail
+     * @name LanguagesList
      * @request GET:/repos/{owner}/{repo}/languages
      */
-    languagesDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    languagesList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.http.request<Languages, void>({
         path: \`/repos/\${owner}/\${repo}/languages\`,
         method: "GET",
@@ -4375,10 +4343,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description List milestones for a repository.
      *
-     * @name MilestonesDetail
+     * @name MilestonesList
      * @request GET:/repos/{owner}/{repo}/milestones
      */
-    milestonesDetail: (
+    milestonesList: (
       owner: string,
       repo: string,
       query?: {
@@ -4433,12 +4401,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description Get a single milestone.
      *
-     * @name MilestonesDetail2
+     * @name MilestonesDetail
      * @request GET:/repos/{owner}/{repo}/milestones/{number}
-     * @originalName milestonesDetail
-     * @duplicate
      */
-    milestonesDetail2: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    milestonesDetail: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.http.request<Milestone, void>({
         path: \`/repos/\${owner}/\${repo}/milestones/\${number}\`,
         method: "GET",
@@ -4470,10 +4436,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description Get labels for every issue in a milestone.
      *
-     * @name MilestonesLabelsDetail
+     * @name MilestonesLabelsList
      * @request GET:/repos/{owner}/{repo}/milestones/{number}/labels
      */
-    milestonesLabelsDetail: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    milestonesLabelsList: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.http.request<Labels, void>({
         path: \`/repos/\${owner}/\${repo}/milestones/\${number}/labels\`,
         method: "GET",
@@ -4484,10 +4450,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description List your notifications in a repository List all notifications for the current user.
      *
-     * @name NotificationsDetail
+     * @name NotificationsList
      * @request GET:/repos/{owner}/{repo}/notifications
      */
-    notificationsDetail: (
+    notificationsList: (
       owner: string,
       repo: string,
       query?: {
@@ -4531,10 +4497,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description List pull requests.
      *
-     * @name PullsDetail
+     * @name PullsList
      * @request GET:/repos/{owner}/{repo}/pulls
      */
-    pullsDetail: (
+    pullsList: (
       owner: string,
       repo: string,
       query?: {
@@ -4580,10 +4546,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description List comments in a repository. By default, Review Comments are ordered by ascending ID.
      *
-     * @name PullsCommentsDetail
+     * @name PullsCommentsList
      * @request GET:/repos/{owner}/{repo}/pulls/comments
      */
-    pullsCommentsDetail: (
+    pullsCommentsList: (
       owner: string,
       repo: string,
       query?: {
@@ -4622,12 +4588,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description Get a single comment.
      *
-     * @name PullsCommentsDetail2
+     * @name PullsCommentsDetail
      * @request GET:/repos/{owner}/{repo}/pulls/comments/{commentId}
-     * @originalName pullsCommentsDetail
-     * @duplicate
      */
-    pullsCommentsDetail2: (owner: string, repo: string, commentId: number, params: RequestParams = {}) =>
+    pullsCommentsDetail: (owner: string, repo: string, commentId: number, params: RequestParams = {}) =>
       this.http.request<PullsComment, void>({
         path: \`/repos/\${owner}/\${repo}/pulls/comments/\${commentId}\`,
         method: "GET",
@@ -4659,12 +4623,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description Get a single pull request.
      *
-     * @name PullsDetail2
+     * @name PullsDetail
      * @request GET:/repos/{owner}/{repo}/pulls/{number}
-     * @originalName pullsDetail
-     * @duplicate
      */
-    pullsDetail2: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    pullsDetail: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.http.request<PullRequest, void>({
         path: \`/repos/\${owner}/\${repo}/pulls/\${number}\`,
         method: "GET",
@@ -4691,12 +4653,12 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description List comments on a pull request.
      *
-     * @name PullsCommentsDetail3
+     * @name PullsCommentsList2
      * @request GET:/repos/{owner}/{repo}/pulls/{number}/comments
-     * @originalName pullsCommentsDetail
+     * @originalName pullsCommentsList
      * @duplicate
      */
-    pullsCommentsDetail3: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    pullsCommentsList2: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.http.request<PullsComment, void>({
         path: \`/repos/\${owner}/\${repo}/pulls/\${number}/comments\`,
         method: "GET",
@@ -4729,10 +4691,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description List commits on a pull request.
      *
-     * @name PullsCommitsDetail
+     * @name PullsCommitsList
      * @request GET:/repos/{owner}/{repo}/pulls/{number}/commits
      */
-    pullsCommitsDetail: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    pullsCommitsList: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.http.request<Commits, void>({
         path: \`/repos/\${owner}/\${repo}/pulls/\${number}/commits\`,
         method: "GET",
@@ -4743,10 +4705,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description List pull requests files.
      *
-     * @name PullsFilesDetail
+     * @name PullsFilesList
      * @request GET:/repos/{owner}/{repo}/pulls/{number}/files
      */
-    pullsFilesDetail: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    pullsFilesList: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.http.request<Pulls, void>({
         path: \`/repos/\${owner}/\${repo}/pulls/\${number}/files\`,
         method: "GET",
@@ -4757,10 +4719,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description Get if a pull request has been merged.
      *
-     * @name PullsMergeDetail
+     * @name PullsMergeList
      * @request GET:/repos/{owner}/{repo}/pulls/{number}/merge
      */
-    pullsMergeDetail: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    pullsMergeList: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.http.request<void, void>({
         path: \`/repos/\${owner}/\${repo}/pulls/\${number}/merge\`,
         method: "GET",
@@ -4786,10 +4748,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description Get the README. This method returns the preferred README for a repository.
      *
-     * @name ReadmeDetail
+     * @name ReadmeList
      * @request GET:/repos/{owner}/{repo}/readme
      */
-    readmeDetail: (
+    readmeList: (
       owner: string,
       repo: string,
       query?: {
@@ -4809,10 +4771,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description Users with push access to the repository will receive all releases (i.e., published releases and draft releases). Users with pull access will receive published releases only
      *
-     * @name ReleasesDetail
+     * @name ReleasesList
      * @request GET:/repos/{owner}/{repo}/releases
      */
-    releasesDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    releasesList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.http.request<Releases, void>({
         path: \`/repos/\${owner}/\${repo}/releases\`,
         method: "GET",
@@ -4900,12 +4862,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description Get a single release
      *
-     * @name ReleasesDetail2
+     * @name ReleasesDetail
      * @request GET:/repos/{owner}/{repo}/releases/{id}
-     * @originalName releasesDetail
-     * @duplicate
      */
-    releasesDetail2: (owner: string, repo: string, id: string, params: RequestParams = {}) =>
+    releasesDetail: (owner: string, repo: string, id: string, params: RequestParams = {}) =>
       this.http.request<Release, void>({
         path: \`/repos/\${owner}/\${repo}/releases/\${id}\`,
         method: "GET",
@@ -4931,12 +4891,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description List assets for a release
      *
-     * @name ReleasesAssetsDetail2
+     * @name ReleasesAssetsList
      * @request GET:/repos/{owner}/{repo}/releases/{id}/assets
-     * @originalName releasesAssetsDetail
-     * @duplicate
      */
-    releasesAssetsDetail2: (owner: string, repo: string, id: string, params: RequestParams = {}) =>
+    releasesAssetsList: (owner: string, repo: string, id: string, params: RequestParams = {}) =>
       this.http.request<Assets, void>({
         path: \`/repos/\${owner}/\${repo}/releases/\${id}/assets\`,
         method: "GET",
@@ -4947,10 +4905,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description List Stargazers.
      *
-     * @name StargazersDetail
+     * @name StargazersList
      * @request GET:/repos/{owner}/{repo}/stargazers
      */
-    stargazersDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    stargazersList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.http.request<Users, void>({
         path: \`/repos/\${owner}/\${repo}/stargazers\`,
         method: "GET",
@@ -4961,10 +4919,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description Get the number of additions and deletions per week. Returns a weekly aggregate of the number of additions and deletions pushed to a repository.
      *
-     * @name StatsCodeFrequencyDetail
+     * @name StatsCodeFrequencyList
      * @request GET:/repos/{owner}/{repo}/stats/code_frequency
      */
-    statsCodeFrequencyDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    statsCodeFrequencyList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.http.request<CodeFrequencyStats, void>({
         path: \`/repos/\${owner}/\${repo}/stats/code_frequency\`,
         method: "GET",
@@ -4975,10 +4933,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description Get the last year of commit activity data. Returns the last year of commit activity grouped by week. The days array is a group of commits per day, starting on Sunday.
      *
-     * @name StatsCommitActivityDetail
+     * @name StatsCommitActivityList
      * @request GET:/repos/{owner}/{repo}/stats/commit_activity
      */
-    statsCommitActivityDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    statsCommitActivityList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.http.request<CommitActivityStats, void>({
         path: \`/repos/\${owner}/\${repo}/stats/commit_activity\`,
         method: "GET",
@@ -4989,10 +4947,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description Get contributors list with additions, deletions, and commit counts.
      *
-     * @name StatsContributorsDetail
+     * @name StatsContributorsList
      * @request GET:/repos/{owner}/{repo}/stats/contributors
      */
-    statsContributorsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    statsContributorsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.http.request<ContributorsStats, void>({
         path: \`/repos/\${owner}/\${repo}/stats/contributors\`,
         method: "GET",
@@ -5003,10 +4961,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description Get the weekly commit count for the repo owner and everyone else.
      *
-     * @name StatsParticipationDetail
+     * @name StatsParticipationList
      * @request GET:/repos/{owner}/{repo}/stats/participation
      */
-    statsParticipationDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    statsParticipationList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.http.request<ParticipationStats, void>({
         path: \`/repos/\${owner}/\${repo}/stats/participation\`,
         method: "GET",
@@ -5017,10 +4975,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description Get the number of commits per hour in each day. Each array contains the day number, hour number, and number of commits 0-6 Sunday - Saturday 0-23 Hour of day Number of commits For example, [2, 14, 25] indicates that there were 25 total commits, during the 2.00pm hour on Tuesdays. All times are based on the time zone of individual commits.
      *
-     * @name StatsPunchCardDetail
+     * @name StatsPunchCardList
      * @request GET:/repos/{owner}/{repo}/stats/punch_card
      */
-    statsPunchCardDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    statsPunchCardList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.http.request<CodeFrequencyStats, void>({
         path: \`/repos/\${owner}/\${repo}/stats/punch_card\`,
         method: "GET",
@@ -5061,10 +5019,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description List watchers.
      *
-     * @name SubscribersDetail
+     * @name SubscribersList
      * @request GET:/repos/{owner}/{repo}/subscribers
      */
-    subscribersDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    subscribersList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.http.request<Users, void>({
         path: \`/repos/\${owner}/\${repo}/subscribers\`,
         method: "GET",
@@ -5088,10 +5046,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description Get a Repository Subscription.
      *
-     * @name SubscriptionDetail
+     * @name SubscriptionList
      * @request GET:/repos/{owner}/{repo}/subscription
      */
-    subscriptionDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    subscriptionList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.http.request<Subscription, void>({
         path: \`/repos/\${owner}/\${repo}/subscription\`,
         method: "GET",
@@ -5118,10 +5076,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description Get list of tags.
      *
-     * @name TagsDetail
+     * @name TagsList
      * @request GET:/repos/{owner}/{repo}/tags
      */
-    tagsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    tagsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.http.request<Tags, void>({
         path: \`/repos/\${owner}/\${repo}/tags\`,
         method: "GET",
@@ -5132,10 +5090,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description Get list of teams
      *
-     * @name TeamsDetail
+     * @name TeamsList
      * @request GET:/repos/{owner}/{repo}/teams
      */
-    teamsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    teamsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.http.request<Teams, void>({
         path: \`/repos/\${owner}/\${repo}/teams\`,
         method: "GET",
@@ -5146,10 +5104,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description List Stargazers. New implementation.
      *
-     * @name WatchersDetail
+     * @name WatchersList
      * @request GET:/repos/{owner}/{repo}/watchers
      */
-    watchersDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    watchersList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.http.request<Users, void>({
         path: \`/repos/\${owner}/\${repo}/watchers\`,
         method: "GET",
@@ -5408,10 +5366,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description List team members. In order to list members in a team, the authenticated user must be a member of the team.
      *
-     * @name MembersDetail
+     * @name MembersList
      * @request GET:/teams/{teamId}/members
      */
-    membersDetail: (teamId: number, params: RequestParams = {}) =>
+    membersList: (teamId: number, params: RequestParams = {}) =>
       this.http.request<Users, void>({
         path: \`/teams/\${teamId}/members\`,
         method: "GET",
@@ -5436,13 +5394,11 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description The "Get team member" API is deprecated and is scheduled for removal in the next major version of the API. We recommend using the Get team membership API instead. It allows you to get both active and pending memberships. Get team member. In order to get if a user is a member of a team, the authenticated user mus be a member of the team.
      *
-     * @name MembersDetail2
+     * @name MembersDetail
      * @request GET:/teams/{teamId}/members/{username}
      * @deprecated
-     * @originalName membersDetail
-     * @duplicate
      */
-    membersDetail2: (teamId: number, username: string, params: RequestParams = {}) =>
+    membersDetail: (teamId: number, username: string, params: RequestParams = {}) =>
       this.http.request<void, void>({
         path: \`/teams/\${teamId}/members/\${username}\`,
         method: "GET",
@@ -5507,10 +5463,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description List team repos
      *
-     * @name ReposDetail
+     * @name ReposList
      * @request GET:/teams/{teamId}/repos
      */
-    reposDetail: (teamId: number, params: RequestParams = {}) =>
+    reposList: (teamId: number, params: RequestParams = {}) =>
       this.http.request<TeamRepos, void>({
         path: \`/teams/\${teamId}/repos\`,
         method: "GET",
@@ -5534,12 +5490,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description Check if a team manages a repository
      *
-     * @name ReposDetail2
+     * @name ReposDetail
      * @request GET:/teams/{teamId}/repos/{owner}/{repo}
-     * @originalName reposDetail
-     * @duplicate
      */
-    reposDetail2: (teamId: number, owner: string, repo: string, params: RequestParams = {}) =>
+    reposDetail: (teamId: number, owner: string, repo: string, params: RequestParams = {}) =>
       this.http.request<any, void>({
         path: \`/teams/\${teamId}/repos/\${owner}/\${repo}\`,
         method: "GET",
@@ -6014,10 +5968,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description If you are authenticated as the given user, you will see your private events. Otherwise, you'll only see public events.
      *
-     * @name EventsDetail
+     * @name EventsList
      * @request GET:/users/{username}/events
      */
-    eventsDetail: (username: string, params: RequestParams = {}) =>
+    eventsList: (username: string, params: RequestParams = {}) =>
       this.http.request<any, void>({
         path: \`/users/\${username}/events\`,
         method: "GET",
@@ -6040,10 +5994,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description List a user's followers
      *
-     * @name FollowersDetail
+     * @name FollowersList
      * @request GET:/users/{username}/followers
      */
-    followersDetail: (username: string, params: RequestParams = {}) =>
+    followersList: (username: string, params: RequestParams = {}) =>
       this.http.request<Users, void>({
         path: \`/users/\${username}/followers\`,
         method: "GET",
@@ -6067,10 +6021,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description List a users gists.
      *
-     * @name GistsDetail
+     * @name GistsList
      * @request GET:/users/{username}/gists
      */
-    gistsDetail: (
+    gistsList: (
       username: string,
       query?: {
         /**
@@ -6092,10 +6046,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description List public keys for a user. Lists the verified public keys for a user. This is accessible by anyone.
      *
-     * @name KeysDetail
+     * @name KeysList
      * @request GET:/users/{username}/keys
      */
-    keysDetail: (username: string, params: RequestParams = {}) =>
+    keysList: (username: string, params: RequestParams = {}) =>
       this.http.request<Gitignore, void>({
         path: \`/users/\${username}/keys\`,
         method: "GET",
@@ -6106,10 +6060,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description List all public organizations for a user.
      *
-     * @name OrgsDetail
+     * @name OrgsList
      * @request GET:/users/{username}/orgs
      */
-    orgsDetail: (username: string, params: RequestParams = {}) =>
+    orgsList: (username: string, params: RequestParams = {}) =>
       this.http.request<Gitignore, void>({
         path: \`/users/\${username}/orgs\`,
         method: "GET",
@@ -6120,10 +6074,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description These are events that you'll only see public events.
      *
-     * @name ReceivedEventsDetail
+     * @name ReceivedEventsList
      * @request GET:/users/{username}/received_events
      */
-    receivedEventsDetail: (username: string, params: RequestParams = {}) =>
+    receivedEventsList: (username: string, params: RequestParams = {}) =>
       this.http.request<any, void>({
         path: \`/users/\${username}/received_events\`,
         method: "GET",
@@ -6133,10 +6087,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description List public events that a user has received
      *
-     * @name ReceivedEventsPublicDetail
+     * @name ReceivedEventsPublicList
      * @request GET:/users/{username}/received_events/public
      */
-    receivedEventsPublicDetail: (username: string, params: RequestParams = {}) =>
+    receivedEventsPublicList: (username: string, params: RequestParams = {}) =>
       this.http.request<any, void>({
         path: \`/users/\${username}/received_events/public\`,
         method: "GET",
@@ -6146,10 +6100,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description List public repositories for the specified user.
      *
-     * @name ReposDetail
+     * @name ReposList
      * @request GET:/users/{username}/repos
      */
-    reposDetail: (
+    reposList: (
       username: string,
       query?: {
         /** @default "all" */
@@ -6168,10 +6122,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description List repositories being starred by a user.
      *
-     * @name StarredDetail
+     * @name StarredList
      * @request GET:/users/{username}/starred
      */
-    starredDetail: (username: string, params: RequestParams = {}) =>
+    starredList: (username: string, params: RequestParams = {}) =>
       this.http.request<any, void>({
         path: \`/users/\${username}/starred\`,
         method: "GET",
@@ -6181,10 +6135,10 @@ export class Api<SecurityDataType extends unknown> {
     /**
      * @description List repositories being watched by a user.
      *
-     * @name SubscriptionsDetail
+     * @name SubscriptionsList
      * @request GET:/users/{username}/subscriptions
      */
-    subscriptionsDetail: (username: string, params: RequestParams = {}) =>
+    subscriptionsList: (username: string, params: RequestParams = {}) =>
       this.http.request<any, void>({
         path: \`/users/\${username}/subscriptions\`,
         method: "GET",

--- a/tests/spec/js/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/js/__snapshots__/basic.test.ts.snap
@@ -253,10 +253,10 @@ export class Api extends HttpClient {
     /**
      * @description List comments on a gist.
      *
-     * @name CommentsDetail
+     * @name CommentsList
      * @request GET:/gists/{id}/comments
      */
-    commentsDetail: (id, params = {}) =>
+    commentsList: (id, params = {}) =>
       this.request({
         path: \`/gists/\${id}/comments\`,
         method: "GET",
@@ -292,12 +292,10 @@ export class Api extends HttpClient {
     /**
      * @description Get a single comment.
      *
-     * @name CommentsDetail2
+     * @name CommentsDetail
      * @request GET:/gists/{id}/comments/{commentId}
-     * @originalName commentsDetail
-     * @duplicate
      */
-    commentsDetail2: (id, commentId, params = {}) =>
+    commentsDetail: (id, commentId, params = {}) =>
       this.request({
         path: \`/gists/\${id}/comments/\${commentId}\`,
         method: "GET",
@@ -346,10 +344,10 @@ export class Api extends HttpClient {
     /**
      * @description Check if a gist is starred.
      *
-     * @name StarDetail
+     * @name StarList
      * @request GET:/gists/{id}/star
      */
-    starDetail: (id, params = {}) =>
+    starList: (id, params = {}) =>
       this.request({
         path: \`/gists/\${id}/star\`,
         method: "GET",
@@ -520,10 +518,10 @@ export class Api extends HttpClient {
     /**
      * @description List public events for a network of repositories.
      *
-     * @name EventsDetail
+     * @name EventsList
      * @request GET:/networks/{owner}/{repo}/events
      */
-    eventsDetail: (owner, repo, params = {}) =>
+    eventsList: (owner, repo, params = {}) =>
       this.request({
         path: \`/networks/\${owner}/\${repo}/events\`,
         method: "GET",
@@ -599,10 +597,10 @@ export class Api extends HttpClient {
     /**
      * @description Get a Thread Subscription.
      *
-     * @name ThreadsSubscriptionDetail
+     * @name ThreadsSubscriptionList
      * @request GET:/notifications/threads/{id}/subscription
      */
-    threadsSubscriptionDetail: (id, params = {}) =>
+    threadsSubscriptionList: (id, params = {}) =>
       this.request({
         path: \`/notifications/threads/\${id}/subscription\`,
         method: "GET",
@@ -657,10 +655,10 @@ export class Api extends HttpClient {
     /**
      * @description List public events for an organization.
      *
-     * @name EventsDetail
+     * @name EventsList
      * @request GET:/orgs/{org}/events
      */
-    eventsDetail: (org, params = {}) =>
+    eventsList: (org, params = {}) =>
       this.request({
         path: \`/orgs/\${org}/events\`,
         method: "GET",
@@ -670,10 +668,10 @@ export class Api extends HttpClient {
     /**
      * @description List issues. List all issues for a given organization for the authenticated user.
      *
-     * @name IssuesDetail
+     * @name IssuesList
      * @request GET:/orgs/{org}/issues
      */
-    issuesDetail: (org, query, params = {}) =>
+    issuesList: (org, query, params = {}) =>
       this.request({
         path: \`/orgs/\${org}/issues\`,
         method: "GET",
@@ -684,10 +682,10 @@ export class Api extends HttpClient {
     /**
      * @description Members list. List all users who are members of an organization. A member is a user tha belongs to at least 1 team in the organization. If the authenticated user is also an owner of this organization then both concealed and public members will be returned. If the requester is not an owner of the organization the query will be redirected to the public members list.
      *
-     * @name MembersDetail
+     * @name MembersList
      * @request GET:/orgs/{org}/members
      */
-    membersDetail: (org, params = {}) =>
+    membersList: (org, params = {}) =>
       this.request({
         path: \`/orgs/\${org}/members\`,
         method: "GET",
@@ -709,12 +707,10 @@ export class Api extends HttpClient {
     /**
      * @description Check if a user is, publicly or privately, a member of the organization.
      *
-     * @name MembersDetail2
+     * @name MembersDetail
      * @request GET:/orgs/{org}/members/{username}
-     * @originalName membersDetail
-     * @duplicate
      */
-    membersDetail2: (org, username, params = {}) =>
+    membersDetail: (org, username, params = {}) =>
       this.request({
         path: \`/orgs/\${org}/members/\${username}\`,
         method: "GET",
@@ -723,10 +719,10 @@ export class Api extends HttpClient {
     /**
      * @description Public members list. Members of an organization can choose to have their membership publicized or not.
      *
-     * @name PublicMembersDetail
+     * @name PublicMembersList
      * @request GET:/orgs/{org}/public_members
      */
-    publicMembersDetail: (org, params = {}) =>
+    publicMembersList: (org, params = {}) =>
       this.request({
         path: \`/orgs/\${org}/public_members\`,
         method: "GET",
@@ -748,12 +744,10 @@ export class Api extends HttpClient {
     /**
      * @description Check public membership.
      *
-     * @name PublicMembersDetail2
+     * @name PublicMembersDetail
      * @request GET:/orgs/{org}/public_members/{username}
-     * @originalName publicMembersDetail
-     * @duplicate
      */
-    publicMembersDetail2: (org, username, params = {}) =>
+    publicMembersDetail: (org, username, params = {}) =>
       this.request({
         path: \`/orgs/\${org}/public_members/\${username}\`,
         method: "GET",
@@ -774,10 +768,10 @@ export class Api extends HttpClient {
     /**
      * @description List repositories for the specified org.
      *
-     * @name ReposDetail
+     * @name ReposList
      * @request GET:/orgs/{org}/repos
      */
-    reposDetail: (org, query, params = {}) =>
+    reposList: (org, query, params = {}) =>
       this.request({
         path: \`/orgs/\${org}/repos\`,
         method: "GET",
@@ -802,10 +796,10 @@ export class Api extends HttpClient {
     /**
      * @description List teams.
      *
-     * @name TeamsDetail
+     * @name TeamsList
      * @request GET:/orgs/{org}/teams
      */
-    teamsDetail: (org, params = {}) =>
+    teamsList: (org, params = {}) =>
       this.request({
         path: \`/orgs/\${org}/teams\`,
         method: "GET",
@@ -887,10 +881,10 @@ export class Api extends HttpClient {
     /**
      * @description List assignees. This call lists all the available assignees (owner + collaborators) to which issues may be assigned.
      *
-     * @name AssigneesDetail
+     * @name AssigneesList
      * @request GET:/repos/{owner}/{repo}/assignees
      */
-    assigneesDetail: (owner, repo, params = {}) =>
+    assigneesList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/assignees\`,
         method: "GET",
@@ -900,12 +894,10 @@ export class Api extends HttpClient {
     /**
      * @description Check assignee. You may also check to see if a particular user is an assignee for a repository.
      *
-     * @name AssigneesDetail2
+     * @name AssigneesDetail
      * @request GET:/repos/{owner}/{repo}/assignees/{assignee}
-     * @originalName assigneesDetail
-     * @duplicate
      */
-    assigneesDetail2: (owner, repo, assignee, params = {}) =>
+    assigneesDetail: (owner, repo, assignee, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/assignees/\${assignee}\`,
         method: "GET",
@@ -914,10 +906,10 @@ export class Api extends HttpClient {
     /**
      * @description Get list of branches
      *
-     * @name BranchesDetail
+     * @name BranchesList
      * @request GET:/repos/{owner}/{repo}/branches
      */
-    branchesDetail: (owner, repo, params = {}) =>
+    branchesList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/branches\`,
         method: "GET",
@@ -927,12 +919,10 @@ export class Api extends HttpClient {
     /**
      * @description Get Branch
      *
-     * @name BranchesDetail2
+     * @name BranchesDetail
      * @request GET:/repos/{owner}/{repo}/branches/{branch}
-     * @originalName branchesDetail
-     * @duplicate
      */
-    branchesDetail2: (owner, repo, branch, params = {}) =>
+    branchesDetail: (owner, repo, branch, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/branches/\${branch}\`,
         method: "GET",
@@ -942,10 +932,10 @@ export class Api extends HttpClient {
     /**
      * @description List. When authenticating as an organization owner of an organization-owned repository, all organization owners are included in the list of collaborators. Otherwise, only users with access to the repository are returned in the collaborators list.
      *
-     * @name CollaboratorsDetail
+     * @name CollaboratorsList
      * @request GET:/repos/{owner}/{repo}/collaborators
      */
-    collaboratorsDetail: (owner, repo, params = {}) =>
+    collaboratorsList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/collaborators\`,
         method: "GET",
@@ -967,12 +957,10 @@ export class Api extends HttpClient {
     /**
      * @description Check if user is a collaborator
      *
-     * @name CollaboratorsDetail2
+     * @name CollaboratorsDetail
      * @request GET:/repos/{owner}/{repo}/collaborators/{user}
-     * @originalName collaboratorsDetail
-     * @duplicate
      */
-    collaboratorsDetail2: (owner, repo, user, params = {}) =>
+    collaboratorsDetail: (owner, repo, user, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/collaborators/\${user}\`,
         method: "GET",
@@ -993,10 +981,10 @@ export class Api extends HttpClient {
     /**
      * @description List commit comments for a repository. Comments are ordered by ascending ID.
      *
-     * @name CommentsDetail
+     * @name CommentsList
      * @request GET:/repos/{owner}/{repo}/comments
      */
-    commentsDetail: (owner, repo, params = {}) =>
+    commentsList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/comments\`,
         method: "GET",
@@ -1018,12 +1006,10 @@ export class Api extends HttpClient {
     /**
      * @description Get a single commit comment.
      *
-     * @name CommentsDetail2
+     * @name CommentsDetail
      * @request GET:/repos/{owner}/{repo}/comments/{commentId}
-     * @originalName commentsDetail
-     * @duplicate
      */
-    commentsDetail2: (owner, repo, commentId, params = {}) =>
+    commentsDetail: (owner, repo, commentId, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/comments/\${commentId}\`,
         method: "GET",
@@ -1047,10 +1033,10 @@ export class Api extends HttpClient {
     /**
      * @description List commits on a repository.
      *
-     * @name CommitsDetail
+     * @name CommitsList
      * @request GET:/repos/{owner}/{repo}/commits
      */
-    commitsDetail: (owner, repo, query, params = {}) =>
+    commitsList: (owner, repo, query, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/commits\`,
         method: "GET",
@@ -1061,10 +1047,10 @@ export class Api extends HttpClient {
     /**
      * @description Get the combined Status for a specific Ref The Combined status endpoint is currently available for developers to preview. During the preview period, the API may change without advance notice. Please see the blog post for full details. To access this endpoint during the preview period, you must provide a custom media type in the Accept header: application/vnd.github.she-hulk-preview+json
      *
-     * @name CommitsStatusDetail
+     * @name CommitsStatusList
      * @request GET:/repos/{owner}/{repo}/commits/{ref}/status
      */
-    commitsStatusDetail: (owner, repo, ref, params = {}) =>
+    commitsStatusList: (owner, repo, ref, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/commits/\${ref}/status\`,
         method: "GET",
@@ -1074,12 +1060,10 @@ export class Api extends HttpClient {
     /**
      * @description Get a single commit.
      *
-     * @name CommitsDetail2
+     * @name CommitsDetail
      * @request GET:/repos/{owner}/{repo}/commits/{shaCode}
-     * @originalName commitsDetail
-     * @duplicate
      */
-    commitsDetail2: (owner, repo, shaCode, params = {}) =>
+    commitsDetail: (owner, repo, shaCode, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/commits/\${shaCode}\`,
         method: "GET",
@@ -1089,10 +1073,10 @@ export class Api extends HttpClient {
     /**
      * @description List comments for a single commitList comments for a single commit.
      *
-     * @name CommitsCommentsDetail
+     * @name CommitsCommentsList
      * @request GET:/repos/{owner}/{repo}/commits/{shaCode}/comments
      */
-    commitsCommentsDetail: (owner, repo, shaCode, params = {}) =>
+    commitsCommentsList: (owner, repo, shaCode, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/commits/\${shaCode}/comments\`,
         method: "GET",
@@ -1174,10 +1158,10 @@ export class Api extends HttpClient {
     /**
      * @description Get list of contributors.
      *
-     * @name ContributorsDetail
+     * @name ContributorsList
      * @request GET:/repos/{owner}/{repo}/contributors
      */
-    contributorsDetail: (owner, repo, query, params = {}) =>
+    contributorsList: (owner, repo, query, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/contributors\`,
         method: "GET",
@@ -1188,10 +1172,10 @@ export class Api extends HttpClient {
     /**
      * @description Users with pull access can view deployments for a repository
      *
-     * @name DeploymentsDetail
+     * @name DeploymentsList
      * @request GET:/repos/{owner}/{repo}/deployments
      */
-    deploymentsDetail: (owner, repo, params = {}) =>
+    deploymentsList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/deployments\`,
         method: "GET",
@@ -1216,10 +1200,10 @@ export class Api extends HttpClient {
     /**
      * @description Users with pull access can view deployment statuses for a deployment
      *
-     * @name DeploymentsStatusesDetail
+     * @name DeploymentsStatusesList
      * @request GET:/repos/{owner}/{repo}/deployments/{id}/statuses
      */
-    deploymentsStatusesDetail: (owner, repo, id, params = {}) =>
+    deploymentsStatusesList: (owner, repo, id, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/deployments/\${id}/statuses\`,
         method: "GET",
@@ -1243,11 +1227,11 @@ export class Api extends HttpClient {
     /**
      * @description Deprecated. List downloads for a repository.
      *
-     * @name DownloadsDetail
+     * @name DownloadsList
      * @request GET:/repos/{owner}/{repo}/downloads
      * @deprecated
      */
-    downloadsDetail: (owner, repo, params = {}) =>
+    downloadsList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/downloads\`,
         method: "GET",
@@ -1270,13 +1254,11 @@ export class Api extends HttpClient {
     /**
      * @description Deprecated. Get a single download.
      *
-     * @name DownloadsDetail2
+     * @name DownloadsDetail
      * @request GET:/repos/{owner}/{repo}/downloads/{downloadId}
      * @deprecated
-     * @originalName downloadsDetail
-     * @duplicate
      */
-    downloadsDetail2: (owner, repo, downloadId, params = {}) =>
+    downloadsDetail: (owner, repo, downloadId, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/downloads/\${downloadId}\`,
         method: "GET",
@@ -1286,10 +1268,10 @@ export class Api extends HttpClient {
     /**
      * @description Get list of repository events.
      *
-     * @name EventsDetail
+     * @name EventsList
      * @request GET:/repos/{owner}/{repo}/events
      */
-    eventsDetail: (owner, repo, params = {}) =>
+    eventsList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/events\`,
         method: "GET",
@@ -1299,10 +1281,10 @@ export class Api extends HttpClient {
     /**
      * @description List forks.
      *
-     * @name ForksDetail
+     * @name ForksList
      * @request GET:/repos/{owner}/{repo}/forks
      */
-    forksDetail: (owner, repo, query, params = {}) =>
+    forksList: (owner, repo, query, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/forks\`,
         method: "GET",
@@ -1384,10 +1366,10 @@ export class Api extends HttpClient {
     /**
      * @description Get all References
      *
-     * @name GitRefsDetail
+     * @name GitRefsList
      * @request GET:/repos/{owner}/{repo}/git/refs
      */
-    gitRefsDetail: (owner, repo, params = {}) =>
+    gitRefsList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/git/refs\`,
         method: "GET",
@@ -1424,12 +1406,10 @@ export class Api extends HttpClient {
     /**
      * @description Get a Reference
      *
-     * @name GitRefsDetail2
+     * @name GitRefsDetail
      * @request GET:/repos/{owner}/{repo}/git/refs/{ref}
-     * @originalName gitRefsDetail
-     * @duplicate
      */
-    gitRefsDetail2: (owner, repo, ref, params = {}) =>
+    gitRefsDetail: (owner, repo, ref, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/git/refs/\${ref}\`,
         method: "GET",
@@ -1511,10 +1491,10 @@ export class Api extends HttpClient {
     /**
      * @description Get list of hooks.
      *
-     * @name HooksDetail
+     * @name HooksList
      * @request GET:/repos/{owner}/{repo}/hooks
      */
-    hooksDetail: (owner, repo, params = {}) =>
+    hooksList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/hooks\`,
         method: "GET",
@@ -1550,12 +1530,10 @@ export class Api extends HttpClient {
     /**
      * @description Get single hook.
      *
-     * @name HooksDetail2
+     * @name HooksDetail
      * @request GET:/repos/{owner}/{repo}/hooks/{hookId}
-     * @originalName hooksDetail
-     * @duplicate
      */
-    hooksDetail2: (owner, repo, hookId, params = {}) =>
+    hooksDetail: (owner, repo, hookId, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/hooks/\${hookId}\`,
         method: "GET",
@@ -1591,10 +1569,10 @@ export class Api extends HttpClient {
     /**
      * @description List issues for a repository.
      *
-     * @name IssuesDetail
+     * @name IssuesList
      * @request GET:/repos/{owner}/{repo}/issues
      */
-    issuesDetail: (owner, repo, query, params = {}) =>
+    issuesList: (owner, repo, query, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/issues\`,
         method: "GET",
@@ -1619,10 +1597,10 @@ export class Api extends HttpClient {
     /**
      * @description List comments in a repository.
      *
-     * @name IssuesCommentsDetail
+     * @name IssuesCommentsList
      * @request GET:/repos/{owner}/{repo}/issues/comments
      */
-    issuesCommentsDetail: (owner, repo, query, params = {}) =>
+    issuesCommentsList: (owner, repo, query, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/issues/comments\`,
         method: "GET",
@@ -1645,12 +1623,10 @@ export class Api extends HttpClient {
     /**
      * @description Get a single comment.
      *
-     * @name IssuesCommentsDetail2
+     * @name IssuesCommentsDetail
      * @request GET:/repos/{owner}/{repo}/issues/comments/{commentId}
-     * @originalName issuesCommentsDetail
-     * @duplicate
      */
-    issuesCommentsDetail2: (owner, repo, commentId, params = {}) =>
+    issuesCommentsDetail: (owner, repo, commentId, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/issues/comments/\${commentId}\`,
         method: "GET",
@@ -1674,10 +1650,10 @@ export class Api extends HttpClient {
     /**
      * @description List issue events for a repository.
      *
-     * @name IssuesEventsDetail
+     * @name IssuesEventsList
      * @request GET:/repos/{owner}/{repo}/issues/events
      */
-    issuesEventsDetail: (owner, repo, params = {}) =>
+    issuesEventsList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/issues/events\`,
         method: "GET",
@@ -1687,12 +1663,10 @@ export class Api extends HttpClient {
     /**
      * @description Get a single event.
      *
-     * @name IssuesEventsDetail2
+     * @name IssuesEventsDetail
      * @request GET:/repos/{owner}/{repo}/issues/events/{eventId}
-     * @originalName issuesEventsDetail
-     * @duplicate
      */
-    issuesEventsDetail2: (owner, repo, eventId, params = {}) =>
+    issuesEventsDetail: (owner, repo, eventId, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/issues/events/\${eventId}\`,
         method: "GET",
@@ -1702,12 +1676,10 @@ export class Api extends HttpClient {
     /**
      * @description Get a single issue
      *
-     * @name IssuesDetail2
+     * @name IssuesDetail
      * @request GET:/repos/{owner}/{repo}/issues/{number}
-     * @originalName issuesDetail
-     * @duplicate
      */
-    issuesDetail2: (owner, repo, number, params = {}) =>
+    issuesDetail: (owner, repo, number, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/issues/\${number}\`,
         method: "GET",
@@ -1731,12 +1703,12 @@ export class Api extends HttpClient {
     /**
      * @description List comments on an issue.
      *
-     * @name IssuesCommentsDetail3
+     * @name IssuesCommentsList2
      * @request GET:/repos/{owner}/{repo}/issues/{number}/comments
-     * @originalName issuesCommentsDetail
+     * @originalName issuesCommentsList
      * @duplicate
      */
-    issuesCommentsDetail3: (owner, repo, number, params = {}) =>
+    issuesCommentsList2: (owner, repo, number, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/issues/\${number}/comments\`,
         method: "GET",
@@ -1760,12 +1732,12 @@ export class Api extends HttpClient {
     /**
      * @description List events for an issue.
      *
-     * @name IssuesEventsDetail3
+     * @name IssuesEventsList2
      * @request GET:/repos/{owner}/{repo}/issues/{number}/events
-     * @originalName issuesEventsDetail
+     * @originalName issuesEventsList
      * @duplicate
      */
-    issuesEventsDetail3: (owner, repo, number, params = {}) =>
+    issuesEventsList2: (owner, repo, number, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/issues/\${number}/events\`,
         method: "GET",
@@ -1787,10 +1759,10 @@ export class Api extends HttpClient {
     /**
      * @description List labels on an issue.
      *
-     * @name IssuesLabelsDetail
+     * @name IssuesLabelsList
      * @request GET:/repos/{owner}/{repo}/issues/{number}/labels
      */
-    issuesLabelsDetail: (owner, repo, number, params = {}) =>
+    issuesLabelsList: (owner, repo, number, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/issues/\${number}/labels\`,
         method: "GET",
@@ -1842,10 +1814,10 @@ export class Api extends HttpClient {
     /**
      * @description Get list of keys.
      *
-     * @name KeysDetail
+     * @name KeysList
      * @request GET:/repos/{owner}/{repo}/keys
      */
-    keysDetail: (owner, repo, params = {}) =>
+    keysList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/keys\`,
         method: "GET",
@@ -1881,12 +1853,10 @@ export class Api extends HttpClient {
     /**
      * @description Get a key
      *
-     * @name KeysDetail2
+     * @name KeysDetail
      * @request GET:/repos/{owner}/{repo}/keys/{keyId}
-     * @originalName keysDetail
-     * @duplicate
      */
-    keysDetail2: (owner, repo, keyId, params = {}) =>
+    keysDetail: (owner, repo, keyId, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/keys/\${keyId}\`,
         method: "GET",
@@ -1896,10 +1866,10 @@ export class Api extends HttpClient {
     /**
      * @description List all labels for this repository.
      *
-     * @name LabelsDetail
+     * @name LabelsList
      * @request GET:/repos/{owner}/{repo}/labels
      */
-    labelsDetail: (owner, repo, params = {}) =>
+    labelsList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/labels\`,
         method: "GET",
@@ -1935,12 +1905,10 @@ export class Api extends HttpClient {
     /**
      * @description Get a single label.
      *
-     * @name LabelsDetail2
+     * @name LabelsDetail
      * @request GET:/repos/{owner}/{repo}/labels/{name}
-     * @originalName labelsDetail
-     * @duplicate
      */
-    labelsDetail2: (owner, repo, name, params = {}) =>
+    labelsDetail: (owner, repo, name, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/labels/\${name}\`,
         method: "GET",
@@ -1964,10 +1932,10 @@ export class Api extends HttpClient {
     /**
      * @description List languages. List languages for the specified repository. The value on the right of a language is the number of bytes of code written in that language.
      *
-     * @name LanguagesDetail
+     * @name LanguagesList
      * @request GET:/repos/{owner}/{repo}/languages
      */
-    languagesDetail: (owner, repo, params = {}) =>
+    languagesList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/languages\`,
         method: "GET",
@@ -1992,10 +1960,10 @@ export class Api extends HttpClient {
     /**
      * @description List milestones for a repository.
      *
-     * @name MilestonesDetail
+     * @name MilestonesList
      * @request GET:/repos/{owner}/{repo}/milestones
      */
-    milestonesDetail: (owner, repo, query, params = {}) =>
+    milestonesList: (owner, repo, query, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/milestones\`,
         method: "GET",
@@ -2032,12 +2000,10 @@ export class Api extends HttpClient {
     /**
      * @description Get a single milestone.
      *
-     * @name MilestonesDetail2
+     * @name MilestonesDetail
      * @request GET:/repos/{owner}/{repo}/milestones/{number}
-     * @originalName milestonesDetail
-     * @duplicate
      */
-    milestonesDetail2: (owner, repo, number, params = {}) =>
+    milestonesDetail: (owner, repo, number, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/milestones/\${number}\`,
         method: "GET",
@@ -2061,10 +2027,10 @@ export class Api extends HttpClient {
     /**
      * @description Get labels for every issue in a milestone.
      *
-     * @name MilestonesLabelsDetail
+     * @name MilestonesLabelsList
      * @request GET:/repos/{owner}/{repo}/milestones/{number}/labels
      */
-    milestonesLabelsDetail: (owner, repo, number, params = {}) =>
+    milestonesLabelsList: (owner, repo, number, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/milestones/\${number}/labels\`,
         method: "GET",
@@ -2074,10 +2040,10 @@ export class Api extends HttpClient {
     /**
      * @description List your notifications in a repository List all notifications for the current user.
      *
-     * @name NotificationsDetail
+     * @name NotificationsList
      * @request GET:/repos/{owner}/{repo}/notifications
      */
-    notificationsDetail: (owner, repo, query, params = {}) =>
+    notificationsList: (owner, repo, query, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/notifications\`,
         method: "GET",
@@ -2101,10 +2067,10 @@ export class Api extends HttpClient {
     /**
      * @description List pull requests.
      *
-     * @name PullsDetail
+     * @name PullsList
      * @request GET:/repos/{owner}/{repo}/pulls
      */
-    pullsDetail: (owner, repo, query, params = {}) =>
+    pullsList: (owner, repo, query, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/pulls\`,
         method: "GET",
@@ -2130,10 +2096,10 @@ export class Api extends HttpClient {
     /**
      * @description List comments in a repository. By default, Review Comments are ordered by ascending ID.
      *
-     * @name PullsCommentsDetail
+     * @name PullsCommentsList
      * @request GET:/repos/{owner}/{repo}/pulls/comments
      */
-    pullsCommentsDetail: (owner, repo, query, params = {}) =>
+    pullsCommentsList: (owner, repo, query, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/pulls/comments\`,
         method: "GET",
@@ -2156,12 +2122,10 @@ export class Api extends HttpClient {
     /**
      * @description Get a single comment.
      *
-     * @name PullsCommentsDetail2
+     * @name PullsCommentsDetail
      * @request GET:/repos/{owner}/{repo}/pulls/comments/{commentId}
-     * @originalName pullsCommentsDetail
-     * @duplicate
      */
-    pullsCommentsDetail2: (owner, repo, commentId, params = {}) =>
+    pullsCommentsDetail: (owner, repo, commentId, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/pulls/comments/\${commentId}\`,
         method: "GET",
@@ -2185,12 +2149,10 @@ export class Api extends HttpClient {
     /**
      * @description Get a single pull request.
      *
-     * @name PullsDetail2
+     * @name PullsDetail
      * @request GET:/repos/{owner}/{repo}/pulls/{number}
-     * @originalName pullsDetail
-     * @duplicate
      */
-    pullsDetail2: (owner, repo, number, params = {}) =>
+    pullsDetail: (owner, repo, number, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/pulls/\${number}\`,
         method: "GET",
@@ -2215,12 +2177,12 @@ export class Api extends HttpClient {
     /**
      * @description List comments on a pull request.
      *
-     * @name PullsCommentsDetail3
+     * @name PullsCommentsList2
      * @request GET:/repos/{owner}/{repo}/pulls/{number}/comments
-     * @originalName pullsCommentsDetail
+     * @originalName pullsCommentsList
      * @duplicate
      */
-    pullsCommentsDetail3: (owner, repo, number, params = {}) =>
+    pullsCommentsList2: (owner, repo, number, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/pulls/\${number}/comments\`,
         method: "GET",
@@ -2245,10 +2207,10 @@ export class Api extends HttpClient {
     /**
      * @description List commits on a pull request.
      *
-     * @name PullsCommitsDetail
+     * @name PullsCommitsList
      * @request GET:/repos/{owner}/{repo}/pulls/{number}/commits
      */
-    pullsCommitsDetail: (owner, repo, number, params = {}) =>
+    pullsCommitsList: (owner, repo, number, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/pulls/\${number}/commits\`,
         method: "GET",
@@ -2258,10 +2220,10 @@ export class Api extends HttpClient {
     /**
      * @description List pull requests files.
      *
-     * @name PullsFilesDetail
+     * @name PullsFilesList
      * @request GET:/repos/{owner}/{repo}/pulls/{number}/files
      */
-    pullsFilesDetail: (owner, repo, number, params = {}) =>
+    pullsFilesList: (owner, repo, number, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/pulls/\${number}/files\`,
         method: "GET",
@@ -2271,10 +2233,10 @@ export class Api extends HttpClient {
     /**
      * @description Get if a pull request has been merged.
      *
-     * @name PullsMergeDetail
+     * @name PullsMergeList
      * @request GET:/repos/{owner}/{repo}/pulls/{number}/merge
      */
-    pullsMergeDetail: (owner, repo, number, params = {}) =>
+    pullsMergeList: (owner, repo, number, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/pulls/\${number}/merge\`,
         method: "GET",
@@ -2298,10 +2260,10 @@ export class Api extends HttpClient {
     /**
      * @description Get the README. This method returns the preferred README for a repository.
      *
-     * @name ReadmeDetail
+     * @name ReadmeList
      * @request GET:/repos/{owner}/{repo}/readme
      */
-    readmeDetail: (owner, repo, query, params = {}) =>
+    readmeList: (owner, repo, query, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/readme\`,
         method: "GET",
@@ -2312,10 +2274,10 @@ export class Api extends HttpClient {
     /**
      * @description Users with push access to the repository will receive all releases (i.e., published releases and draft releases). Users with pull access will receive published releases only
      *
-     * @name ReleasesDetail
+     * @name ReleasesList
      * @request GET:/repos/{owner}/{repo}/releases
      */
-    releasesDetail: (owner, repo, params = {}) =>
+    releasesList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/releases\`,
         method: "GET",
@@ -2391,12 +2353,10 @@ export class Api extends HttpClient {
     /**
      * @description Get a single release
      *
-     * @name ReleasesDetail2
+     * @name ReleasesDetail
      * @request GET:/repos/{owner}/{repo}/releases/{id}
-     * @originalName releasesDetail
-     * @duplicate
      */
-    releasesDetail2: (owner, repo, id, params = {}) =>
+    releasesDetail: (owner, repo, id, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/releases/\${id}\`,
         method: "GET",
@@ -2420,12 +2380,10 @@ export class Api extends HttpClient {
     /**
      * @description List assets for a release
      *
-     * @name ReleasesAssetsDetail2
+     * @name ReleasesAssetsList
      * @request GET:/repos/{owner}/{repo}/releases/{id}/assets
-     * @originalName releasesAssetsDetail
-     * @duplicate
      */
-    releasesAssetsDetail2: (owner, repo, id, params = {}) =>
+    releasesAssetsList: (owner, repo, id, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/releases/\${id}/assets\`,
         method: "GET",
@@ -2435,10 +2393,10 @@ export class Api extends HttpClient {
     /**
      * @description List Stargazers.
      *
-     * @name StargazersDetail
+     * @name StargazersList
      * @request GET:/repos/{owner}/{repo}/stargazers
      */
-    stargazersDetail: (owner, repo, params = {}) =>
+    stargazersList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/stargazers\`,
         method: "GET",
@@ -2448,10 +2406,10 @@ export class Api extends HttpClient {
     /**
      * @description Get the number of additions and deletions per week. Returns a weekly aggregate of the number of additions and deletions pushed to a repository.
      *
-     * @name StatsCodeFrequencyDetail
+     * @name StatsCodeFrequencyList
      * @request GET:/repos/{owner}/{repo}/stats/code_frequency
      */
-    statsCodeFrequencyDetail: (owner, repo, params = {}) =>
+    statsCodeFrequencyList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/stats/code_frequency\`,
         method: "GET",
@@ -2461,10 +2419,10 @@ export class Api extends HttpClient {
     /**
      * @description Get the last year of commit activity data. Returns the last year of commit activity grouped by week. The days array is a group of commits per day, starting on Sunday.
      *
-     * @name StatsCommitActivityDetail
+     * @name StatsCommitActivityList
      * @request GET:/repos/{owner}/{repo}/stats/commit_activity
      */
-    statsCommitActivityDetail: (owner, repo, params = {}) =>
+    statsCommitActivityList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/stats/commit_activity\`,
         method: "GET",
@@ -2474,10 +2432,10 @@ export class Api extends HttpClient {
     /**
      * @description Get contributors list with additions, deletions, and commit counts.
      *
-     * @name StatsContributorsDetail
+     * @name StatsContributorsList
      * @request GET:/repos/{owner}/{repo}/stats/contributors
      */
-    statsContributorsDetail: (owner, repo, params = {}) =>
+    statsContributorsList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/stats/contributors\`,
         method: "GET",
@@ -2487,10 +2445,10 @@ export class Api extends HttpClient {
     /**
      * @description Get the weekly commit count for the repo owner and everyone else.
      *
-     * @name StatsParticipationDetail
+     * @name StatsParticipationList
      * @request GET:/repos/{owner}/{repo}/stats/participation
      */
-    statsParticipationDetail: (owner, repo, params = {}) =>
+    statsParticipationList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/stats/participation\`,
         method: "GET",
@@ -2500,10 +2458,10 @@ export class Api extends HttpClient {
     /**
      * @description Get the number of commits per hour in each day. Each array contains the day number, hour number, and number of commits 0-6 Sunday - Saturday 0-23 Hour of day Number of commits For example, [2, 14, 25] indicates that there were 25 total commits, during the 2.00pm hour on Tuesdays. All times are based on the time zone of individual commits.
      *
-     * @name StatsPunchCardDetail
+     * @name StatsPunchCardList
      * @request GET:/repos/{owner}/{repo}/stats/punch_card
      */
-    statsPunchCardDetail: (owner, repo, params = {}) =>
+    statsPunchCardList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/stats/punch_card\`,
         method: "GET",
@@ -2541,10 +2499,10 @@ export class Api extends HttpClient {
     /**
      * @description List watchers.
      *
-     * @name SubscribersDetail
+     * @name SubscribersList
      * @request GET:/repos/{owner}/{repo}/subscribers
      */
-    subscribersDetail: (owner, repo, params = {}) =>
+    subscribersList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/subscribers\`,
         method: "GET",
@@ -2566,10 +2524,10 @@ export class Api extends HttpClient {
     /**
      * @description Get a Repository Subscription.
      *
-     * @name SubscriptionDetail
+     * @name SubscriptionList
      * @request GET:/repos/{owner}/{repo}/subscription
      */
-    subscriptionDetail: (owner, repo, params = {}) =>
+    subscriptionList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/subscription\`,
         method: "GET",
@@ -2594,10 +2552,10 @@ export class Api extends HttpClient {
     /**
      * @description Get list of tags.
      *
-     * @name TagsDetail
+     * @name TagsList
      * @request GET:/repos/{owner}/{repo}/tags
      */
-    tagsDetail: (owner, repo, params = {}) =>
+    tagsList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/tags\`,
         method: "GET",
@@ -2607,10 +2565,10 @@ export class Api extends HttpClient {
     /**
      * @description Get list of teams
      *
-     * @name TeamsDetail
+     * @name TeamsList
      * @request GET:/repos/{owner}/{repo}/teams
      */
-    teamsDetail: (owner, repo, params = {}) =>
+    teamsList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/teams\`,
         method: "GET",
@@ -2620,10 +2578,10 @@ export class Api extends HttpClient {
     /**
      * @description List Stargazers. New implementation.
      *
-     * @name WatchersDetail
+     * @name WatchersList
      * @request GET:/repos/{owner}/{repo}/watchers
      */
-    watchersDetail: (owner, repo, params = {}) =>
+    watchersList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/watchers\`,
         method: "GET",
@@ -2763,10 +2721,10 @@ export class Api extends HttpClient {
     /**
      * @description List team members. In order to list members in a team, the authenticated user must be a member of the team.
      *
-     * @name MembersDetail
+     * @name MembersList
      * @request GET:/teams/{teamId}/members
      */
-    membersDetail: (teamId, params = {}) =>
+    membersList: (teamId, params = {}) =>
       this.request({
         path: \`/teams/\${teamId}/members\`,
         method: "GET",
@@ -2789,13 +2747,11 @@ export class Api extends HttpClient {
     /**
      * @description The "Get team member" API is deprecated and is scheduled for removal in the next major version of the API. We recommend using the Get team membership API instead. It allows you to get both active and pending memberships. Get team member. In order to get if a user is a member of a team, the authenticated user mus be a member of the team.
      *
-     * @name MembersDetail2
+     * @name MembersDetail
      * @request GET:/teams/{teamId}/members/{username}
      * @deprecated
-     * @originalName membersDetail
-     * @duplicate
      */
-    membersDetail2: (teamId, username, params = {}) =>
+    membersDetail: (teamId, username, params = {}) =>
       this.request({
         path: \`/teams/\${teamId}/members/\${username}\`,
         method: "GET",
@@ -2855,10 +2811,10 @@ export class Api extends HttpClient {
     /**
      * @description List team repos
      *
-     * @name ReposDetail
+     * @name ReposList
      * @request GET:/teams/{teamId}/repos
      */
-    reposDetail: (teamId, params = {}) =>
+    reposList: (teamId, params = {}) =>
       this.request({
         path: \`/teams/\${teamId}/repos\`,
         method: "GET",
@@ -2880,12 +2836,10 @@ export class Api extends HttpClient {
     /**
      * @description Check if a team manages a repository
      *
-     * @name ReposDetail2
+     * @name ReposDetail
      * @request GET:/teams/{teamId}/repos/{owner}/{repo}
-     * @originalName reposDetail
-     * @duplicate
      */
-    reposDetail2: (teamId, owner, repo, params = {}) =>
+    reposDetail: (teamId, owner, repo, params = {}) =>
       this.request({
         path: \`/teams/\${teamId}/repos/\${owner}/\${repo}\`,
         method: "GET",
@@ -3288,10 +3242,10 @@ export class Api extends HttpClient {
     /**
      * @description If you are authenticated as the given user, you will see your private events. Otherwise, you'll only see public events.
      *
-     * @name EventsDetail
+     * @name EventsList
      * @request GET:/users/{username}/events
      */
-    eventsDetail: (username, params = {}) =>
+    eventsList: (username, params = {}) =>
       this.request({
         path: \`/users/\${username}/events\`,
         method: "GET",
@@ -3312,10 +3266,10 @@ export class Api extends HttpClient {
     /**
      * @description List a user's followers
      *
-     * @name FollowersDetail
+     * @name FollowersList
      * @request GET:/users/{username}/followers
      */
-    followersDetail: (username, params = {}) =>
+    followersList: (username, params = {}) =>
       this.request({
         path: \`/users/\${username}/followers\`,
         method: "GET",
@@ -3337,10 +3291,10 @@ export class Api extends HttpClient {
     /**
      * @description List a users gists.
      *
-     * @name GistsDetail
+     * @name GistsList
      * @request GET:/users/{username}/gists
      */
-    gistsDetail: (username, query, params = {}) =>
+    gistsList: (username, query, params = {}) =>
       this.request({
         path: \`/users/\${username}/gists\`,
         method: "GET",
@@ -3351,10 +3305,10 @@ export class Api extends HttpClient {
     /**
      * @description List public keys for a user. Lists the verified public keys for a user. This is accessible by anyone.
      *
-     * @name KeysDetail
+     * @name KeysList
      * @request GET:/users/{username}/keys
      */
-    keysDetail: (username, params = {}) =>
+    keysList: (username, params = {}) =>
       this.request({
         path: \`/users/\${username}/keys\`,
         method: "GET",
@@ -3364,10 +3318,10 @@ export class Api extends HttpClient {
     /**
      * @description List all public organizations for a user.
      *
-     * @name OrgsDetail
+     * @name OrgsList
      * @request GET:/users/{username}/orgs
      */
-    orgsDetail: (username, params = {}) =>
+    orgsList: (username, params = {}) =>
       this.request({
         path: \`/users/\${username}/orgs\`,
         method: "GET",
@@ -3377,10 +3331,10 @@ export class Api extends HttpClient {
     /**
      * @description These are events that you'll only see public events.
      *
-     * @name ReceivedEventsDetail
+     * @name ReceivedEventsList
      * @request GET:/users/{username}/received_events
      */
-    receivedEventsDetail: (username, params = {}) =>
+    receivedEventsList: (username, params = {}) =>
       this.request({
         path: \`/users/\${username}/received_events\`,
         method: "GET",
@@ -3389,10 +3343,10 @@ export class Api extends HttpClient {
     /**
      * @description List public events that a user has received
      *
-     * @name ReceivedEventsPublicDetail
+     * @name ReceivedEventsPublicList
      * @request GET:/users/{username}/received_events/public
      */
-    receivedEventsPublicDetail: (username, params = {}) =>
+    receivedEventsPublicList: (username, params = {}) =>
       this.request({
         path: \`/users/\${username}/received_events/public\`,
         method: "GET",
@@ -3401,10 +3355,10 @@ export class Api extends HttpClient {
     /**
      * @description List public repositories for the specified user.
      *
-     * @name ReposDetail
+     * @name ReposList
      * @request GET:/users/{username}/repos
      */
-    reposDetail: (username, query, params = {}) =>
+    reposList: (username, query, params = {}) =>
       this.request({
         path: \`/users/\${username}/repos\`,
         method: "GET",
@@ -3415,10 +3369,10 @@ export class Api extends HttpClient {
     /**
      * @description List repositories being starred by a user.
      *
-     * @name StarredDetail
+     * @name StarredList
      * @request GET:/users/{username}/starred
      */
-    starredDetail: (username, params = {}) =>
+    starredList: (username, params = {}) =>
       this.request({
         path: \`/users/\${username}/starred\`,
         method: "GET",
@@ -3427,10 +3381,10 @@ export class Api extends HttpClient {
     /**
      * @description List repositories being watched by a user.
      *
-     * @name SubscriptionsDetail
+     * @name SubscriptionsList
      * @request GET:/users/{username}/subscriptions
      */
-    subscriptionsDetail: (username, params = {}) =>
+    subscriptionsList: (username, params = {}) =>
       this.request({
         path: \`/users/\${username}/subscriptions\`,
         method: "GET",

--- a/tests/spec/jsAxios/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/jsAxios/__snapshots__/basic.test.ts.snap
@@ -311,10 +311,10 @@ export class Api extends HttpClient {
     /**
      * @description List comments on a gist.
      *
-     * @name CommentsDetail
+     * @name CommentsList
      * @request GET:/gists/{id}/comments
      */
-    commentsDetail: (id, params = {}) =>
+    commentsList: (id, params = {}) =>
       this.request({
         path: \`/gists/\${id}/comments\`,
         method: "GET",
@@ -350,12 +350,10 @@ export class Api extends HttpClient {
     /**
      * @description Get a single comment.
      *
-     * @name CommentsDetail2
+     * @name CommentsDetail
      * @request GET:/gists/{id}/comments/{commentId}
-     * @originalName commentsDetail
-     * @duplicate
      */
-    commentsDetail2: (id, commentId, params = {}) =>
+    commentsDetail: (id, commentId, params = {}) =>
       this.request({
         path: \`/gists/\${id}/comments/\${commentId}\`,
         method: "GET",
@@ -404,10 +402,10 @@ export class Api extends HttpClient {
     /**
      * @description Check if a gist is starred.
      *
-     * @name StarDetail
+     * @name StarList
      * @request GET:/gists/{id}/star
      */
-    starDetail: (id, params = {}) =>
+    starList: (id, params = {}) =>
       this.request({
         path: \`/gists/\${id}/star\`,
         method: "GET",
@@ -578,10 +576,10 @@ export class Api extends HttpClient {
     /**
      * @description List public events for a network of repositories.
      *
-     * @name EventsDetail
+     * @name EventsList
      * @request GET:/networks/{owner}/{repo}/events
      */
-    eventsDetail: (owner, repo, params = {}) =>
+    eventsList: (owner, repo, params = {}) =>
       this.request({
         path: \`/networks/\${owner}/\${repo}/events\`,
         method: "GET",
@@ -657,10 +655,10 @@ export class Api extends HttpClient {
     /**
      * @description Get a Thread Subscription.
      *
-     * @name ThreadsSubscriptionDetail
+     * @name ThreadsSubscriptionList
      * @request GET:/notifications/threads/{id}/subscription
      */
-    threadsSubscriptionDetail: (id, params = {}) =>
+    threadsSubscriptionList: (id, params = {}) =>
       this.request({
         path: \`/notifications/threads/\${id}/subscription\`,
         method: "GET",
@@ -715,10 +713,10 @@ export class Api extends HttpClient {
     /**
      * @description List public events for an organization.
      *
-     * @name EventsDetail
+     * @name EventsList
      * @request GET:/orgs/{org}/events
      */
-    eventsDetail: (org, params = {}) =>
+    eventsList: (org, params = {}) =>
       this.request({
         path: \`/orgs/\${org}/events\`,
         method: "GET",
@@ -728,10 +726,10 @@ export class Api extends HttpClient {
     /**
      * @description List issues. List all issues for a given organization for the authenticated user.
      *
-     * @name IssuesDetail
+     * @name IssuesList
      * @request GET:/orgs/{org}/issues
      */
-    issuesDetail: (org, query, params = {}) =>
+    issuesList: (org, query, params = {}) =>
       this.request({
         path: \`/orgs/\${org}/issues\`,
         method: "GET",
@@ -742,10 +740,10 @@ export class Api extends HttpClient {
     /**
      * @description Members list. List all users who are members of an organization. A member is a user tha belongs to at least 1 team in the organization. If the authenticated user is also an owner of this organization then both concealed and public members will be returned. If the requester is not an owner of the organization the query will be redirected to the public members list.
      *
-     * @name MembersDetail
+     * @name MembersList
      * @request GET:/orgs/{org}/members
      */
-    membersDetail: (org, params = {}) =>
+    membersList: (org, params = {}) =>
       this.request({
         path: \`/orgs/\${org}/members\`,
         method: "GET",
@@ -767,12 +765,10 @@ export class Api extends HttpClient {
     /**
      * @description Check if a user is, publicly or privately, a member of the organization.
      *
-     * @name MembersDetail2
+     * @name MembersDetail
      * @request GET:/orgs/{org}/members/{username}
-     * @originalName membersDetail
-     * @duplicate
      */
-    membersDetail2: (org, username, params = {}) =>
+    membersDetail: (org, username, params = {}) =>
       this.request({
         path: \`/orgs/\${org}/members/\${username}\`,
         method: "GET",
@@ -781,10 +777,10 @@ export class Api extends HttpClient {
     /**
      * @description Public members list. Members of an organization can choose to have their membership publicized or not.
      *
-     * @name PublicMembersDetail
+     * @name PublicMembersList
      * @request GET:/orgs/{org}/public_members
      */
-    publicMembersDetail: (org, params = {}) =>
+    publicMembersList: (org, params = {}) =>
       this.request({
         path: \`/orgs/\${org}/public_members\`,
         method: "GET",
@@ -806,12 +802,10 @@ export class Api extends HttpClient {
     /**
      * @description Check public membership.
      *
-     * @name PublicMembersDetail2
+     * @name PublicMembersDetail
      * @request GET:/orgs/{org}/public_members/{username}
-     * @originalName publicMembersDetail
-     * @duplicate
      */
-    publicMembersDetail2: (org, username, params = {}) =>
+    publicMembersDetail: (org, username, params = {}) =>
       this.request({
         path: \`/orgs/\${org}/public_members/\${username}\`,
         method: "GET",
@@ -832,10 +826,10 @@ export class Api extends HttpClient {
     /**
      * @description List repositories for the specified org.
      *
-     * @name ReposDetail
+     * @name ReposList
      * @request GET:/orgs/{org}/repos
      */
-    reposDetail: (org, query, params = {}) =>
+    reposList: (org, query, params = {}) =>
       this.request({
         path: \`/orgs/\${org}/repos\`,
         method: "GET",
@@ -860,10 +854,10 @@ export class Api extends HttpClient {
     /**
      * @description List teams.
      *
-     * @name TeamsDetail
+     * @name TeamsList
      * @request GET:/orgs/{org}/teams
      */
-    teamsDetail: (org, params = {}) =>
+    teamsList: (org, params = {}) =>
       this.request({
         path: \`/orgs/\${org}/teams\`,
         method: "GET",
@@ -945,10 +939,10 @@ export class Api extends HttpClient {
     /**
      * @description List assignees. This call lists all the available assignees (owner + collaborators) to which issues may be assigned.
      *
-     * @name AssigneesDetail
+     * @name AssigneesList
      * @request GET:/repos/{owner}/{repo}/assignees
      */
-    assigneesDetail: (owner, repo, params = {}) =>
+    assigneesList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/assignees\`,
         method: "GET",
@@ -958,12 +952,10 @@ export class Api extends HttpClient {
     /**
      * @description Check assignee. You may also check to see if a particular user is an assignee for a repository.
      *
-     * @name AssigneesDetail2
+     * @name AssigneesDetail
      * @request GET:/repos/{owner}/{repo}/assignees/{assignee}
-     * @originalName assigneesDetail
-     * @duplicate
      */
-    assigneesDetail2: (owner, repo, assignee, params = {}) =>
+    assigneesDetail: (owner, repo, assignee, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/assignees/\${assignee}\`,
         method: "GET",
@@ -972,10 +964,10 @@ export class Api extends HttpClient {
     /**
      * @description Get list of branches
      *
-     * @name BranchesDetail
+     * @name BranchesList
      * @request GET:/repos/{owner}/{repo}/branches
      */
-    branchesDetail: (owner, repo, params = {}) =>
+    branchesList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/branches\`,
         method: "GET",
@@ -985,12 +977,10 @@ export class Api extends HttpClient {
     /**
      * @description Get Branch
      *
-     * @name BranchesDetail2
+     * @name BranchesDetail
      * @request GET:/repos/{owner}/{repo}/branches/{branch}
-     * @originalName branchesDetail
-     * @duplicate
      */
-    branchesDetail2: (owner, repo, branch, params = {}) =>
+    branchesDetail: (owner, repo, branch, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/branches/\${branch}\`,
         method: "GET",
@@ -1000,10 +990,10 @@ export class Api extends HttpClient {
     /**
      * @description List. When authenticating as an organization owner of an organization-owned repository, all organization owners are included in the list of collaborators. Otherwise, only users with access to the repository are returned in the collaborators list.
      *
-     * @name CollaboratorsDetail
+     * @name CollaboratorsList
      * @request GET:/repos/{owner}/{repo}/collaborators
      */
-    collaboratorsDetail: (owner, repo, params = {}) =>
+    collaboratorsList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/collaborators\`,
         method: "GET",
@@ -1025,12 +1015,10 @@ export class Api extends HttpClient {
     /**
      * @description Check if user is a collaborator
      *
-     * @name CollaboratorsDetail2
+     * @name CollaboratorsDetail
      * @request GET:/repos/{owner}/{repo}/collaborators/{user}
-     * @originalName collaboratorsDetail
-     * @duplicate
      */
-    collaboratorsDetail2: (owner, repo, user, params = {}) =>
+    collaboratorsDetail: (owner, repo, user, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/collaborators/\${user}\`,
         method: "GET",
@@ -1051,10 +1039,10 @@ export class Api extends HttpClient {
     /**
      * @description List commit comments for a repository. Comments are ordered by ascending ID.
      *
-     * @name CommentsDetail
+     * @name CommentsList
      * @request GET:/repos/{owner}/{repo}/comments
      */
-    commentsDetail: (owner, repo, params = {}) =>
+    commentsList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/comments\`,
         method: "GET",
@@ -1076,12 +1064,10 @@ export class Api extends HttpClient {
     /**
      * @description Get a single commit comment.
      *
-     * @name CommentsDetail2
+     * @name CommentsDetail
      * @request GET:/repos/{owner}/{repo}/comments/{commentId}
-     * @originalName commentsDetail
-     * @duplicate
      */
-    commentsDetail2: (owner, repo, commentId, params = {}) =>
+    commentsDetail: (owner, repo, commentId, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/comments/\${commentId}\`,
         method: "GET",
@@ -1105,10 +1091,10 @@ export class Api extends HttpClient {
     /**
      * @description List commits on a repository.
      *
-     * @name CommitsDetail
+     * @name CommitsList
      * @request GET:/repos/{owner}/{repo}/commits
      */
-    commitsDetail: (owner, repo, query, params = {}) =>
+    commitsList: (owner, repo, query, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/commits\`,
         method: "GET",
@@ -1119,10 +1105,10 @@ export class Api extends HttpClient {
     /**
      * @description Get the combined Status for a specific Ref The Combined status endpoint is currently available for developers to preview. During the preview period, the API may change without advance notice. Please see the blog post for full details. To access this endpoint during the preview period, you must provide a custom media type in the Accept header: application/vnd.github.she-hulk-preview+json
      *
-     * @name CommitsStatusDetail
+     * @name CommitsStatusList
      * @request GET:/repos/{owner}/{repo}/commits/{ref}/status
      */
-    commitsStatusDetail: (owner, repo, ref, params = {}) =>
+    commitsStatusList: (owner, repo, ref, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/commits/\${ref}/status\`,
         method: "GET",
@@ -1132,12 +1118,10 @@ export class Api extends HttpClient {
     /**
      * @description Get a single commit.
      *
-     * @name CommitsDetail2
+     * @name CommitsDetail
      * @request GET:/repos/{owner}/{repo}/commits/{shaCode}
-     * @originalName commitsDetail
-     * @duplicate
      */
-    commitsDetail2: (owner, repo, shaCode, params = {}) =>
+    commitsDetail: (owner, repo, shaCode, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/commits/\${shaCode}\`,
         method: "GET",
@@ -1147,10 +1131,10 @@ export class Api extends HttpClient {
     /**
      * @description List comments for a single commitList comments for a single commit.
      *
-     * @name CommitsCommentsDetail
+     * @name CommitsCommentsList
      * @request GET:/repos/{owner}/{repo}/commits/{shaCode}/comments
      */
-    commitsCommentsDetail: (owner, repo, shaCode, params = {}) =>
+    commitsCommentsList: (owner, repo, shaCode, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/commits/\${shaCode}/comments\`,
         method: "GET",
@@ -1232,10 +1216,10 @@ export class Api extends HttpClient {
     /**
      * @description Get list of contributors.
      *
-     * @name ContributorsDetail
+     * @name ContributorsList
      * @request GET:/repos/{owner}/{repo}/contributors
      */
-    contributorsDetail: (owner, repo, query, params = {}) =>
+    contributorsList: (owner, repo, query, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/contributors\`,
         method: "GET",
@@ -1246,10 +1230,10 @@ export class Api extends HttpClient {
     /**
      * @description Users with pull access can view deployments for a repository
      *
-     * @name DeploymentsDetail
+     * @name DeploymentsList
      * @request GET:/repos/{owner}/{repo}/deployments
      */
-    deploymentsDetail: (owner, repo, params = {}) =>
+    deploymentsList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/deployments\`,
         method: "GET",
@@ -1274,10 +1258,10 @@ export class Api extends HttpClient {
     /**
      * @description Users with pull access can view deployment statuses for a deployment
      *
-     * @name DeploymentsStatusesDetail
+     * @name DeploymentsStatusesList
      * @request GET:/repos/{owner}/{repo}/deployments/{id}/statuses
      */
-    deploymentsStatusesDetail: (owner, repo, id, params = {}) =>
+    deploymentsStatusesList: (owner, repo, id, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/deployments/\${id}/statuses\`,
         method: "GET",
@@ -1301,11 +1285,11 @@ export class Api extends HttpClient {
     /**
      * @description Deprecated. List downloads for a repository.
      *
-     * @name DownloadsDetail
+     * @name DownloadsList
      * @request GET:/repos/{owner}/{repo}/downloads
      * @deprecated
      */
-    downloadsDetail: (owner, repo, params = {}) =>
+    downloadsList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/downloads\`,
         method: "GET",
@@ -1328,13 +1312,11 @@ export class Api extends HttpClient {
     /**
      * @description Deprecated. Get a single download.
      *
-     * @name DownloadsDetail2
+     * @name DownloadsDetail
      * @request GET:/repos/{owner}/{repo}/downloads/{downloadId}
      * @deprecated
-     * @originalName downloadsDetail
-     * @duplicate
      */
-    downloadsDetail2: (owner, repo, downloadId, params = {}) =>
+    downloadsDetail: (owner, repo, downloadId, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/downloads/\${downloadId}\`,
         method: "GET",
@@ -1344,10 +1326,10 @@ export class Api extends HttpClient {
     /**
      * @description Get list of repository events.
      *
-     * @name EventsDetail
+     * @name EventsList
      * @request GET:/repos/{owner}/{repo}/events
      */
-    eventsDetail: (owner, repo, params = {}) =>
+    eventsList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/events\`,
         method: "GET",
@@ -1357,10 +1339,10 @@ export class Api extends HttpClient {
     /**
      * @description List forks.
      *
-     * @name ForksDetail
+     * @name ForksList
      * @request GET:/repos/{owner}/{repo}/forks
      */
-    forksDetail: (owner, repo, query, params = {}) =>
+    forksList: (owner, repo, query, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/forks\`,
         method: "GET",
@@ -1442,10 +1424,10 @@ export class Api extends HttpClient {
     /**
      * @description Get all References
      *
-     * @name GitRefsDetail
+     * @name GitRefsList
      * @request GET:/repos/{owner}/{repo}/git/refs
      */
-    gitRefsDetail: (owner, repo, params = {}) =>
+    gitRefsList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/git/refs\`,
         method: "GET",
@@ -1482,12 +1464,10 @@ export class Api extends HttpClient {
     /**
      * @description Get a Reference
      *
-     * @name GitRefsDetail2
+     * @name GitRefsDetail
      * @request GET:/repos/{owner}/{repo}/git/refs/{ref}
-     * @originalName gitRefsDetail
-     * @duplicate
      */
-    gitRefsDetail2: (owner, repo, ref, params = {}) =>
+    gitRefsDetail: (owner, repo, ref, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/git/refs/\${ref}\`,
         method: "GET",
@@ -1569,10 +1549,10 @@ export class Api extends HttpClient {
     /**
      * @description Get list of hooks.
      *
-     * @name HooksDetail
+     * @name HooksList
      * @request GET:/repos/{owner}/{repo}/hooks
      */
-    hooksDetail: (owner, repo, params = {}) =>
+    hooksList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/hooks\`,
         method: "GET",
@@ -1608,12 +1588,10 @@ export class Api extends HttpClient {
     /**
      * @description Get single hook.
      *
-     * @name HooksDetail2
+     * @name HooksDetail
      * @request GET:/repos/{owner}/{repo}/hooks/{hookId}
-     * @originalName hooksDetail
-     * @duplicate
      */
-    hooksDetail2: (owner, repo, hookId, params = {}) =>
+    hooksDetail: (owner, repo, hookId, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/hooks/\${hookId}\`,
         method: "GET",
@@ -1649,10 +1627,10 @@ export class Api extends HttpClient {
     /**
      * @description List issues for a repository.
      *
-     * @name IssuesDetail
+     * @name IssuesList
      * @request GET:/repos/{owner}/{repo}/issues
      */
-    issuesDetail: (owner, repo, query, params = {}) =>
+    issuesList: (owner, repo, query, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/issues\`,
         method: "GET",
@@ -1677,10 +1655,10 @@ export class Api extends HttpClient {
     /**
      * @description List comments in a repository.
      *
-     * @name IssuesCommentsDetail
+     * @name IssuesCommentsList
      * @request GET:/repos/{owner}/{repo}/issues/comments
      */
-    issuesCommentsDetail: (owner, repo, query, params = {}) =>
+    issuesCommentsList: (owner, repo, query, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/issues/comments\`,
         method: "GET",
@@ -1703,12 +1681,10 @@ export class Api extends HttpClient {
     /**
      * @description Get a single comment.
      *
-     * @name IssuesCommentsDetail2
+     * @name IssuesCommentsDetail
      * @request GET:/repos/{owner}/{repo}/issues/comments/{commentId}
-     * @originalName issuesCommentsDetail
-     * @duplicate
      */
-    issuesCommentsDetail2: (owner, repo, commentId, params = {}) =>
+    issuesCommentsDetail: (owner, repo, commentId, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/issues/comments/\${commentId}\`,
         method: "GET",
@@ -1732,10 +1708,10 @@ export class Api extends HttpClient {
     /**
      * @description List issue events for a repository.
      *
-     * @name IssuesEventsDetail
+     * @name IssuesEventsList
      * @request GET:/repos/{owner}/{repo}/issues/events
      */
-    issuesEventsDetail: (owner, repo, params = {}) =>
+    issuesEventsList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/issues/events\`,
         method: "GET",
@@ -1745,12 +1721,10 @@ export class Api extends HttpClient {
     /**
      * @description Get a single event.
      *
-     * @name IssuesEventsDetail2
+     * @name IssuesEventsDetail
      * @request GET:/repos/{owner}/{repo}/issues/events/{eventId}
-     * @originalName issuesEventsDetail
-     * @duplicate
      */
-    issuesEventsDetail2: (owner, repo, eventId, params = {}) =>
+    issuesEventsDetail: (owner, repo, eventId, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/issues/events/\${eventId}\`,
         method: "GET",
@@ -1760,12 +1734,10 @@ export class Api extends HttpClient {
     /**
      * @description Get a single issue
      *
-     * @name IssuesDetail2
+     * @name IssuesDetail
      * @request GET:/repos/{owner}/{repo}/issues/{number}
-     * @originalName issuesDetail
-     * @duplicate
      */
-    issuesDetail2: (owner, repo, number, params = {}) =>
+    issuesDetail: (owner, repo, number, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/issues/\${number}\`,
         method: "GET",
@@ -1789,12 +1761,12 @@ export class Api extends HttpClient {
     /**
      * @description List comments on an issue.
      *
-     * @name IssuesCommentsDetail3
+     * @name IssuesCommentsList2
      * @request GET:/repos/{owner}/{repo}/issues/{number}/comments
-     * @originalName issuesCommentsDetail
+     * @originalName issuesCommentsList
      * @duplicate
      */
-    issuesCommentsDetail3: (owner, repo, number, params = {}) =>
+    issuesCommentsList2: (owner, repo, number, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/issues/\${number}/comments\`,
         method: "GET",
@@ -1818,12 +1790,12 @@ export class Api extends HttpClient {
     /**
      * @description List events for an issue.
      *
-     * @name IssuesEventsDetail3
+     * @name IssuesEventsList2
      * @request GET:/repos/{owner}/{repo}/issues/{number}/events
-     * @originalName issuesEventsDetail
+     * @originalName issuesEventsList
      * @duplicate
      */
-    issuesEventsDetail3: (owner, repo, number, params = {}) =>
+    issuesEventsList2: (owner, repo, number, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/issues/\${number}/events\`,
         method: "GET",
@@ -1845,10 +1817,10 @@ export class Api extends HttpClient {
     /**
      * @description List labels on an issue.
      *
-     * @name IssuesLabelsDetail
+     * @name IssuesLabelsList
      * @request GET:/repos/{owner}/{repo}/issues/{number}/labels
      */
-    issuesLabelsDetail: (owner, repo, number, params = {}) =>
+    issuesLabelsList: (owner, repo, number, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/issues/\${number}/labels\`,
         method: "GET",
@@ -1900,10 +1872,10 @@ export class Api extends HttpClient {
     /**
      * @description Get list of keys.
      *
-     * @name KeysDetail
+     * @name KeysList
      * @request GET:/repos/{owner}/{repo}/keys
      */
-    keysDetail: (owner, repo, params = {}) =>
+    keysList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/keys\`,
         method: "GET",
@@ -1939,12 +1911,10 @@ export class Api extends HttpClient {
     /**
      * @description Get a key
      *
-     * @name KeysDetail2
+     * @name KeysDetail
      * @request GET:/repos/{owner}/{repo}/keys/{keyId}
-     * @originalName keysDetail
-     * @duplicate
      */
-    keysDetail2: (owner, repo, keyId, params = {}) =>
+    keysDetail: (owner, repo, keyId, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/keys/\${keyId}\`,
         method: "GET",
@@ -1954,10 +1924,10 @@ export class Api extends HttpClient {
     /**
      * @description List all labels for this repository.
      *
-     * @name LabelsDetail
+     * @name LabelsList
      * @request GET:/repos/{owner}/{repo}/labels
      */
-    labelsDetail: (owner, repo, params = {}) =>
+    labelsList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/labels\`,
         method: "GET",
@@ -1993,12 +1963,10 @@ export class Api extends HttpClient {
     /**
      * @description Get a single label.
      *
-     * @name LabelsDetail2
+     * @name LabelsDetail
      * @request GET:/repos/{owner}/{repo}/labels/{name}
-     * @originalName labelsDetail
-     * @duplicate
      */
-    labelsDetail2: (owner, repo, name, params = {}) =>
+    labelsDetail: (owner, repo, name, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/labels/\${name}\`,
         method: "GET",
@@ -2022,10 +1990,10 @@ export class Api extends HttpClient {
     /**
      * @description List languages. List languages for the specified repository. The value on the right of a language is the number of bytes of code written in that language.
      *
-     * @name LanguagesDetail
+     * @name LanguagesList
      * @request GET:/repos/{owner}/{repo}/languages
      */
-    languagesDetail: (owner, repo, params = {}) =>
+    languagesList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/languages\`,
         method: "GET",
@@ -2050,10 +2018,10 @@ export class Api extends HttpClient {
     /**
      * @description List milestones for a repository.
      *
-     * @name MilestonesDetail
+     * @name MilestonesList
      * @request GET:/repos/{owner}/{repo}/milestones
      */
-    milestonesDetail: (owner, repo, query, params = {}) =>
+    milestonesList: (owner, repo, query, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/milestones\`,
         method: "GET",
@@ -2090,12 +2058,10 @@ export class Api extends HttpClient {
     /**
      * @description Get a single milestone.
      *
-     * @name MilestonesDetail2
+     * @name MilestonesDetail
      * @request GET:/repos/{owner}/{repo}/milestones/{number}
-     * @originalName milestonesDetail
-     * @duplicate
      */
-    milestonesDetail2: (owner, repo, number, params = {}) =>
+    milestonesDetail: (owner, repo, number, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/milestones/\${number}\`,
         method: "GET",
@@ -2119,10 +2085,10 @@ export class Api extends HttpClient {
     /**
      * @description Get labels for every issue in a milestone.
      *
-     * @name MilestonesLabelsDetail
+     * @name MilestonesLabelsList
      * @request GET:/repos/{owner}/{repo}/milestones/{number}/labels
      */
-    milestonesLabelsDetail: (owner, repo, number, params = {}) =>
+    milestonesLabelsList: (owner, repo, number, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/milestones/\${number}/labels\`,
         method: "GET",
@@ -2132,10 +2098,10 @@ export class Api extends HttpClient {
     /**
      * @description List your notifications in a repository List all notifications for the current user.
      *
-     * @name NotificationsDetail
+     * @name NotificationsList
      * @request GET:/repos/{owner}/{repo}/notifications
      */
-    notificationsDetail: (owner, repo, query, params = {}) =>
+    notificationsList: (owner, repo, query, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/notifications\`,
         method: "GET",
@@ -2159,10 +2125,10 @@ export class Api extends HttpClient {
     /**
      * @description List pull requests.
      *
-     * @name PullsDetail
+     * @name PullsList
      * @request GET:/repos/{owner}/{repo}/pulls
      */
-    pullsDetail: (owner, repo, query, params = {}) =>
+    pullsList: (owner, repo, query, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/pulls\`,
         method: "GET",
@@ -2188,10 +2154,10 @@ export class Api extends HttpClient {
     /**
      * @description List comments in a repository. By default, Review Comments are ordered by ascending ID.
      *
-     * @name PullsCommentsDetail
+     * @name PullsCommentsList
      * @request GET:/repos/{owner}/{repo}/pulls/comments
      */
-    pullsCommentsDetail: (owner, repo, query, params = {}) =>
+    pullsCommentsList: (owner, repo, query, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/pulls/comments\`,
         method: "GET",
@@ -2214,12 +2180,10 @@ export class Api extends HttpClient {
     /**
      * @description Get a single comment.
      *
-     * @name PullsCommentsDetail2
+     * @name PullsCommentsDetail
      * @request GET:/repos/{owner}/{repo}/pulls/comments/{commentId}
-     * @originalName pullsCommentsDetail
-     * @duplicate
      */
-    pullsCommentsDetail2: (owner, repo, commentId, params = {}) =>
+    pullsCommentsDetail: (owner, repo, commentId, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/pulls/comments/\${commentId}\`,
         method: "GET",
@@ -2243,12 +2207,10 @@ export class Api extends HttpClient {
     /**
      * @description Get a single pull request.
      *
-     * @name PullsDetail2
+     * @name PullsDetail
      * @request GET:/repos/{owner}/{repo}/pulls/{number}
-     * @originalName pullsDetail
-     * @duplicate
      */
-    pullsDetail2: (owner, repo, number, params = {}) =>
+    pullsDetail: (owner, repo, number, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/pulls/\${number}\`,
         method: "GET",
@@ -2273,12 +2235,12 @@ export class Api extends HttpClient {
     /**
      * @description List comments on a pull request.
      *
-     * @name PullsCommentsDetail3
+     * @name PullsCommentsList2
      * @request GET:/repos/{owner}/{repo}/pulls/{number}/comments
-     * @originalName pullsCommentsDetail
+     * @originalName pullsCommentsList
      * @duplicate
      */
-    pullsCommentsDetail3: (owner, repo, number, params = {}) =>
+    pullsCommentsList2: (owner, repo, number, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/pulls/\${number}/comments\`,
         method: "GET",
@@ -2303,10 +2265,10 @@ export class Api extends HttpClient {
     /**
      * @description List commits on a pull request.
      *
-     * @name PullsCommitsDetail
+     * @name PullsCommitsList
      * @request GET:/repos/{owner}/{repo}/pulls/{number}/commits
      */
-    pullsCommitsDetail: (owner, repo, number, params = {}) =>
+    pullsCommitsList: (owner, repo, number, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/pulls/\${number}/commits\`,
         method: "GET",
@@ -2316,10 +2278,10 @@ export class Api extends HttpClient {
     /**
      * @description List pull requests files.
      *
-     * @name PullsFilesDetail
+     * @name PullsFilesList
      * @request GET:/repos/{owner}/{repo}/pulls/{number}/files
      */
-    pullsFilesDetail: (owner, repo, number, params = {}) =>
+    pullsFilesList: (owner, repo, number, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/pulls/\${number}/files\`,
         method: "GET",
@@ -2329,10 +2291,10 @@ export class Api extends HttpClient {
     /**
      * @description Get if a pull request has been merged.
      *
-     * @name PullsMergeDetail
+     * @name PullsMergeList
      * @request GET:/repos/{owner}/{repo}/pulls/{number}/merge
      */
-    pullsMergeDetail: (owner, repo, number, params = {}) =>
+    pullsMergeList: (owner, repo, number, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/pulls/\${number}/merge\`,
         method: "GET",
@@ -2356,10 +2318,10 @@ export class Api extends HttpClient {
     /**
      * @description Get the README. This method returns the preferred README for a repository.
      *
-     * @name ReadmeDetail
+     * @name ReadmeList
      * @request GET:/repos/{owner}/{repo}/readme
      */
-    readmeDetail: (owner, repo, query, params = {}) =>
+    readmeList: (owner, repo, query, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/readme\`,
         method: "GET",
@@ -2370,10 +2332,10 @@ export class Api extends HttpClient {
     /**
      * @description Users with push access to the repository will receive all releases (i.e., published releases and draft releases). Users with pull access will receive published releases only
      *
-     * @name ReleasesDetail
+     * @name ReleasesList
      * @request GET:/repos/{owner}/{repo}/releases
      */
-    releasesDetail: (owner, repo, params = {}) =>
+    releasesList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/releases\`,
         method: "GET",
@@ -2449,12 +2411,10 @@ export class Api extends HttpClient {
     /**
      * @description Get a single release
      *
-     * @name ReleasesDetail2
+     * @name ReleasesDetail
      * @request GET:/repos/{owner}/{repo}/releases/{id}
-     * @originalName releasesDetail
-     * @duplicate
      */
-    releasesDetail2: (owner, repo, id, params = {}) =>
+    releasesDetail: (owner, repo, id, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/releases/\${id}\`,
         method: "GET",
@@ -2478,12 +2438,10 @@ export class Api extends HttpClient {
     /**
      * @description List assets for a release
      *
-     * @name ReleasesAssetsDetail2
+     * @name ReleasesAssetsList
      * @request GET:/repos/{owner}/{repo}/releases/{id}/assets
-     * @originalName releasesAssetsDetail
-     * @duplicate
      */
-    releasesAssetsDetail2: (owner, repo, id, params = {}) =>
+    releasesAssetsList: (owner, repo, id, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/releases/\${id}/assets\`,
         method: "GET",
@@ -2493,10 +2451,10 @@ export class Api extends HttpClient {
     /**
      * @description List Stargazers.
      *
-     * @name StargazersDetail
+     * @name StargazersList
      * @request GET:/repos/{owner}/{repo}/stargazers
      */
-    stargazersDetail: (owner, repo, params = {}) =>
+    stargazersList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/stargazers\`,
         method: "GET",
@@ -2506,10 +2464,10 @@ export class Api extends HttpClient {
     /**
      * @description Get the number of additions and deletions per week. Returns a weekly aggregate of the number of additions and deletions pushed to a repository.
      *
-     * @name StatsCodeFrequencyDetail
+     * @name StatsCodeFrequencyList
      * @request GET:/repos/{owner}/{repo}/stats/code_frequency
      */
-    statsCodeFrequencyDetail: (owner, repo, params = {}) =>
+    statsCodeFrequencyList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/stats/code_frequency\`,
         method: "GET",
@@ -2519,10 +2477,10 @@ export class Api extends HttpClient {
     /**
      * @description Get the last year of commit activity data. Returns the last year of commit activity grouped by week. The days array is a group of commits per day, starting on Sunday.
      *
-     * @name StatsCommitActivityDetail
+     * @name StatsCommitActivityList
      * @request GET:/repos/{owner}/{repo}/stats/commit_activity
      */
-    statsCommitActivityDetail: (owner, repo, params = {}) =>
+    statsCommitActivityList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/stats/commit_activity\`,
         method: "GET",
@@ -2532,10 +2490,10 @@ export class Api extends HttpClient {
     /**
      * @description Get contributors list with additions, deletions, and commit counts.
      *
-     * @name StatsContributorsDetail
+     * @name StatsContributorsList
      * @request GET:/repos/{owner}/{repo}/stats/contributors
      */
-    statsContributorsDetail: (owner, repo, params = {}) =>
+    statsContributorsList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/stats/contributors\`,
         method: "GET",
@@ -2545,10 +2503,10 @@ export class Api extends HttpClient {
     /**
      * @description Get the weekly commit count for the repo owner and everyone else.
      *
-     * @name StatsParticipationDetail
+     * @name StatsParticipationList
      * @request GET:/repos/{owner}/{repo}/stats/participation
      */
-    statsParticipationDetail: (owner, repo, params = {}) =>
+    statsParticipationList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/stats/participation\`,
         method: "GET",
@@ -2558,10 +2516,10 @@ export class Api extends HttpClient {
     /**
      * @description Get the number of commits per hour in each day. Each array contains the day number, hour number, and number of commits 0-6 Sunday - Saturday 0-23 Hour of day Number of commits For example, [2, 14, 25] indicates that there were 25 total commits, during the 2.00pm hour on Tuesdays. All times are based on the time zone of individual commits.
      *
-     * @name StatsPunchCardDetail
+     * @name StatsPunchCardList
      * @request GET:/repos/{owner}/{repo}/stats/punch_card
      */
-    statsPunchCardDetail: (owner, repo, params = {}) =>
+    statsPunchCardList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/stats/punch_card\`,
         method: "GET",
@@ -2599,10 +2557,10 @@ export class Api extends HttpClient {
     /**
      * @description List watchers.
      *
-     * @name SubscribersDetail
+     * @name SubscribersList
      * @request GET:/repos/{owner}/{repo}/subscribers
      */
-    subscribersDetail: (owner, repo, params = {}) =>
+    subscribersList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/subscribers\`,
         method: "GET",
@@ -2624,10 +2582,10 @@ export class Api extends HttpClient {
     /**
      * @description Get a Repository Subscription.
      *
-     * @name SubscriptionDetail
+     * @name SubscriptionList
      * @request GET:/repos/{owner}/{repo}/subscription
      */
-    subscriptionDetail: (owner, repo, params = {}) =>
+    subscriptionList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/subscription\`,
         method: "GET",
@@ -2652,10 +2610,10 @@ export class Api extends HttpClient {
     /**
      * @description Get list of tags.
      *
-     * @name TagsDetail
+     * @name TagsList
      * @request GET:/repos/{owner}/{repo}/tags
      */
-    tagsDetail: (owner, repo, params = {}) =>
+    tagsList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/tags\`,
         method: "GET",
@@ -2665,10 +2623,10 @@ export class Api extends HttpClient {
     /**
      * @description Get list of teams
      *
-     * @name TeamsDetail
+     * @name TeamsList
      * @request GET:/repos/{owner}/{repo}/teams
      */
-    teamsDetail: (owner, repo, params = {}) =>
+    teamsList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/teams\`,
         method: "GET",
@@ -2678,10 +2636,10 @@ export class Api extends HttpClient {
     /**
      * @description List Stargazers. New implementation.
      *
-     * @name WatchersDetail
+     * @name WatchersList
      * @request GET:/repos/{owner}/{repo}/watchers
      */
-    watchersDetail: (owner, repo, params = {}) =>
+    watchersList: (owner, repo, params = {}) =>
       this.request({
         path: \`/repos/\${owner}/\${repo}/watchers\`,
         method: "GET",
@@ -2821,10 +2779,10 @@ export class Api extends HttpClient {
     /**
      * @description List team members. In order to list members in a team, the authenticated user must be a member of the team.
      *
-     * @name MembersDetail
+     * @name MembersList
      * @request GET:/teams/{teamId}/members
      */
-    membersDetail: (teamId, params = {}) =>
+    membersList: (teamId, params = {}) =>
       this.request({
         path: \`/teams/\${teamId}/members\`,
         method: "GET",
@@ -2847,13 +2805,11 @@ export class Api extends HttpClient {
     /**
      * @description The "Get team member" API is deprecated and is scheduled for removal in the next major version of the API. We recommend using the Get team membership API instead. It allows you to get both active and pending memberships. Get team member. In order to get if a user is a member of a team, the authenticated user mus be a member of the team.
      *
-     * @name MembersDetail2
+     * @name MembersDetail
      * @request GET:/teams/{teamId}/members/{username}
      * @deprecated
-     * @originalName membersDetail
-     * @duplicate
      */
-    membersDetail2: (teamId, username, params = {}) =>
+    membersDetail: (teamId, username, params = {}) =>
       this.request({
         path: \`/teams/\${teamId}/members/\${username}\`,
         method: "GET",
@@ -2913,10 +2869,10 @@ export class Api extends HttpClient {
     /**
      * @description List team repos
      *
-     * @name ReposDetail
+     * @name ReposList
      * @request GET:/teams/{teamId}/repos
      */
-    reposDetail: (teamId, params = {}) =>
+    reposList: (teamId, params = {}) =>
       this.request({
         path: \`/teams/\${teamId}/repos\`,
         method: "GET",
@@ -2938,12 +2894,10 @@ export class Api extends HttpClient {
     /**
      * @description Check if a team manages a repository
      *
-     * @name ReposDetail2
+     * @name ReposDetail
      * @request GET:/teams/{teamId}/repos/{owner}/{repo}
-     * @originalName reposDetail
-     * @duplicate
      */
-    reposDetail2: (teamId, owner, repo, params = {}) =>
+    reposDetail: (teamId, owner, repo, params = {}) =>
       this.request({
         path: \`/teams/\${teamId}/repos/\${owner}/\${repo}\`,
         method: "GET",
@@ -3346,10 +3300,10 @@ export class Api extends HttpClient {
     /**
      * @description If you are authenticated as the given user, you will see your private events. Otherwise, you'll only see public events.
      *
-     * @name EventsDetail
+     * @name EventsList
      * @request GET:/users/{username}/events
      */
-    eventsDetail: (username, params = {}) =>
+    eventsList: (username, params = {}) =>
       this.request({
         path: \`/users/\${username}/events\`,
         method: "GET",
@@ -3370,10 +3324,10 @@ export class Api extends HttpClient {
     /**
      * @description List a user's followers
      *
-     * @name FollowersDetail
+     * @name FollowersList
      * @request GET:/users/{username}/followers
      */
-    followersDetail: (username, params = {}) =>
+    followersList: (username, params = {}) =>
       this.request({
         path: \`/users/\${username}/followers\`,
         method: "GET",
@@ -3395,10 +3349,10 @@ export class Api extends HttpClient {
     /**
      * @description List a users gists.
      *
-     * @name GistsDetail
+     * @name GistsList
      * @request GET:/users/{username}/gists
      */
-    gistsDetail: (username, query, params = {}) =>
+    gistsList: (username, query, params = {}) =>
       this.request({
         path: \`/users/\${username}/gists\`,
         method: "GET",
@@ -3409,10 +3363,10 @@ export class Api extends HttpClient {
     /**
      * @description List public keys for a user. Lists the verified public keys for a user. This is accessible by anyone.
      *
-     * @name KeysDetail
+     * @name KeysList
      * @request GET:/users/{username}/keys
      */
-    keysDetail: (username, params = {}) =>
+    keysList: (username, params = {}) =>
       this.request({
         path: \`/users/\${username}/keys\`,
         method: "GET",
@@ -3422,10 +3376,10 @@ export class Api extends HttpClient {
     /**
      * @description List all public organizations for a user.
      *
-     * @name OrgsDetail
+     * @name OrgsList
      * @request GET:/users/{username}/orgs
      */
-    orgsDetail: (username, params = {}) =>
+    orgsList: (username, params = {}) =>
       this.request({
         path: \`/users/\${username}/orgs\`,
         method: "GET",
@@ -3435,10 +3389,10 @@ export class Api extends HttpClient {
     /**
      * @description These are events that you'll only see public events.
      *
-     * @name ReceivedEventsDetail
+     * @name ReceivedEventsList
      * @request GET:/users/{username}/received_events
      */
-    receivedEventsDetail: (username, params = {}) =>
+    receivedEventsList: (username, params = {}) =>
       this.request({
         path: \`/users/\${username}/received_events\`,
         method: "GET",
@@ -3447,10 +3401,10 @@ export class Api extends HttpClient {
     /**
      * @description List public events that a user has received
      *
-     * @name ReceivedEventsPublicDetail
+     * @name ReceivedEventsPublicList
      * @request GET:/users/{username}/received_events/public
      */
-    receivedEventsPublicDetail: (username, params = {}) =>
+    receivedEventsPublicList: (username, params = {}) =>
       this.request({
         path: \`/users/\${username}/received_events/public\`,
         method: "GET",
@@ -3459,10 +3413,10 @@ export class Api extends HttpClient {
     /**
      * @description List public repositories for the specified user.
      *
-     * @name ReposDetail
+     * @name ReposList
      * @request GET:/users/{username}/repos
      */
-    reposDetail: (username, query, params = {}) =>
+    reposList: (username, query, params = {}) =>
       this.request({
         path: \`/users/\${username}/repos\`,
         method: "GET",
@@ -3473,10 +3427,10 @@ export class Api extends HttpClient {
     /**
      * @description List repositories being starred by a user.
      *
-     * @name StarredDetail
+     * @name StarredList
      * @request GET:/users/{username}/starred
      */
-    starredDetail: (username, params = {}) =>
+    starredList: (username, params = {}) =>
       this.request({
         path: \`/users/\${username}/starred\`,
         method: "GET",
@@ -3485,10 +3439,10 @@ export class Api extends HttpClient {
     /**
      * @description List repositories being watched by a user.
      *
-     * @name SubscriptionsDetail
+     * @name SubscriptionsList
      * @request GET:/users/{username}/subscriptions
      */
-    subscriptionsDetail: (username, params = {}) =>
+    subscriptionsList: (username, params = {}) =>
       this.request({
         path: \`/users/\${username}/subscriptions\`,
         method: "GET",

--- a/tests/spec/patch/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/patch/__snapshots__/basic.test.ts.snap
@@ -2205,10 +2205,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name CommentsDetail
+     * @name CommentsList
      * @request GET:/gists/{id}/comments
      */
-    commentsDetail: (id: number, params: RequestParams = {}) =>
+    commentsList: (id: number, params: RequestParams = {}) =>
       this.request<Comments, void>({
         path: \`/gists/\${id}/comments\`,
         method: "GET",
@@ -2247,12 +2247,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name CommentsDetail2
+     * @name CommentsDetail
      * @request GET:/gists/{id}/comments/{commentId}
-     * @originalName commentsDetail
-     * @duplicate
      */
-    commentsDetail2: (id: number, commentId: number, params: RequestParams = {}) =>
+    commentsDetail: (id: number, commentId: number, params: RequestParams = {}) =>
       this.request<Comment, void>({
         path: \`/gists/\${id}/comments/\${commentId}\`,
         method: "GET",
@@ -2305,10 +2303,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name StarDetail
+     * @name StarList
      * @request GET:/gists/{id}/star
      */
-    starDetail: (id: number, params: RequestParams = {}) =>
+    starList: (id: number, params: RequestParams = {}) =>
       this.request<void, void>({
         path: \`/gists/\${id}/star\`,
         method: "GET",
@@ -2524,10 +2522,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name EventsDetail
+     * @name EventsList
      * @request GET:/networks/{owner}/{repo}/events
      */
-    eventsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    eventsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Events, void>({
         path: \`/networks/\${owner}/\${repo}/events\`,
         method: "GET",
@@ -2615,10 +2613,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ThreadsSubscriptionDetail
+     * @name ThreadsSubscriptionList
      * @request GET:/notifications/threads/{id}/subscription
      */
-    threadsSubscriptionDetail: (id: number, params: RequestParams = {}) =>
+    threadsSubscriptionList: (id: number, params: RequestParams = {}) =>
       this.request<Subscription, void>({
         path: \`/notifications/threads/\${id}/subscription\`,
         method: "GET",
@@ -2676,10 +2674,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name EventsDetail
+     * @name EventsList
      * @request GET:/orgs/{org}/events
      */
-    eventsDetail: (org: string, params: RequestParams = {}) =>
+    eventsList: (org: string, params: RequestParams = {}) =>
       this.request<Events, void>({
         path: \`/orgs/\${org}/events\`,
         method: "GET",
@@ -2690,10 +2688,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name IssuesDetail
+     * @name IssuesList
      * @request GET:/orgs/{org}/issues
      */
-    issuesDetail: (
+    issuesList: (
       org: string,
       query: {
         /** @default "all" */
@@ -2720,10 +2718,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name MembersDetail
+     * @name MembersList
      * @request GET:/orgs/{org}/members
      */
-    membersDetail: (org: string, params: RequestParams = {}) =>
+    membersList: (org: string, params: RequestParams = {}) =>
       this.request<Users, void>({
         path: \`/orgs/\${org}/members\`,
         method: "GET",
@@ -2747,12 +2745,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name MembersDetail2
+     * @name MembersDetail
      * @request GET:/orgs/{org}/members/{username}
-     * @originalName membersDetail
-     * @duplicate
      */
-    membersDetail2: (org: string, username: string, params: RequestParams = {}) =>
+    membersDetail: (org: string, username: string, params: RequestParams = {}) =>
       this.request<void, void>({
         path: \`/orgs/\${org}/members/\${username}\`,
         method: "GET",
@@ -2762,10 +2758,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name PublicMembersDetail
+     * @name PublicMembersList
      * @request GET:/orgs/{org}/public_members
      */
-    publicMembersDetail: (org: string, params: RequestParams = {}) =>
+    publicMembersList: (org: string, params: RequestParams = {}) =>
       this.request<Users, void>({
         path: \`/orgs/\${org}/public_members\`,
         method: "GET",
@@ -2789,12 +2785,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name PublicMembersDetail2
+     * @name PublicMembersDetail
      * @request GET:/orgs/{org}/public_members/{username}
-     * @originalName publicMembersDetail
-     * @duplicate
      */
-    publicMembersDetail2: (org: string, username: string, params: RequestParams = {}) =>
+    publicMembersDetail: (org: string, username: string, params: RequestParams = {}) =>
       this.request<void, void>({
         path: \`/orgs/\${org}/public_members/\${username}\`,
         method: "GET",
@@ -2817,10 +2811,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ReposDetail
+     * @name ReposList
      * @request GET:/orgs/{org}/repos
      */
-    reposDetail: (
+    reposList: (
       org: string,
       query?: {
         /** @default "all" */
@@ -2854,10 +2848,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name TeamsDetail
+     * @name TeamsList
      * @request GET:/orgs/{org}/teams
      */
-    teamsDetail: (org: string, params: RequestParams = {}) =>
+    teamsList: (org: string, params: RequestParams = {}) =>
       this.request<Teams, void>({
         path: \`/orgs/\${org}/teams\`,
         method: "GET",
@@ -2943,10 +2937,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name AssigneesDetail
+     * @name AssigneesList
      * @request GET:/repos/{owner}/{repo}/assignees
      */
-    assigneesDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    assigneesList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Assignees, void>({
         path: \`/repos/\${owner}/\${repo}/assignees\`,
         method: "GET",
@@ -2957,12 +2951,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name AssigneesDetail2
+     * @name AssigneesDetail
      * @request GET:/repos/{owner}/{repo}/assignees/{assignee}
-     * @originalName assigneesDetail
-     * @duplicate
      */
-    assigneesDetail2: (owner: string, repo: string, assignee: string, params: RequestParams = {}) =>
+    assigneesDetail: (owner: string, repo: string, assignee: string, params: RequestParams = {}) =>
       this.request<void, void>({
         path: \`/repos/\${owner}/\${repo}/assignees/\${assignee}\`,
         method: "GET",
@@ -2972,10 +2964,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name BranchesDetail
+     * @name BranchesList
      * @request GET:/repos/{owner}/{repo}/branches
      */
-    branchesDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    branchesList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Branches, void>({
         path: \`/repos/\${owner}/\${repo}/branches\`,
         method: "GET",
@@ -2986,12 +2978,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name BranchesDetail2
+     * @name BranchesDetail
      * @request GET:/repos/{owner}/{repo}/branches/{branch}
-     * @originalName branchesDetail
-     * @duplicate
      */
-    branchesDetail2: (owner: string, repo: string, branch: string, params: RequestParams = {}) =>
+    branchesDetail: (owner: string, repo: string, branch: string, params: RequestParams = {}) =>
       this.request<Branch, void>({
         path: \`/repos/\${owner}/\${repo}/branches/\${branch}\`,
         method: "GET",
@@ -3002,10 +2992,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name CollaboratorsDetail
+     * @name CollaboratorsList
      * @request GET:/repos/{owner}/{repo}/collaborators
      */
-    collaboratorsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    collaboratorsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Users, void>({
         path: \`/repos/\${owner}/\${repo}/collaborators\`,
         method: "GET",
@@ -3029,12 +3019,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name CollaboratorsDetail2
+     * @name CollaboratorsDetail
      * @request GET:/repos/{owner}/{repo}/collaborators/{user}
-     * @originalName collaboratorsDetail
-     * @duplicate
      */
-    collaboratorsDetail2: (owner: string, repo: string, user: string, params: RequestParams = {}) =>
+    collaboratorsDetail: (owner: string, repo: string, user: string, params: RequestParams = {}) =>
       this.request<void, void>({
         path: \`/repos/\${owner}/\${repo}/collaborators/\${user}\`,
         method: "GET",
@@ -3057,10 +3045,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name CommentsDetail
+     * @name CommentsList
      * @request GET:/repos/{owner}/{repo}/comments
      */
-    commentsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    commentsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<RepoComments, void>({
         path: \`/repos/\${owner}/\${repo}/comments\`,
         method: "GET",
@@ -3084,12 +3072,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name CommentsDetail2
+     * @name CommentsDetail
      * @request GET:/repos/{owner}/{repo}/comments/{commentId}
-     * @originalName commentsDetail
-     * @duplicate
      */
-    commentsDetail2: (owner: string, repo: string, commentId: number, params: RequestParams = {}) =>
+    commentsDetail: (owner: string, repo: string, commentId: number, params: RequestParams = {}) =>
       this.request<CommitComment, void>({
         path: \`/repos/\${owner}/\${repo}/comments/\${commentId}\`,
         method: "GET",
@@ -3121,10 +3107,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name CommitsDetail
+     * @name CommitsList
      * @request GET:/repos/{owner}/{repo}/commits
      */
-    commitsDetail: (
+    commitsList: (
       owner: string,
       repo: string,
       query?: {
@@ -3147,10 +3133,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name CommitsStatusDetail
+     * @name CommitsStatusList
      * @request GET:/repos/{owner}/{repo}/commits/{ref}/status
      */
-    commitsStatusDetail: (owner: string, repo: string, ref: string, params: RequestParams = {}) =>
+    commitsStatusList: (owner: string, repo: string, ref: string, params: RequestParams = {}) =>
       this.request<RefStatus, void>({
         path: \`/repos/\${owner}/\${repo}/commits/\${ref}/status\`,
         method: "GET",
@@ -3161,12 +3147,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name CommitsDetail2
+     * @name CommitsDetail
      * @request GET:/repos/{owner}/{repo}/commits/{shaCode}
-     * @originalName commitsDetail
-     * @duplicate
      */
-    commitsDetail2: (owner: string, repo: string, shaCode: string, params: RequestParams = {}) =>
+    commitsDetail: (owner: string, repo: string, shaCode: string, params: RequestParams = {}) =>
       this.request<Commit, void>({
         path: \`/repos/\${owner}/\${repo}/commits/\${shaCode}\`,
         method: "GET",
@@ -3177,10 +3161,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name CommitsCommentsDetail
+     * @name CommitsCommentsList
      * @request GET:/repos/{owner}/{repo}/commits/{shaCode}/comments
      */
-    commitsCommentsDetail: (owner: string, repo: string, shaCode: string, params: RequestParams = {}) =>
+    commitsCommentsList: (owner: string, repo: string, shaCode: string, params: RequestParams = {}) =>
       this.request<RepoComments, void>({
         path: \`/repos/\${owner}/\${repo}/commits/\${shaCode}/comments\`,
         method: "GET",
@@ -3283,10 +3267,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ContributorsDetail
+     * @name ContributorsList
      * @request GET:/repos/{owner}/{repo}/contributors
      */
-    contributorsDetail: (
+    contributorsList: (
       owner: string,
       repo: string,
       query: {
@@ -3305,10 +3289,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name DeploymentsDetail
+     * @name DeploymentsList
      * @request GET:/repos/{owner}/{repo}/deployments
      */
-    deploymentsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    deploymentsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<RepoDeployments, void>({
         path: \`/repos/\${owner}/\${repo}/deployments\`,
         method: "GET",
@@ -3335,10 +3319,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name DeploymentsStatusesDetail
+     * @name DeploymentsStatusesList
      * @request GET:/repos/{owner}/{repo}/deployments/{id}/statuses
      */
-    deploymentsStatusesDetail: (owner: string, repo: string, id: number, params: RequestParams = {}) =>
+    deploymentsStatusesList: (owner: string, repo: string, id: number, params: RequestParams = {}) =>
       this.request<DeploymentStatuses, void>({
         path: \`/repos/\${owner}/\${repo}/deployments/\${id}/statuses\`,
         method: "GET",
@@ -3370,11 +3354,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name DownloadsDetail
+     * @name DownloadsList
      * @request GET:/repos/{owner}/{repo}/downloads
      * @deprecated
      */
-    downloadsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    downloadsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Downloads, void>({
         path: \`/repos/\${owner}/\${repo}/downloads\`,
         method: "GET",
@@ -3399,13 +3383,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name DownloadsDetail2
+     * @name DownloadsDetail
      * @request GET:/repos/{owner}/{repo}/downloads/{downloadId}
      * @deprecated
-     * @originalName downloadsDetail
-     * @duplicate
      */
-    downloadsDetail2: (owner: string, repo: string, downloadId: number, params: RequestParams = {}) =>
+    downloadsDetail: (owner: string, repo: string, downloadId: number, params: RequestParams = {}) =>
       this.request<Download, void>({
         path: \`/repos/\${owner}/\${repo}/downloads/\${downloadId}\`,
         method: "GET",
@@ -3416,10 +3398,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name EventsDetail
+     * @name EventsList
      * @request GET:/repos/{owner}/{repo}/events
      */
-    eventsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    eventsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Events, void>({
         path: \`/repos/\${owner}/\${repo}/events\`,
         method: "GET",
@@ -3430,10 +3412,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ForksDetail
+     * @name ForksList
      * @request GET:/repos/{owner}/{repo}/forks
      */
-    forksDetail: (
+    forksList: (
       owner: string,
       repo: string,
       query?: {
@@ -3529,10 +3511,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name GitRefsDetail
+     * @name GitRefsList
      * @request GET:/repos/{owner}/{repo}/git/refs
      */
-    gitRefsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    gitRefsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Refs, void>({
         path: \`/repos/\${owner}/\${repo}/git/refs\`,
         method: "GET",
@@ -3572,12 +3554,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name GitRefsDetail2
+     * @name GitRefsDetail
      * @request GET:/repos/{owner}/{repo}/git/refs/{ref}
-     * @originalName gitRefsDetail
-     * @duplicate
      */
-    gitRefsDetail2: (owner: string, repo: string, ref: string, params: RequestParams = {}) =>
+    gitRefsDetail: (owner: string, repo: string, ref: string, params: RequestParams = {}) =>
       this.request<HeadBranch, void>({
         path: \`/repos/\${owner}/\${repo}/git/refs/\${ref}\`,
         method: "GET",
@@ -3673,10 +3653,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name HooksDetail
+     * @name HooksList
      * @request GET:/repos/{owner}/{repo}/hooks
      */
-    hooksDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    hooksList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Hook, void>({
         path: \`/repos/\${owner}/\${repo}/hooks\`,
         method: "GET",
@@ -3715,12 +3695,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name HooksDetail2
+     * @name HooksDetail
      * @request GET:/repos/{owner}/{repo}/hooks/{hookId}
-     * @originalName hooksDetail
-     * @duplicate
      */
-    hooksDetail2: (owner: string, repo: string, hookId: number, params: RequestParams = {}) =>
+    hooksDetail: (owner: string, repo: string, hookId: number, params: RequestParams = {}) =>
       this.request<Hook, void>({
         path: \`/repos/\${owner}/\${repo}/hooks/\${hookId}\`,
         method: "GET",
@@ -3759,10 +3737,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name IssuesDetail
+     * @name IssuesList
      * @request GET:/repos/{owner}/{repo}/issues
      */
-    issuesDetail: (
+    issuesList: (
       owner: string,
       repo: string,
       query: {
@@ -3805,10 +3783,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name IssuesCommentsDetail
+     * @name IssuesCommentsList
      * @request GET:/repos/{owner}/{repo}/issues/comments
      */
-    issuesCommentsDetail: (
+    issuesCommentsList: (
       owner: string,
       repo: string,
       query?: {
@@ -3842,12 +3820,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name IssuesCommentsDetail2
+     * @name IssuesCommentsDetail
      * @request GET:/repos/{owner}/{repo}/issues/comments/{commentId}
-     * @originalName issuesCommentsDetail
-     * @duplicate
      */
-    issuesCommentsDetail2: (owner: string, repo: string, commentId: number, params: RequestParams = {}) =>
+    issuesCommentsDetail: (owner: string, repo: string, commentId: number, params: RequestParams = {}) =>
       this.request<IssuesComment, void>({
         path: \`/repos/\${owner}/\${repo}/issues/comments/\${commentId}\`,
         method: "GET",
@@ -3879,10 +3855,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name IssuesEventsDetail
+     * @name IssuesEventsList
      * @request GET:/repos/{owner}/{repo}/issues/events
      */
-    issuesEventsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    issuesEventsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<IssueEvents, void>({
         path: \`/repos/\${owner}/\${repo}/issues/events\`,
         method: "GET",
@@ -3893,12 +3869,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name IssuesEventsDetail2
+     * @name IssuesEventsDetail
      * @request GET:/repos/{owner}/{repo}/issues/events/{eventId}
-     * @originalName issuesEventsDetail
-     * @duplicate
      */
-    issuesEventsDetail2: (owner: string, repo: string, eventId: number, params: RequestParams = {}) =>
+    issuesEventsDetail: (owner: string, repo: string, eventId: number, params: RequestParams = {}) =>
       this.request<IssueEvent, void>({
         path: \`/repos/\${owner}/\${repo}/issues/events/\${eventId}\`,
         method: "GET",
@@ -3909,12 +3883,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name IssuesDetail2
+     * @name IssuesDetail
      * @request GET:/repos/{owner}/{repo}/issues/{number}
-     * @originalName issuesDetail
-     * @duplicate
      */
-    issuesDetail2: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    issuesDetail: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<Issue, void>({
         path: \`/repos/\${owner}/\${repo}/issues/\${number}\`,
         method: "GET",
@@ -3940,12 +3912,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name IssuesCommentsDetail3
+     * @name IssuesCommentsList2
      * @request GET:/repos/{owner}/{repo}/issues/{number}/comments
-     * @originalName issuesCommentsDetail
+     * @originalName issuesCommentsList
      * @duplicate
      */
-    issuesCommentsDetail3: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    issuesCommentsList2: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<IssuesComments, void>({
         path: \`/repos/\${owner}/\${repo}/issues/\${number}/comments\`,
         method: "GET",
@@ -3977,12 +3949,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name IssuesEventsDetail3
+     * @name IssuesEventsList2
      * @request GET:/repos/{owner}/{repo}/issues/{number}/events
-     * @originalName issuesEventsDetail
+     * @originalName issuesEventsList
      * @duplicate
      */
-    issuesEventsDetail3: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    issuesEventsList2: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<IssueEvents, void>({
         path: \`/repos/\${owner}/\${repo}/issues/\${number}/events\`,
         method: "GET",
@@ -4006,10 +3978,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name IssuesLabelsDetail
+     * @name IssuesLabelsList
      * @request GET:/repos/{owner}/{repo}/issues/{number}/labels
      */
-    issuesLabelsDetail: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    issuesLabelsList: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<Labels, void>({
         path: \`/repos/\${owner}/\${repo}/issues/\${number}/labels\`,
         method: "GET",
@@ -4065,10 +4037,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name KeysDetail
+     * @name KeysList
      * @request GET:/repos/{owner}/{repo}/keys
      */
-    keysDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    keysList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Keys, void>({
         path: \`/repos/\${owner}/\${repo}/keys\`,
         method: "GET",
@@ -4107,12 +4079,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name KeysDetail2
+     * @name KeysDetail
      * @request GET:/repos/{owner}/{repo}/keys/{keyId}
-     * @originalName keysDetail
-     * @duplicate
      */
-    keysDetail2: (owner: string, repo: string, keyId: number, params: RequestParams = {}) =>
+    keysDetail: (owner: string, repo: string, keyId: number, params: RequestParams = {}) =>
       this.request<UserKeysKeyId, void>({
         path: \`/repos/\${owner}/\${repo}/keys/\${keyId}\`,
         method: "GET",
@@ -4123,10 +4093,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name LabelsDetail
+     * @name LabelsList
      * @request GET:/repos/{owner}/{repo}/labels
      */
-    labelsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    labelsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Labels, void>({
         path: \`/repos/\${owner}/\${repo}/labels\`,
         method: "GET",
@@ -4165,12 +4135,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name LabelsDetail2
+     * @name LabelsDetail
      * @request GET:/repos/{owner}/{repo}/labels/{name}
-     * @originalName labelsDetail
-     * @duplicate
      */
-    labelsDetail2: (owner: string, repo: string, name: string, params: RequestParams = {}) =>
+    labelsDetail: (owner: string, repo: string, name: string, params: RequestParams = {}) =>
       this.request<Label, void>({
         path: \`/repos/\${owner}/\${repo}/labels/\${name}\`,
         method: "GET",
@@ -4196,10 +4164,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name LanguagesDetail
+     * @name LanguagesList
      * @request GET:/repos/{owner}/{repo}/languages
      */
-    languagesDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    languagesList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Languages, void>({
         path: \`/repos/\${owner}/\${repo}/languages\`,
         method: "GET",
@@ -4226,10 +4194,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name MilestonesDetail
+     * @name MilestonesList
      * @request GET:/repos/{owner}/{repo}/milestones
      */
-    milestonesDetail: (
+    milestonesList: (
       owner: string,
       repo: string,
       query?: {
@@ -4280,12 +4248,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name MilestonesDetail2
+     * @name MilestonesDetail
      * @request GET:/repos/{owner}/{repo}/milestones/{number}
-     * @originalName milestonesDetail
-     * @duplicate
      */
-    milestonesDetail2: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    milestonesDetail: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<Milestone, void>({
         path: \`/repos/\${owner}/\${repo}/milestones/\${number}\`,
         method: "GET",
@@ -4317,10 +4283,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name MilestonesLabelsDetail
+     * @name MilestonesLabelsList
      * @request GET:/repos/{owner}/{repo}/milestones/{number}/labels
      */
-    milestonesLabelsDetail: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    milestonesLabelsList: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<Labels, void>({
         path: \`/repos/\${owner}/\${repo}/milestones/\${number}/labels\`,
         method: "GET",
@@ -4331,10 +4297,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name NotificationsDetail
+     * @name NotificationsList
      * @request GET:/repos/{owner}/{repo}/notifications
      */
-    notificationsDetail: (
+    notificationsList: (
       owner: string,
       repo: string,
       query?: {
@@ -4369,10 +4335,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name PullsDetail
+     * @name PullsList
      * @request GET:/repos/{owner}/{repo}/pulls
      */
-    pullsDetail: (
+    pullsList: (
       owner: string,
       repo: string,
       query?: {
@@ -4410,10 +4376,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name PullsCommentsDetail
+     * @name PullsCommentsList
      * @request GET:/repos/{owner}/{repo}/pulls/comments
      */
-    pullsCommentsDetail: (
+    pullsCommentsList: (
       owner: string,
       repo: string,
       query?: {
@@ -4447,12 +4413,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name PullsCommentsDetail2
+     * @name PullsCommentsDetail
      * @request GET:/repos/{owner}/{repo}/pulls/comments/{commentId}
-     * @originalName pullsCommentsDetail
-     * @duplicate
      */
-    pullsCommentsDetail2: (owner: string, repo: string, commentId: number, params: RequestParams = {}) =>
+    pullsCommentsDetail: (owner: string, repo: string, commentId: number, params: RequestParams = {}) =>
       this.request<PullsComment, void>({
         path: \`/repos/\${owner}/\${repo}/pulls/comments/\${commentId}\`,
         method: "GET",
@@ -4484,12 +4448,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name PullsDetail2
+     * @name PullsDetail
      * @request GET:/repos/{owner}/{repo}/pulls/{number}
-     * @originalName pullsDetail
-     * @duplicate
      */
-    pullsDetail2: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    pullsDetail: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<PullRequest, void>({
         path: \`/repos/\${owner}/\${repo}/pulls/\${number}\`,
         method: "GET",
@@ -4516,12 +4478,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name PullsCommentsDetail3
+     * @name PullsCommentsList2
      * @request GET:/repos/{owner}/{repo}/pulls/{number}/comments
-     * @originalName pullsCommentsDetail
+     * @originalName pullsCommentsList
      * @duplicate
      */
-    pullsCommentsDetail3: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    pullsCommentsList2: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<PullsComment, void>({
         path: \`/repos/\${owner}/\${repo}/pulls/\${number}/comments\`,
         method: "GET",
@@ -4554,10 +4516,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name PullsCommitsDetail
+     * @name PullsCommitsList
      * @request GET:/repos/{owner}/{repo}/pulls/{number}/commits
      */
-    pullsCommitsDetail: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    pullsCommitsList: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<Commits, void>({
         path: \`/repos/\${owner}/\${repo}/pulls/\${number}/commits\`,
         method: "GET",
@@ -4568,10 +4530,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name PullsFilesDetail
+     * @name PullsFilesList
      * @request GET:/repos/{owner}/{repo}/pulls/{number}/files
      */
-    pullsFilesDetail: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    pullsFilesList: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<Pulls, void>({
         path: \`/repos/\${owner}/\${repo}/pulls/\${number}/files\`,
         method: "GET",
@@ -4582,10 +4544,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name PullsMergeDetail
+     * @name PullsMergeList
      * @request GET:/repos/{owner}/{repo}/pulls/{number}/merge
      */
-    pullsMergeDetail: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    pullsMergeList: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<void, void>({
         path: \`/repos/\${owner}/\${repo}/pulls/\${number}/merge\`,
         method: "GET",
@@ -4611,10 +4573,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ReadmeDetail
+     * @name ReadmeList
      * @request GET:/repos/{owner}/{repo}/readme
      */
-    readmeDetail: (
+    readmeList: (
       owner: string,
       repo: string,
       query?: {
@@ -4633,10 +4595,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ReleasesDetail
+     * @name ReleasesList
      * @request GET:/repos/{owner}/{repo}/releases
      */
-    releasesDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    releasesList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Releases, void>({
         path: \`/repos/\${owner}/\${repo}/releases\`,
         method: "GET",
@@ -4724,12 +4686,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ReleasesDetail2
+     * @name ReleasesDetail
      * @request GET:/repos/{owner}/{repo}/releases/{id}
-     * @originalName releasesDetail
-     * @duplicate
      */
-    releasesDetail2: (owner: string, repo: string, id: string, params: RequestParams = {}) =>
+    releasesDetail: (owner: string, repo: string, id: string, params: RequestParams = {}) =>
       this.request<Release, void>({
         path: \`/repos/\${owner}/\${repo}/releases/\${id}\`,
         method: "GET",
@@ -4755,12 +4715,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ReleasesAssetsDetail2
+     * @name ReleasesAssetsList
      * @request GET:/repos/{owner}/{repo}/releases/{id}/assets
-     * @originalName releasesAssetsDetail
-     * @duplicate
      */
-    releasesAssetsDetail2: (owner: string, repo: string, id: string, params: RequestParams = {}) =>
+    releasesAssetsList: (owner: string, repo: string, id: string, params: RequestParams = {}) =>
       this.request<Assets, void>({
         path: \`/repos/\${owner}/\${repo}/releases/\${id}/assets\`,
         method: "GET",
@@ -4771,10 +4729,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name StargazersDetail
+     * @name StargazersList
      * @request GET:/repos/{owner}/{repo}/stargazers
      */
-    stargazersDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    stargazersList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Users, void>({
         path: \`/repos/\${owner}/\${repo}/stargazers\`,
         method: "GET",
@@ -4785,10 +4743,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name StatsCodeFrequencyDetail
+     * @name StatsCodeFrequencyList
      * @request GET:/repos/{owner}/{repo}/stats/code_frequency
      */
-    statsCodeFrequencyDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    statsCodeFrequencyList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<CodeFrequencyStats, void>({
         path: \`/repos/\${owner}/\${repo}/stats/code_frequency\`,
         method: "GET",
@@ -4799,10 +4757,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name StatsCommitActivityDetail
+     * @name StatsCommitActivityList
      * @request GET:/repos/{owner}/{repo}/stats/commit_activity
      */
-    statsCommitActivityDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    statsCommitActivityList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<CommitActivityStats, void>({
         path: \`/repos/\${owner}/\${repo}/stats/commit_activity\`,
         method: "GET",
@@ -4813,10 +4771,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name StatsContributorsDetail
+     * @name StatsContributorsList
      * @request GET:/repos/{owner}/{repo}/stats/contributors
      */
-    statsContributorsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    statsContributorsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<ContributorsStats, void>({
         path: \`/repos/\${owner}/\${repo}/stats/contributors\`,
         method: "GET",
@@ -4827,10 +4785,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name StatsParticipationDetail
+     * @name StatsParticipationList
      * @request GET:/repos/{owner}/{repo}/stats/participation
      */
-    statsParticipationDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    statsParticipationList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<ParticipationStats, void>({
         path: \`/repos/\${owner}/\${repo}/stats/participation\`,
         method: "GET",
@@ -4841,10 +4799,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name StatsPunchCardDetail
+     * @name StatsPunchCardList
      * @request GET:/repos/{owner}/{repo}/stats/punch_card
      */
-    statsPunchCardDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    statsPunchCardList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<CodeFrequencyStats, void>({
         path: \`/repos/\${owner}/\${repo}/stats/punch_card\`,
         method: "GET",
@@ -4885,10 +4843,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name SubscribersDetail
+     * @name SubscribersList
      * @request GET:/repos/{owner}/{repo}/subscribers
      */
-    subscribersDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    subscribersList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Users, void>({
         path: \`/repos/\${owner}/\${repo}/subscribers\`,
         method: "GET",
@@ -4912,10 +4870,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name SubscriptionDetail
+     * @name SubscriptionList
      * @request GET:/repos/{owner}/{repo}/subscription
      */
-    subscriptionDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    subscriptionList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Subscription, void>({
         path: \`/repos/\${owner}/\${repo}/subscription\`,
         method: "GET",
@@ -4942,10 +4900,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name TagsDetail
+     * @name TagsList
      * @request GET:/repos/{owner}/{repo}/tags
      */
-    tagsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    tagsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Tags, void>({
         path: \`/repos/\${owner}/\${repo}/tags\`,
         method: "GET",
@@ -4956,10 +4914,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name TeamsDetail
+     * @name TeamsList
      * @request GET:/repos/{owner}/{repo}/teams
      */
-    teamsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    teamsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Teams, void>({
         path: \`/repos/\${owner}/\${repo}/teams\`,
         method: "GET",
@@ -4970,10 +4928,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name WatchersDetail
+     * @name WatchersList
      * @request GET:/repos/{owner}/{repo}/watchers
      */
-    watchersDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    watchersList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Users, void>({
         path: \`/repos/\${owner}/\${repo}/watchers\`,
         method: "GET",
@@ -5163,10 +5121,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name MembersDetail
+     * @name MembersList
      * @request GET:/teams/{teamId}/members
      */
-    membersDetail: (teamId: number, params: RequestParams = {}) =>
+    membersList: (teamId: number, params: RequestParams = {}) =>
       this.request<Users, void>({
         path: \`/teams/\${teamId}/members\`,
         method: "GET",
@@ -5191,13 +5149,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name MembersDetail2
+     * @name MembersDetail
      * @request GET:/teams/{teamId}/members/{username}
      * @deprecated
-     * @originalName membersDetail
-     * @duplicate
      */
-    membersDetail2: (teamId: number, username: string, params: RequestParams = {}) =>
+    membersDetail: (teamId: number, username: string, params: RequestParams = {}) =>
       this.request<void, void>({
         path: \`/teams/\${teamId}/members/\${username}\`,
         method: "GET",
@@ -5262,10 +5218,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ReposDetail
+     * @name ReposList
      * @request GET:/teams/{teamId}/repos
      */
-    reposDetail: (teamId: number, params: RequestParams = {}) =>
+    reposList: (teamId: number, params: RequestParams = {}) =>
       this.request<TeamRepos, void>({
         path: \`/teams/\${teamId}/repos\`,
         method: "GET",
@@ -5289,12 +5245,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ReposDetail2
+     * @name ReposDetail
      * @request GET:/teams/{teamId}/repos/{owner}/{repo}
-     * @originalName reposDetail
-     * @duplicate
      */
-    reposDetail2: (teamId: number, owner: string, repo: string, params: RequestParams = {}) =>
+    reposDetail: (teamId: number, owner: string, repo: string, params: RequestParams = {}) =>
       this.request<any, void>({
         path: \`/teams/\${teamId}/repos/\${owner}/\${repo}\`,
         method: "GET",
@@ -5758,10 +5712,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name EventsDetail
+     * @name EventsList
      * @request GET:/users/{username}/events
      */
-    eventsDetail: (username: string, params: RequestParams = {}) =>
+    eventsList: (username: string, params: RequestParams = {}) =>
       this.request<any, void>({
         path: \`/users/\${username}/events\`,
         method: "GET",
@@ -5784,10 +5738,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name FollowersDetail
+     * @name FollowersList
      * @request GET:/users/{username}/followers
      */
-    followersDetail: (username: string, params: RequestParams = {}) =>
+    followersList: (username: string, params: RequestParams = {}) =>
       this.request<Users, void>({
         path: \`/users/\${username}/followers\`,
         method: "GET",
@@ -5811,10 +5765,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name GistsDetail
+     * @name GistsList
      * @request GET:/users/{username}/gists
      */
-    gistsDetail: (
+    gistsList: (
       username: string,
       query?: {
         since?: string;
@@ -5832,10 +5786,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name KeysDetail
+     * @name KeysList
      * @request GET:/users/{username}/keys
      */
-    keysDetail: (username: string, params: RequestParams = {}) =>
+    keysList: (username: string, params: RequestParams = {}) =>
       this.request<Gitignore, void>({
         path: \`/users/\${username}/keys\`,
         method: "GET",
@@ -5846,10 +5800,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name OrgsDetail
+     * @name OrgsList
      * @request GET:/users/{username}/orgs
      */
-    orgsDetail: (username: string, params: RequestParams = {}) =>
+    orgsList: (username: string, params: RequestParams = {}) =>
       this.request<Gitignore, void>({
         path: \`/users/\${username}/orgs\`,
         method: "GET",
@@ -5860,10 +5814,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ReceivedEventsDetail
+     * @name ReceivedEventsList
      * @request GET:/users/{username}/received_events
      */
-    receivedEventsDetail: (username: string, params: RequestParams = {}) =>
+    receivedEventsList: (username: string, params: RequestParams = {}) =>
       this.request<any, void>({
         path: \`/users/\${username}/received_events\`,
         method: "GET",
@@ -5873,10 +5827,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ReceivedEventsPublicDetail
+     * @name ReceivedEventsPublicList
      * @request GET:/users/{username}/received_events/public
      */
-    receivedEventsPublicDetail: (username: string, params: RequestParams = {}) =>
+    receivedEventsPublicList: (username: string, params: RequestParams = {}) =>
       this.request<any, void>({
         path: \`/users/\${username}/received_events/public\`,
         method: "GET",
@@ -5886,10 +5840,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ReposDetail
+     * @name ReposList
      * @request GET:/users/{username}/repos
      */
-    reposDetail: (
+    reposList: (
       username: string,
       query?: {
         /** @default "all" */
@@ -5908,10 +5862,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name StarredDetail
+     * @name StarredList
      * @request GET:/users/{username}/starred
      */
-    starredDetail: (username: string, params: RequestParams = {}) =>
+    starredList: (username: string, params: RequestParams = {}) =>
       this.request<any, void>({
         path: \`/users/\${username}/starred\`,
         method: "GET",
@@ -5921,10 +5875,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name SubscriptionsDetail
+     * @name SubscriptionsList
      * @request GET:/users/{username}/subscriptions
      */
-    subscriptionsDetail: (username: string, params: RequestParams = {}) =>
+    subscriptionsList: (username: string, params: RequestParams = {}) =>
       this.request<any, void>({
         path: \`/users/\${username}/subscriptions\`,
         method: "GET",

--- a/tests/spec/routeTypes/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/routeTypes/__snapshots__/basic.test.ts.snap
@@ -2161,10 +2161,10 @@ export namespace Gists {
 
   /**
    * @description List comments on a gist.
-   * @name CommentsDetail
+   * @name CommentsList
    * @request GET:/gists/{id}/comments
    */
-  export namespace CommentsDetail {
+  export namespace CommentsList {
     export type RequestParams = {
       /** Id of gist. */
       id: number;
@@ -2220,12 +2220,10 @@ export namespace Gists {
 
   /**
    * @description Get a single comment.
-   * @name CommentsDetail2
+   * @name CommentsDetail
    * @request GET:/gists/{id}/comments/{commentId}
-   * @originalName commentsDetail
-   * @duplicate
    */
-  export namespace CommentsDetail2 {
+  export namespace CommentsDetail {
     export type RequestParams = {
       /** Id of gist. */
       id: number;
@@ -2302,10 +2300,10 @@ export namespace Gists {
 
   /**
    * @description Check if a gist is starred.
-   * @name StarDetail
+   * @name StarList
    * @request GET:/gists/{id}/star
    */
-  export namespace StarDetail {
+  export namespace StarList {
     export type RequestParams = {
       /** Id of gist. */
       id: number;
@@ -2576,10 +2574,10 @@ export namespace Meta {
 export namespace Networks {
   /**
    * @description List public events for a network of repositories.
-   * @name EventsDetail
+   * @name EventsList
    * @request GET:/networks/{owner}/{repo}/events
    */
-  export namespace EventsDetail {
+  export namespace EventsList {
     export type RequestParams = {
       /** Name of the owner. */
       owner: string;
@@ -2701,10 +2699,10 @@ export namespace Notifications {
 
   /**
    * @description Get a Thread Subscription.
-   * @name ThreadsSubscriptionDetail
+   * @name ThreadsSubscriptionList
    * @request GET:/notifications/threads/{id}/subscription
    */
-  export namespace ThreadsSubscriptionDetail {
+  export namespace ThreadsSubscriptionList {
     export type RequestParams = {
       /** Id of thread. */
       id: number;
@@ -2779,10 +2777,10 @@ export namespace Orgs {
 
   /**
    * @description List public events for an organization.
-   * @name EventsDetail
+   * @name EventsList
    * @request GET:/orgs/{org}/events
    */
-  export namespace EventsDetail {
+  export namespace EventsList {
     export type RequestParams = {
       /** Name of organisation. */
       org: string;
@@ -2798,10 +2796,10 @@ export namespace Orgs {
 
   /**
    * @description List issues. List all issues for a given organization for the authenticated user.
-   * @name IssuesDetail
+   * @name IssuesList
    * @request GET:/orgs/{org}/issues
    */
-  export namespace IssuesDetail {
+  export namespace IssuesList {
     export type RequestParams = {
       /** Name of organisation. */
       org: string;
@@ -2837,10 +2835,10 @@ export namespace Orgs {
 
   /**
    * @description Members list. List all users who are members of an organization. A member is a user tha belongs to at least 1 team in the organization. If the authenticated user is also an owner of this organization then both concealed and public members will be returned. If the requester is not an owner of the organization the query will be redirected to the public members list.
-   * @name MembersDetail
+   * @name MembersList
    * @request GET:/orgs/{org}/members
    */
-  export namespace MembersDetail {
+  export namespace MembersList {
     export type RequestParams = {
       /** Name of organisation. */
       org: string;
@@ -2877,12 +2875,10 @@ export namespace Orgs {
 
   /**
    * @description Check if a user is, publicly or privately, a member of the organization.
-   * @name MembersDetail2
+   * @name MembersDetail
    * @request GET:/orgs/{org}/members/{username}
-   * @originalName membersDetail
-   * @duplicate
    */
-  export namespace MembersDetail2 {
+  export namespace MembersDetail {
     export type RequestParams = {
       /** Name of organisation. */
       org: string;
@@ -2900,10 +2896,10 @@ export namespace Orgs {
 
   /**
    * @description Public members list. Members of an organization can choose to have their membership publicized or not.
-   * @name PublicMembersDetail
+   * @name PublicMembersList
    * @request GET:/orgs/{org}/public_members
    */
-  export namespace PublicMembersDetail {
+  export namespace PublicMembersList {
     export type RequestParams = {
       /** Name of organisation. */
       org: string;
@@ -2940,12 +2936,10 @@ export namespace Orgs {
 
   /**
    * @description Check public membership.
-   * @name PublicMembersDetail2
+   * @name PublicMembersDetail
    * @request GET:/orgs/{org}/public_members/{username}
-   * @originalName publicMembersDetail
-   * @duplicate
    */
-  export namespace PublicMembersDetail2 {
+  export namespace PublicMembersDetail {
     export type RequestParams = {
       /** Name of organisation. */
       org: string;
@@ -2984,10 +2978,10 @@ export namespace Orgs {
 
   /**
    * @description List repositories for the specified org.
-   * @name ReposDetail
+   * @name ReposList
    * @request GET:/orgs/{org}/repos
    */
-  export namespace ReposDetail {
+  export namespace ReposList {
     export type RequestParams = {
       /** Name of organisation. */
       org: string;
@@ -3025,10 +3019,10 @@ export namespace Orgs {
 
   /**
    * @description List teams.
-   * @name TeamsDetail
+   * @name TeamsList
    * @request GET:/orgs/{org}/teams
    */
-  export namespace TeamsDetail {
+  export namespace TeamsList {
     export type RequestParams = {
       /** Name of organisation. */
       org: string;
@@ -3146,10 +3140,10 @@ export namespace Repos {
 
   /**
    * @description List assignees. This call lists all the available assignees (owner + collaborators) to which issues may be assigned.
-   * @name AssigneesDetail
+   * @name AssigneesList
    * @request GET:/repos/{owner}/{repo}/assignees
    */
-  export namespace AssigneesDetail {
+  export namespace AssigneesList {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -3167,12 +3161,10 @@ export namespace Repos {
 
   /**
    * @description Check assignee. You may also check to see if a particular user is an assignee for a repository.
-   * @name AssigneesDetail2
+   * @name AssigneesDetail
    * @request GET:/repos/{owner}/{repo}/assignees/{assignee}
-   * @originalName assigneesDetail
-   * @duplicate
    */
-  export namespace AssigneesDetail2 {
+  export namespace AssigneesDetail {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -3192,10 +3184,10 @@ export namespace Repos {
 
   /**
    * @description Get list of branches
-   * @name BranchesDetail
+   * @name BranchesList
    * @request GET:/repos/{owner}/{repo}/branches
    */
-  export namespace BranchesDetail {
+  export namespace BranchesList {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -3213,12 +3205,10 @@ export namespace Repos {
 
   /**
    * @description Get Branch
-   * @name BranchesDetail2
+   * @name BranchesDetail
    * @request GET:/repos/{owner}/{repo}/branches/{branch}
-   * @originalName branchesDetail
-   * @duplicate
    */
-  export namespace BranchesDetail2 {
+  export namespace BranchesDetail {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -3238,10 +3228,10 @@ export namespace Repos {
 
   /**
    * @description List. When authenticating as an organization owner of an organization-owned repository, all organization owners are included in the list of collaborators. Otherwise, only users with access to the repository are returned in the collaborators list.
-   * @name CollaboratorsDetail
+   * @name CollaboratorsList
    * @request GET:/repos/{owner}/{repo}/collaborators
    */
-  export namespace CollaboratorsDetail {
+  export namespace CollaboratorsList {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -3282,12 +3272,10 @@ export namespace Repos {
 
   /**
    * @description Check if user is a collaborator
-   * @name CollaboratorsDetail2
+   * @name CollaboratorsDetail
    * @request GET:/repos/{owner}/{repo}/collaborators/{user}
-   * @originalName collaboratorsDetail
-   * @duplicate
    */
-  export namespace CollaboratorsDetail2 {
+  export namespace CollaboratorsDetail {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -3330,10 +3318,10 @@ export namespace Repos {
 
   /**
    * @description List commit comments for a repository. Comments are ordered by ascending ID.
-   * @name CommentsDetail
+   * @name CommentsList
    * @request GET:/repos/{owner}/{repo}/comments
    */
-  export namespace CommentsDetail {
+  export namespace CommentsList {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -3374,12 +3362,10 @@ export namespace Repos {
 
   /**
    * @description Get a single commit comment.
-   * @name CommentsDetail2
+   * @name CommentsDetail
    * @request GET:/repos/{owner}/{repo}/comments/{commentId}
-   * @originalName commentsDetail
-   * @duplicate
    */
-  export namespace CommentsDetail2 {
+  export namespace CommentsDetail {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -3422,10 +3408,10 @@ export namespace Repos {
 
   /**
    * @description List commits on a repository.
-   * @name CommitsDetail
+   * @name CommitsList
    * @request GET:/repos/{owner}/{repo}/commits
    */
-  export namespace CommitsDetail {
+  export namespace CommitsList {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -3457,10 +3443,10 @@ export namespace Repos {
 
   /**
    * @description Get the combined Status for a specific Ref The Combined status endpoint is currently available for developers to preview. During the preview period, the API may change without advance notice. Please see the blog post for full details. To access this endpoint during the preview period, you must provide a custom media type in the Accept header: application/vnd.github.she-hulk-preview+json
-   * @name CommitsStatusDetail
+   * @name CommitsStatusList
    * @request GET:/repos/{owner}/{repo}/commits/{ref}/status
    */
-  export namespace CommitsStatusDetail {
+  export namespace CommitsStatusList {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -3479,12 +3465,10 @@ export namespace Repos {
 
   /**
    * @description Get a single commit.
-   * @name CommitsDetail2
+   * @name CommitsDetail
    * @request GET:/repos/{owner}/{repo}/commits/{shaCode}
-   * @originalName commitsDetail
-   * @duplicate
    */
-  export namespace CommitsDetail2 {
+  export namespace CommitsDetail {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -3504,10 +3488,10 @@ export namespace Repos {
 
   /**
    * @description List comments for a single commitList comments for a single commit.
-   * @name CommitsCommentsDetail
+   * @name CommitsCommentsList
    * @request GET:/repos/{owner}/{repo}/commits/{shaCode}/comments
    */
-  export namespace CommitsCommentsDetail {
+  export namespace CommitsCommentsList {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -3644,10 +3628,10 @@ export namespace Repos {
 
   /**
    * @description Get list of contributors.
-   * @name ContributorsDetail
+   * @name ContributorsList
    * @request GET:/repos/{owner}/{repo}/contributors
    */
-  export namespace ContributorsDetail {
+  export namespace ContributorsList {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -3668,10 +3652,10 @@ export namespace Repos {
 
   /**
    * @description Users with pull access can view deployments for a repository
-   * @name DeploymentsDetail
+   * @name DeploymentsList
    * @request GET:/repos/{owner}/{repo}/deployments
    */
-  export namespace DeploymentsDetail {
+  export namespace DeploymentsList {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -3710,10 +3694,10 @@ export namespace Repos {
 
   /**
    * @description Users with pull access can view deployment statuses for a deployment
-   * @name DeploymentsStatusesDetail
+   * @name DeploymentsStatusesList
    * @request GET:/repos/{owner}/{repo}/deployments/{id}/statuses
    */
-  export namespace DeploymentsStatusesDetail {
+  export namespace DeploymentsStatusesList {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -3756,11 +3740,11 @@ export namespace Repos {
 
   /**
    * @description Deprecated. List downloads for a repository.
-   * @name DownloadsDetail
+   * @name DownloadsList
    * @request GET:/repos/{owner}/{repo}/downloads
    * @deprecated
    */
-  export namespace DownloadsDetail {
+  export namespace DownloadsList {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -3802,13 +3786,11 @@ export namespace Repos {
 
   /**
    * @description Deprecated. Get a single download.
-   * @name DownloadsDetail2
+   * @name DownloadsDetail
    * @request GET:/repos/{owner}/{repo}/downloads/{downloadId}
    * @deprecated
-   * @originalName downloadsDetail
-   * @duplicate
    */
-  export namespace DownloadsDetail2 {
+  export namespace DownloadsDetail {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -3828,10 +3810,10 @@ export namespace Repos {
 
   /**
    * @description Get list of repository events.
-   * @name EventsDetail
+   * @name EventsList
    * @request GET:/repos/{owner}/{repo}/events
    */
-  export namespace EventsDetail {
+  export namespace EventsList {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -3849,10 +3831,10 @@ export namespace Repos {
 
   /**
    * @description List forks.
-   * @name ForksDetail
+   * @name ForksList
    * @request GET:/repos/{owner}/{repo}/forks
    */
-  export namespace ForksDetail {
+  export namespace ForksList {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -3982,10 +3964,10 @@ export namespace Repos {
 
   /**
    * @description Get all References
-   * @name GitRefsDetail
+   * @name GitRefsList
    * @request GET:/repos/{owner}/{repo}/git/refs
    */
-  export namespace GitRefsDetail {
+  export namespace GitRefsList {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -4046,12 +4028,10 @@ export namespace Repos {
 
   /**
    * @description Get a Reference
-   * @name GitRefsDetail2
+   * @name GitRefsDetail
    * @request GET:/repos/{owner}/{repo}/git/refs/{ref}
-   * @originalName gitRefsDetail
-   * @duplicate
    */
-  export namespace GitRefsDetail2 {
+  export namespace GitRefsDetail {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -4182,10 +4162,10 @@ export namespace Repos {
 
   /**
    * @description Get list of hooks.
-   * @name HooksDetail
+   * @name HooksList
    * @request GET:/repos/{owner}/{repo}/hooks
    */
-  export namespace HooksDetail {
+  export namespace HooksList {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -4247,12 +4227,10 @@ export namespace Repos {
 
   /**
    * @description Get single hook.
-   * @name HooksDetail2
+   * @name HooksDetail
    * @request GET:/repos/{owner}/{repo}/hooks/{hookId}
-   * @originalName hooksDetail
-   * @duplicate
    */
-  export namespace HooksDetail2 {
+  export namespace HooksDetail {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -4318,10 +4296,10 @@ export namespace Repos {
 
   /**
    * @description List issues for a repository.
-   * @name IssuesDetail
+   * @name IssuesList
    * @request GET:/repos/{owner}/{repo}/issues
    */
-  export namespace IssuesDetail {
+  export namespace IssuesList {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -4380,10 +4358,10 @@ export namespace Repos {
 
   /**
    * @description List comments in a repository.
-   * @name IssuesCommentsDetail
+   * @name IssuesCommentsList
    * @request GET:/repos/{owner}/{repo}/issues/comments
    */
-  export namespace IssuesCommentsDetail {
+  export namespace IssuesCommentsList {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -4433,12 +4411,10 @@ export namespace Repos {
 
   /**
    * @description Get a single comment.
-   * @name IssuesCommentsDetail2
+   * @name IssuesCommentsDetail
    * @request GET:/repos/{owner}/{repo}/issues/comments/{commentId}
-   * @originalName issuesCommentsDetail
-   * @duplicate
    */
-  export namespace IssuesCommentsDetail2 {
+  export namespace IssuesCommentsDetail {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -4481,10 +4457,10 @@ export namespace Repos {
 
   /**
    * @description List issue events for a repository.
-   * @name IssuesEventsDetail
+   * @name IssuesEventsList
    * @request GET:/repos/{owner}/{repo}/issues/events
    */
-  export namespace IssuesEventsDetail {
+  export namespace IssuesEventsList {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -4502,12 +4478,10 @@ export namespace Repos {
 
   /**
    * @description Get a single event.
-   * @name IssuesEventsDetail2
+   * @name IssuesEventsDetail
    * @request GET:/repos/{owner}/{repo}/issues/events/{eventId}
-   * @originalName issuesEventsDetail
-   * @duplicate
    */
-  export namespace IssuesEventsDetail2 {
+  export namespace IssuesEventsDetail {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -4527,12 +4501,10 @@ export namespace Repos {
 
   /**
    * @description Get a single issue
-   * @name IssuesDetail2
+   * @name IssuesDetail
    * @request GET:/repos/{owner}/{repo}/issues/{number}
-   * @originalName issuesDetail
-   * @duplicate
    */
-  export namespace IssuesDetail2 {
+  export namespace IssuesDetail {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -4575,12 +4547,12 @@ export namespace Repos {
 
   /**
    * @description List comments on an issue.
-   * @name IssuesCommentsDetail3
+   * @name IssuesCommentsList2
    * @request GET:/repos/{owner}/{repo}/issues/{number}/comments
-   * @originalName issuesCommentsDetail
+   * @originalName issuesCommentsList
    * @duplicate
    */
-  export namespace IssuesCommentsDetail3 {
+  export namespace IssuesCommentsList2 {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -4623,12 +4595,12 @@ export namespace Repos {
 
   /**
    * @description List events for an issue.
-   * @name IssuesEventsDetail3
+   * @name IssuesEventsList2
    * @request GET:/repos/{owner}/{repo}/issues/{number}/events
-   * @originalName issuesEventsDetail
+   * @originalName issuesEventsList
    * @duplicate
    */
-  export namespace IssuesEventsDetail3 {
+  export namespace IssuesEventsList2 {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -4671,10 +4643,10 @@ export namespace Repos {
 
   /**
    * @description List labels on an issue.
-   * @name IssuesLabelsDetail
+   * @name IssuesLabelsList
    * @request GET:/repos/{owner}/{repo}/issues/{number}/labels
    */
-  export namespace IssuesLabelsDetail {
+  export namespace IssuesLabelsList {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -4767,10 +4739,10 @@ export namespace Repos {
 
   /**
    * @description Get list of keys.
-   * @name KeysDetail
+   * @name KeysList
    * @request GET:/repos/{owner}/{repo}/keys
    */
-  export namespace KeysDetail {
+  export namespace KeysList {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -4832,12 +4804,10 @@ export namespace Repos {
 
   /**
    * @description Get a key
-   * @name KeysDetail2
+   * @name KeysDetail
    * @request GET:/repos/{owner}/{repo}/keys/{keyId}
-   * @originalName keysDetail
-   * @duplicate
    */
-  export namespace KeysDetail2 {
+  export namespace KeysDetail {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -4857,10 +4827,10 @@ export namespace Repos {
 
   /**
    * @description List all labels for this repository.
-   * @name LabelsDetail
+   * @name LabelsList
    * @request GET:/repos/{owner}/{repo}/labels
    */
-  export namespace LabelsDetail {
+  export namespace LabelsList {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -4922,12 +4892,10 @@ export namespace Repos {
 
   /**
    * @description Get a single label.
-   * @name LabelsDetail2
+   * @name LabelsDetail
    * @request GET:/repos/{owner}/{repo}/labels/{name}
-   * @originalName labelsDetail
-   * @duplicate
    */
-  export namespace LabelsDetail2 {
+  export namespace LabelsDetail {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -4970,10 +4938,10 @@ export namespace Repos {
 
   /**
    * @description List languages. List languages for the specified repository. The value on the right of a language is the number of bytes of code written in that language.
-   * @name LanguagesDetail
+   * @name LanguagesList
    * @request GET:/repos/{owner}/{repo}/languages
    */
-  export namespace LanguagesDetail {
+  export namespace LanguagesList {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -5012,10 +4980,10 @@ export namespace Repos {
 
   /**
    * @description List milestones for a repository.
-   * @name MilestonesDetail
+   * @name MilestonesList
    * @request GET:/repos/{owner}/{repo}/milestones
    */
-  export namespace MilestonesDetail {
+  export namespace MilestonesList {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -5087,12 +5055,10 @@ export namespace Repos {
 
   /**
    * @description Get a single milestone.
-   * @name MilestonesDetail2
+   * @name MilestonesDetail
    * @request GET:/repos/{owner}/{repo}/milestones/{number}
-   * @originalName milestonesDetail
-   * @duplicate
    */
-  export namespace MilestonesDetail2 {
+  export namespace MilestonesDetail {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -5135,10 +5101,10 @@ export namespace Repos {
 
   /**
    * @description Get labels for every issue in a milestone.
-   * @name MilestonesLabelsDetail
+   * @name MilestonesLabelsList
    * @request GET:/repos/{owner}/{repo}/milestones/{number}/labels
    */
-  export namespace MilestonesLabelsDetail {
+  export namespace MilestonesLabelsList {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -5158,10 +5124,10 @@ export namespace Repos {
 
   /**
    * @description List your notifications in a repository List all notifications for the current user.
-   * @name NotificationsDetail
+   * @name NotificationsList
    * @request GET:/repos/{owner}/{repo}/notifications
    */
-  export namespace NotificationsDetail {
+  export namespace NotificationsList {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -5213,10 +5179,10 @@ export namespace Repos {
 
   /**
    * @description List pull requests.
-   * @name PullsDetail
+   * @name PullsList
    * @request GET:/repos/{owner}/{repo}/pulls
    */
-  export namespace PullsDetail {
+  export namespace PullsList {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -5268,10 +5234,10 @@ export namespace Repos {
 
   /**
    * @description List comments in a repository. By default, Review Comments are ordered by ascending ID.
-   * @name PullsCommentsDetail
+   * @name PullsCommentsList
    * @request GET:/repos/{owner}/{repo}/pulls/comments
    */
-  export namespace PullsCommentsDetail {
+  export namespace PullsCommentsList {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -5321,12 +5287,10 @@ export namespace Repos {
 
   /**
    * @description Get a single comment.
-   * @name PullsCommentsDetail2
+   * @name PullsCommentsDetail
    * @request GET:/repos/{owner}/{repo}/pulls/comments/{commentId}
-   * @originalName pullsCommentsDetail
-   * @duplicate
    */
-  export namespace PullsCommentsDetail2 {
+  export namespace PullsCommentsDetail {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -5369,12 +5333,10 @@ export namespace Repos {
 
   /**
    * @description Get a single pull request.
-   * @name PullsDetail2
+   * @name PullsDetail
    * @request GET:/repos/{owner}/{repo}/pulls/{number}
-   * @originalName pullsDetail
-   * @duplicate
    */
-  export namespace PullsDetail2 {
+  export namespace PullsDetail {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -5417,12 +5379,12 @@ export namespace Repos {
 
   /**
    * @description List comments on a pull request.
-   * @name PullsCommentsDetail3
+   * @name PullsCommentsList2
    * @request GET:/repos/{owner}/{repo}/pulls/{number}/comments
-   * @originalName pullsCommentsDetail
+   * @originalName pullsCommentsList
    * @duplicate
    */
-  export namespace PullsCommentsDetail3 {
+  export namespace PullsCommentsList2 {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -5465,10 +5427,10 @@ export namespace Repos {
 
   /**
    * @description List commits on a pull request.
-   * @name PullsCommitsDetail
+   * @name PullsCommitsList
    * @request GET:/repos/{owner}/{repo}/pulls/{number}/commits
    */
-  export namespace PullsCommitsDetail {
+  export namespace PullsCommitsList {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -5488,10 +5450,10 @@ export namespace Repos {
 
   /**
    * @description List pull requests files.
-   * @name PullsFilesDetail
+   * @name PullsFilesList
    * @request GET:/repos/{owner}/{repo}/pulls/{number}/files
    */
-  export namespace PullsFilesDetail {
+  export namespace PullsFilesList {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -5511,10 +5473,10 @@ export namespace Repos {
 
   /**
    * @description Get if a pull request has been merged.
-   * @name PullsMergeDetail
+   * @name PullsMergeList
    * @request GET:/repos/{owner}/{repo}/pulls/{number}/merge
    */
-  export namespace PullsMergeDetail {
+  export namespace PullsMergeList {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -5557,10 +5519,10 @@ export namespace Repos {
 
   /**
    * @description Get the README. This method returns the preferred README for a repository.
-   * @name ReadmeDetail
+   * @name ReadmeList
    * @request GET:/repos/{owner}/{repo}/readme
    */
-  export namespace ReadmeDetail {
+  export namespace ReadmeList {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -5581,10 +5543,10 @@ export namespace Repos {
 
   /**
    * @description Users with push access to the repository will receive all releases (i.e., published releases and draft releases). Users with pull access will receive published releases only
-   * @name ReleasesDetail
+   * @name ReleasesList
    * @request GET:/repos/{owner}/{repo}/releases
    */
-  export namespace ReleasesDetail {
+  export namespace ReleasesList {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -5711,12 +5673,10 @@ export namespace Repos {
 
   /**
    * @description Get a single release
-   * @name ReleasesDetail2
+   * @name ReleasesDetail
    * @request GET:/repos/{owner}/{repo}/releases/{id}
-   * @originalName releasesDetail
-   * @duplicate
    */
-  export namespace ReleasesDetail2 {
+  export namespace ReleasesDetail {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -5757,12 +5717,10 @@ export namespace Repos {
 
   /**
    * @description List assets for a release
-   * @name ReleasesAssetsDetail2
+   * @name ReleasesAssetsList
    * @request GET:/repos/{owner}/{repo}/releases/{id}/assets
-   * @originalName releasesAssetsDetail
-   * @duplicate
    */
-  export namespace ReleasesAssetsDetail2 {
+  export namespace ReleasesAssetsList {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -5781,10 +5739,10 @@ export namespace Repos {
 
   /**
    * @description List Stargazers.
-   * @name StargazersDetail
+   * @name StargazersList
    * @request GET:/repos/{owner}/{repo}/stargazers
    */
-  export namespace StargazersDetail {
+  export namespace StargazersList {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -5802,10 +5760,10 @@ export namespace Repos {
 
   /**
    * @description Get the number of additions and deletions per week. Returns a weekly aggregate of the number of additions and deletions pushed to a repository.
-   * @name StatsCodeFrequencyDetail
+   * @name StatsCodeFrequencyList
    * @request GET:/repos/{owner}/{repo}/stats/code_frequency
    */
-  export namespace StatsCodeFrequencyDetail {
+  export namespace StatsCodeFrequencyList {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -5823,10 +5781,10 @@ export namespace Repos {
 
   /**
    * @description Get the last year of commit activity data. Returns the last year of commit activity grouped by week. The days array is a group of commits per day, starting on Sunday.
-   * @name StatsCommitActivityDetail
+   * @name StatsCommitActivityList
    * @request GET:/repos/{owner}/{repo}/stats/commit_activity
    */
-  export namespace StatsCommitActivityDetail {
+  export namespace StatsCommitActivityList {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -5844,10 +5802,10 @@ export namespace Repos {
 
   /**
    * @description Get contributors list with additions, deletions, and commit counts.
-   * @name StatsContributorsDetail
+   * @name StatsContributorsList
    * @request GET:/repos/{owner}/{repo}/stats/contributors
    */
-  export namespace StatsContributorsDetail {
+  export namespace StatsContributorsList {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -5865,10 +5823,10 @@ export namespace Repos {
 
   /**
    * @description Get the weekly commit count for the repo owner and everyone else.
-   * @name StatsParticipationDetail
+   * @name StatsParticipationList
    * @request GET:/repos/{owner}/{repo}/stats/participation
    */
-  export namespace StatsParticipationDetail {
+  export namespace StatsParticipationList {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -5886,10 +5844,10 @@ export namespace Repos {
 
   /**
    * @description Get the number of commits per hour in each day. Each array contains the day number, hour number, and number of commits 0-6 Sunday - Saturday 0-23 Hour of day Number of commits For example, [2, 14, 25] indicates that there were 25 total commits, during the 2.00pm hour on Tuesdays. All times are based on the time zone of individual commits.
-   * @name StatsPunchCardDetail
+   * @name StatsPunchCardList
    * @request GET:/repos/{owner}/{repo}/stats/punch_card
    */
-  export namespace StatsPunchCardDetail {
+  export namespace StatsPunchCardList {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -5953,10 +5911,10 @@ export namespace Repos {
 
   /**
    * @description List watchers.
-   * @name SubscribersDetail
+   * @name SubscribersList
    * @request GET:/repos/{owner}/{repo}/subscribers
    */
-  export namespace SubscribersDetail {
+  export namespace SubscribersList {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -5995,10 +5953,10 @@ export namespace Repos {
 
   /**
    * @description Get a Repository Subscription.
-   * @name SubscriptionDetail
+   * @name SubscriptionList
    * @request GET:/repos/{owner}/{repo}/subscription
    */
-  export namespace SubscriptionDetail {
+  export namespace SubscriptionList {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -6037,10 +5995,10 @@ export namespace Repos {
 
   /**
    * @description Get list of tags.
-   * @name TagsDetail
+   * @name TagsList
    * @request GET:/repos/{owner}/{repo}/tags
    */
-  export namespace TagsDetail {
+  export namespace TagsList {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -6058,10 +6016,10 @@ export namespace Repos {
 
   /**
    * @description Get list of teams
-   * @name TeamsDetail
+   * @name TeamsList
    * @request GET:/repos/{owner}/{repo}/teams
    */
-  export namespace TeamsDetail {
+  export namespace TeamsList {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -6079,10 +6037,10 @@ export namespace Repos {
 
   /**
    * @description List Stargazers. New implementation.
-   * @name WatchersDetail
+   * @name WatchersList
    * @request GET:/repos/{owner}/{repo}/watchers
    */
-  export namespace WatchersDetail {
+  export namespace WatchersList {
     export type RequestParams = {
       /** Name of repository owner. */
       owner: string;
@@ -6360,10 +6318,10 @@ export namespace Teams {
 
   /**
    * @description List team members. In order to list members in a team, the authenticated user must be a member of the team.
-   * @name MembersDetail
+   * @name MembersList
    * @request GET:/teams/{teamId}/members
    */
-  export namespace MembersDetail {
+  export namespace MembersList {
     export type RequestParams = {
       /** Id of team. */
       teamId: number;
@@ -6401,13 +6359,11 @@ export namespace Teams {
 
   /**
    * @description The "Get team member" API is deprecated and is scheduled for removal in the next major version of the API. We recommend using the Get team membership API instead. It allows you to get both active and pending memberships. Get team member. In order to get if a user is a member of a team, the authenticated user mus be a member of the team.
-   * @name MembersDetail2
+   * @name MembersDetail
    * @request GET:/teams/{teamId}/members/{username}
    * @deprecated
-   * @originalName membersDetail
-   * @duplicate
    */
-  export namespace MembersDetail2 {
+  export namespace MembersDetail {
     export type RequestParams = {
       /** Id of team. */
       teamId: number;
@@ -6510,10 +6466,10 @@ export namespace Teams {
 
   /**
    * @description List team repos
-   * @name ReposDetail
+   * @name ReposList
    * @request GET:/teams/{teamId}/repos
    */
-  export namespace ReposDetail {
+  export namespace ReposList {
     export type RequestParams = {
       /** Id of team. */
       teamId: number;
@@ -6552,12 +6508,10 @@ export namespace Teams {
 
   /**
    * @description Check if a team manages a repository
-   * @name ReposDetail2
+   * @name ReposDetail
    * @request GET:/teams/{teamId}/repos/{owner}/{repo}
-   * @originalName reposDetail
-   * @duplicate
    */
-  export namespace ReposDetail2 {
+  export namespace ReposDetail {
     export type RequestParams = {
       /** Id of team. */
       teamId: number;
@@ -7150,10 +7104,10 @@ export namespace Users {
 
   /**
    * @description If you are authenticated as the given user, you will see your private events. Otherwise, you'll only see public events.
-   * @name EventsDetail
+   * @name EventsList
    * @request GET:/users/{username}/events
    */
-  export namespace EventsDetail {
+  export namespace EventsList {
     export type RequestParams = {
       /** Name of user. */
       username: string;
@@ -7189,10 +7143,10 @@ export namespace Users {
 
   /**
    * @description List a user's followers
-   * @name FollowersDetail
+   * @name FollowersList
    * @request GET:/users/{username}/followers
    */
-  export namespace FollowersDetail {
+  export namespace FollowersList {
     export type RequestParams = {
       /** Name of user. */
       username: string;
@@ -7229,10 +7183,10 @@ export namespace Users {
 
   /**
    * @description List a users gists.
-   * @name GistsDetail
+   * @name GistsList
    * @request GET:/users/{username}/gists
    */
-  export namespace GistsDetail {
+  export namespace GistsList {
     export type RequestParams = {
       /** Name of user. */
       username: string;
@@ -7254,10 +7208,10 @@ export namespace Users {
 
   /**
    * @description List public keys for a user. Lists the verified public keys for a user. This is accessible by anyone.
-   * @name KeysDetail
+   * @name KeysList
    * @request GET:/users/{username}/keys
    */
-  export namespace KeysDetail {
+  export namespace KeysList {
     export type RequestParams = {
       /** Name of user. */
       username: string;
@@ -7273,10 +7227,10 @@ export namespace Users {
 
   /**
    * @description List all public organizations for a user.
-   * @name OrgsDetail
+   * @name OrgsList
    * @request GET:/users/{username}/orgs
    */
-  export namespace OrgsDetail {
+  export namespace OrgsList {
     export type RequestParams = {
       /** Name of user. */
       username: string;
@@ -7292,10 +7246,10 @@ export namespace Users {
 
   /**
    * @description These are events that you'll only see public events.
-   * @name ReceivedEventsDetail
+   * @name ReceivedEventsList
    * @request GET:/users/{username}/received_events
    */
-  export namespace ReceivedEventsDetail {
+  export namespace ReceivedEventsList {
     export type RequestParams = {
       /** Name of user. */
       username: string;
@@ -7311,10 +7265,10 @@ export namespace Users {
 
   /**
    * @description List public events that a user has received
-   * @name ReceivedEventsPublicDetail
+   * @name ReceivedEventsPublicList
    * @request GET:/users/{username}/received_events/public
    */
-  export namespace ReceivedEventsPublicDetail {
+  export namespace ReceivedEventsPublicList {
     export type RequestParams = {
       /** Name of user. */
       username: string;
@@ -7330,10 +7284,10 @@ export namespace Users {
 
   /**
    * @description List public repositories for the specified user.
-   * @name ReposDetail
+   * @name ReposList
    * @request GET:/users/{username}/repos
    */
-  export namespace ReposDetail {
+  export namespace ReposList {
     export type RequestParams = {
       /** Name of user. */
       username: string;
@@ -7352,10 +7306,10 @@ export namespace Users {
 
   /**
    * @description List repositories being starred by a user.
-   * @name StarredDetail
+   * @name StarredList
    * @request GET:/users/{username}/starred
    */
-  export namespace StarredDetail {
+  export namespace StarredList {
     export type RequestParams = {
       /** Name of user. */
       username: string;
@@ -7371,10 +7325,10 @@ export namespace Users {
 
   /**
    * @description List repositories being watched by a user.
-   * @name SubscriptionsDetail
+   * @name SubscriptionsList
    * @request GET:/users/{username}/subscriptions
    */
-  export namespace SubscriptionsDetail {
+  export namespace SubscriptionsList {
     export type RequestParams = {
       /** Name of user. */
       username: string;

--- a/tests/spec/sortTypes-false/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/sortTypes-false/__snapshots__/basic.test.ts.snap
@@ -2207,10 +2207,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name CommentsDetail
+     * @name CommentsList
      * @request GET:/gists/{id}/comments
      */
-    commentsDetail: (id: number, params: RequestParams = {}) =>
+    commentsList: (id: number, params: RequestParams = {}) =>
       this.request<Comments, void>({
         path: \`/gists/\${id}/comments\`,
         method: "GET",
@@ -2249,12 +2249,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name CommentsDetail2
+     * @name CommentsDetail
      * @request GET:/gists/{id}/comments/{commentId}
-     * @originalName commentsDetail
-     * @duplicate
      */
-    commentsDetail2: (id: number, commentId: number, params: RequestParams = {}) =>
+    commentsDetail: (id: number, commentId: number, params: RequestParams = {}) =>
       this.request<Comment, void>({
         path: \`/gists/\${id}/comments/\${commentId}\`,
         method: "GET",
@@ -2307,10 +2305,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name StarDetail
+     * @name StarList
      * @request GET:/gists/{id}/star
      */
-    starDetail: (id: number, params: RequestParams = {}) =>
+    starList: (id: number, params: RequestParams = {}) =>
       this.request<void, void>({
         path: \`/gists/\${id}/star\`,
         method: "GET",
@@ -2516,10 +2514,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name EventsDetail
+     * @name EventsList
      * @request GET:/networks/{owner}/{repo}/events
      */
-    eventsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    eventsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Events, void>({
         path: \`/networks/\${owner}/\${repo}/events\`,
         method: "GET",
@@ -2607,10 +2605,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ThreadsSubscriptionDetail
+     * @name ThreadsSubscriptionList
      * @request GET:/notifications/threads/{id}/subscription
      */
-    threadsSubscriptionDetail: (id: number, params: RequestParams = {}) =>
+    threadsSubscriptionList: (id: number, params: RequestParams = {}) =>
       this.request<Subscription, void>({
         path: \`/notifications/threads/\${id}/subscription\`,
         method: "GET",
@@ -2668,10 +2666,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name EventsDetail
+     * @name EventsList
      * @request GET:/orgs/{org}/events
      */
-    eventsDetail: (org: string, params: RequestParams = {}) =>
+    eventsList: (org: string, params: RequestParams = {}) =>
       this.request<Events, void>({
         path: \`/orgs/\${org}/events\`,
         method: "GET",
@@ -2682,10 +2680,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name IssuesDetail
+     * @name IssuesList
      * @request GET:/orgs/{org}/issues
      */
-    issuesDetail: (
+    issuesList: (
       org: string,
       query: {
         filter: "assigned" | "created" | "mentioned" | "subscribed" | "all";
@@ -2708,10 +2706,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name MembersDetail
+     * @name MembersList
      * @request GET:/orgs/{org}/members
      */
-    membersDetail: (org: string, params: RequestParams = {}) =>
+    membersList: (org: string, params: RequestParams = {}) =>
       this.request<Users, void>({
         path: \`/orgs/\${org}/members\`,
         method: "GET",
@@ -2735,12 +2733,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name MembersDetail2
+     * @name MembersDetail
      * @request GET:/orgs/{org}/members/{username}
-     * @originalName membersDetail
-     * @duplicate
      */
-    membersDetail2: (org: string, username: string, params: RequestParams = {}) =>
+    membersDetail: (org: string, username: string, params: RequestParams = {}) =>
       this.request<void, void>({
         path: \`/orgs/\${org}/members/\${username}\`,
         method: "GET",
@@ -2750,10 +2746,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name PublicMembersDetail
+     * @name PublicMembersList
      * @request GET:/orgs/{org}/public_members
      */
-    publicMembersDetail: (org: string, params: RequestParams = {}) =>
+    publicMembersList: (org: string, params: RequestParams = {}) =>
       this.request<Users, void>({
         path: \`/orgs/\${org}/public_members\`,
         method: "GET",
@@ -2777,12 +2773,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name PublicMembersDetail2
+     * @name PublicMembersDetail
      * @request GET:/orgs/{org}/public_members/{username}
-     * @originalName publicMembersDetail
-     * @duplicate
      */
-    publicMembersDetail2: (org: string, username: string, params: RequestParams = {}) =>
+    publicMembersDetail: (org: string, username: string, params: RequestParams = {}) =>
       this.request<void, void>({
         path: \`/orgs/\${org}/public_members/\${username}\`,
         method: "GET",
@@ -2805,10 +2799,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ReposDetail
+     * @name ReposList
      * @request GET:/orgs/{org}/repos
      */
-    reposDetail: (
+    reposList: (
       org: string,
       query?: {
         type?: "all" | "public" | "private" | "forks" | "sources" | "member";
@@ -2841,10 +2835,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name TeamsDetail
+     * @name TeamsList
      * @request GET:/orgs/{org}/teams
      */
-    teamsDetail: (org: string, params: RequestParams = {}) =>
+    teamsList: (org: string, params: RequestParams = {}) =>
       this.request<Teams, void>({
         path: \`/orgs/\${org}/teams\`,
         method: "GET",
@@ -2930,10 +2924,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name AssigneesDetail
+     * @name AssigneesList
      * @request GET:/repos/{owner}/{repo}/assignees
      */
-    assigneesDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    assigneesList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Assignees, void>({
         path: \`/repos/\${owner}/\${repo}/assignees\`,
         method: "GET",
@@ -2944,12 +2938,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name AssigneesDetail2
+     * @name AssigneesDetail
      * @request GET:/repos/{owner}/{repo}/assignees/{assignee}
-     * @originalName assigneesDetail
-     * @duplicate
      */
-    assigneesDetail2: (owner: string, repo: string, assignee: string, params: RequestParams = {}) =>
+    assigneesDetail: (owner: string, repo: string, assignee: string, params: RequestParams = {}) =>
       this.request<void, void>({
         path: \`/repos/\${owner}/\${repo}/assignees/\${assignee}\`,
         method: "GET",
@@ -2959,10 +2951,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name BranchesDetail
+     * @name BranchesList
      * @request GET:/repos/{owner}/{repo}/branches
      */
-    branchesDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    branchesList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Branches, void>({
         path: \`/repos/\${owner}/\${repo}/branches\`,
         method: "GET",
@@ -2973,12 +2965,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name BranchesDetail2
+     * @name BranchesDetail
      * @request GET:/repos/{owner}/{repo}/branches/{branch}
-     * @originalName branchesDetail
-     * @duplicate
      */
-    branchesDetail2: (owner: string, repo: string, branch: string, params: RequestParams = {}) =>
+    branchesDetail: (owner: string, repo: string, branch: string, params: RequestParams = {}) =>
       this.request<Branch, void>({
         path: \`/repos/\${owner}/\${repo}/branches/\${branch}\`,
         method: "GET",
@@ -2989,10 +2979,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name CollaboratorsDetail
+     * @name CollaboratorsList
      * @request GET:/repos/{owner}/{repo}/collaborators
      */
-    collaboratorsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    collaboratorsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Users, void>({
         path: \`/repos/\${owner}/\${repo}/collaborators\`,
         method: "GET",
@@ -3016,12 +3006,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name CollaboratorsDetail2
+     * @name CollaboratorsDetail
      * @request GET:/repos/{owner}/{repo}/collaborators/{user}
-     * @originalName collaboratorsDetail
-     * @duplicate
      */
-    collaboratorsDetail2: (owner: string, repo: string, user: string, params: RequestParams = {}) =>
+    collaboratorsDetail: (owner: string, repo: string, user: string, params: RequestParams = {}) =>
       this.request<void, void>({
         path: \`/repos/\${owner}/\${repo}/collaborators/\${user}\`,
         method: "GET",
@@ -3044,10 +3032,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name CommentsDetail
+     * @name CommentsList
      * @request GET:/repos/{owner}/{repo}/comments
      */
-    commentsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    commentsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<RepoComments, void>({
         path: \`/repos/\${owner}/\${repo}/comments\`,
         method: "GET",
@@ -3071,12 +3059,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name CommentsDetail2
+     * @name CommentsDetail
      * @request GET:/repos/{owner}/{repo}/comments/{commentId}
-     * @originalName commentsDetail
-     * @duplicate
      */
-    commentsDetail2: (owner: string, repo: string, commentId: number, params: RequestParams = {}) =>
+    commentsDetail: (owner: string, repo: string, commentId: number, params: RequestParams = {}) =>
       this.request<CommitComment, void>({
         path: \`/repos/\${owner}/\${repo}/comments/\${commentId}\`,
         method: "GET",
@@ -3108,10 +3094,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name CommitsDetail
+     * @name CommitsList
      * @request GET:/repos/{owner}/{repo}/commits
      */
-    commitsDetail: (
+    commitsList: (
       owner: string,
       repo: string,
       query?: {
@@ -3134,10 +3120,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name CommitsStatusDetail
+     * @name CommitsStatusList
      * @request GET:/repos/{owner}/{repo}/commits/{ref}/status
      */
-    commitsStatusDetail: (owner: string, repo: string, ref: string, params: RequestParams = {}) =>
+    commitsStatusList: (owner: string, repo: string, ref: string, params: RequestParams = {}) =>
       this.request<RefStatus, void>({
         path: \`/repos/\${owner}/\${repo}/commits/\${ref}/status\`,
         method: "GET",
@@ -3148,12 +3134,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name CommitsDetail2
+     * @name CommitsDetail
      * @request GET:/repos/{owner}/{repo}/commits/{shaCode}
-     * @originalName commitsDetail
-     * @duplicate
      */
-    commitsDetail2: (owner: string, repo: string, shaCode: string, params: RequestParams = {}) =>
+    commitsDetail: (owner: string, repo: string, shaCode: string, params: RequestParams = {}) =>
       this.request<Commit, void>({
         path: \`/repos/\${owner}/\${repo}/commits/\${shaCode}\`,
         method: "GET",
@@ -3164,10 +3148,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name CommitsCommentsDetail
+     * @name CommitsCommentsList
      * @request GET:/repos/{owner}/{repo}/commits/{shaCode}/comments
      */
-    commitsCommentsDetail: (owner: string, repo: string, shaCode: string, params: RequestParams = {}) =>
+    commitsCommentsList: (owner: string, repo: string, shaCode: string, params: RequestParams = {}) =>
       this.request<RepoComments, void>({
         path: \`/repos/\${owner}/\${repo}/commits/\${shaCode}/comments\`,
         method: "GET",
@@ -3270,10 +3254,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ContributorsDetail
+     * @name ContributorsList
      * @request GET:/repos/{owner}/{repo}/contributors
      */
-    contributorsDetail: (
+    contributorsList: (
       owner: string,
       repo: string,
       query: {
@@ -3292,10 +3276,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name DeploymentsDetail
+     * @name DeploymentsList
      * @request GET:/repos/{owner}/{repo}/deployments
      */
-    deploymentsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    deploymentsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<RepoDeployments, void>({
         path: \`/repos/\${owner}/\${repo}/deployments\`,
         method: "GET",
@@ -3322,10 +3306,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name DeploymentsStatusesDetail
+     * @name DeploymentsStatusesList
      * @request GET:/repos/{owner}/{repo}/deployments/{id}/statuses
      */
-    deploymentsStatusesDetail: (owner: string, repo: string, id: number, params: RequestParams = {}) =>
+    deploymentsStatusesList: (owner: string, repo: string, id: number, params: RequestParams = {}) =>
       this.request<DeploymentStatuses, void>({
         path: \`/repos/\${owner}/\${repo}/deployments/\${id}/statuses\`,
         method: "GET",
@@ -3357,10 +3341,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name DownloadsDetail
+     * @name DownloadsList
      * @request GET:/repos/{owner}/{repo}/downloads
      */
-    downloadsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    downloadsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Downloads, void>({
         path: \`/repos/\${owner}/\${repo}/downloads\`,
         method: "GET",
@@ -3384,12 +3368,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name DownloadsDetail2
+     * @name DownloadsDetail
      * @request GET:/repos/{owner}/{repo}/downloads/{downloadId}
-     * @originalName downloadsDetail
-     * @duplicate
      */
-    downloadsDetail2: (owner: string, repo: string, downloadId: number, params: RequestParams = {}) =>
+    downloadsDetail: (owner: string, repo: string, downloadId: number, params: RequestParams = {}) =>
       this.request<Download, void>({
         path: \`/repos/\${owner}/\${repo}/downloads/\${downloadId}\`,
         method: "GET",
@@ -3400,10 +3382,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name EventsDetail
+     * @name EventsList
      * @request GET:/repos/{owner}/{repo}/events
      */
-    eventsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    eventsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Events, void>({
         path: \`/repos/\${owner}/\${repo}/events\`,
         method: "GET",
@@ -3414,10 +3396,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ForksDetail
+     * @name ForksList
      * @request GET:/repos/{owner}/{repo}/forks
      */
-    forksDetail: (
+    forksList: (
       owner: string,
       repo: string,
       query?: {
@@ -3512,10 +3494,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name GitRefsDetail
+     * @name GitRefsList
      * @request GET:/repos/{owner}/{repo}/git/refs
      */
-    gitRefsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    gitRefsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Refs, void>({
         path: \`/repos/\${owner}/\${repo}/git/refs\`,
         method: "GET",
@@ -3555,12 +3537,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name GitRefsDetail2
+     * @name GitRefsDetail
      * @request GET:/repos/{owner}/{repo}/git/refs/{ref}
-     * @originalName gitRefsDetail
-     * @duplicate
      */
-    gitRefsDetail2: (owner: string, repo: string, ref: string, params: RequestParams = {}) =>
+    gitRefsDetail: (owner: string, repo: string, ref: string, params: RequestParams = {}) =>
       this.request<HeadBranch, void>({
         path: \`/repos/\${owner}/\${repo}/git/refs/\${ref}\`,
         method: "GET",
@@ -3656,10 +3636,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name HooksDetail
+     * @name HooksList
      * @request GET:/repos/{owner}/{repo}/hooks
      */
-    hooksDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    hooksList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Hook, void>({
         path: \`/repos/\${owner}/\${repo}/hooks\`,
         method: "GET",
@@ -3698,12 +3678,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name HooksDetail2
+     * @name HooksDetail
      * @request GET:/repos/{owner}/{repo}/hooks/{hookId}
-     * @originalName hooksDetail
-     * @duplicate
      */
-    hooksDetail2: (owner: string, repo: string, hookId: number, params: RequestParams = {}) =>
+    hooksDetail: (owner: string, repo: string, hookId: number, params: RequestParams = {}) =>
       this.request<Hook, void>({
         path: \`/repos/\${owner}/\${repo}/hooks/\${hookId}\`,
         method: "GET",
@@ -3742,10 +3720,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name IssuesDetail
+     * @name IssuesList
      * @request GET:/repos/{owner}/{repo}/issues
      */
-    issuesDetail: (
+    issuesList: (
       owner: string,
       repo: string,
       query: {
@@ -3784,10 +3762,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name IssuesCommentsDetail
+     * @name IssuesCommentsList
      * @request GET:/repos/{owner}/{repo}/issues/comments
      */
-    issuesCommentsDetail: (
+    issuesCommentsList: (
       owner: string,
       repo: string,
       query?: {
@@ -3821,12 +3799,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name IssuesCommentsDetail2
+     * @name IssuesCommentsDetail
      * @request GET:/repos/{owner}/{repo}/issues/comments/{commentId}
-     * @originalName issuesCommentsDetail
-     * @duplicate
      */
-    issuesCommentsDetail2: (owner: string, repo: string, commentId: number, params: RequestParams = {}) =>
+    issuesCommentsDetail: (owner: string, repo: string, commentId: number, params: RequestParams = {}) =>
       this.request<IssuesComment, void>({
         path: \`/repos/\${owner}/\${repo}/issues/comments/\${commentId}\`,
         method: "GET",
@@ -3858,10 +3834,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name IssuesEventsDetail
+     * @name IssuesEventsList
      * @request GET:/repos/{owner}/{repo}/issues/events
      */
-    issuesEventsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    issuesEventsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<IssueEvents, void>({
         path: \`/repos/\${owner}/\${repo}/issues/events\`,
         method: "GET",
@@ -3872,12 +3848,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name IssuesEventsDetail2
+     * @name IssuesEventsDetail
      * @request GET:/repos/{owner}/{repo}/issues/events/{eventId}
-     * @originalName issuesEventsDetail
-     * @duplicate
      */
-    issuesEventsDetail2: (owner: string, repo: string, eventId: number, params: RequestParams = {}) =>
+    issuesEventsDetail: (owner: string, repo: string, eventId: number, params: RequestParams = {}) =>
       this.request<IssueEvent, void>({
         path: \`/repos/\${owner}/\${repo}/issues/events/\${eventId}\`,
         method: "GET",
@@ -3888,12 +3862,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name IssuesDetail2
+     * @name IssuesDetail
      * @request GET:/repos/{owner}/{repo}/issues/{number}
-     * @originalName issuesDetail
-     * @duplicate
      */
-    issuesDetail2: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    issuesDetail: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<Issue, void>({
         path: \`/repos/\${owner}/\${repo}/issues/\${number}\`,
         method: "GET",
@@ -3919,12 +3891,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name IssuesCommentsDetail3
+     * @name IssuesCommentsList2
      * @request GET:/repos/{owner}/{repo}/issues/{number}/comments
-     * @originalName issuesCommentsDetail
+     * @originalName issuesCommentsList
      * @duplicate
      */
-    issuesCommentsDetail3: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    issuesCommentsList2: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<IssuesComments, void>({
         path: \`/repos/\${owner}/\${repo}/issues/\${number}/comments\`,
         method: "GET",
@@ -3956,12 +3928,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name IssuesEventsDetail3
+     * @name IssuesEventsList2
      * @request GET:/repos/{owner}/{repo}/issues/{number}/events
-     * @originalName issuesEventsDetail
+     * @originalName issuesEventsList
      * @duplicate
      */
-    issuesEventsDetail3: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    issuesEventsList2: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<IssueEvents, void>({
         path: \`/repos/\${owner}/\${repo}/issues/\${number}/events\`,
         method: "GET",
@@ -3985,10 +3957,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name IssuesLabelsDetail
+     * @name IssuesLabelsList
      * @request GET:/repos/{owner}/{repo}/issues/{number}/labels
      */
-    issuesLabelsDetail: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    issuesLabelsList: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<Labels, void>({
         path: \`/repos/\${owner}/\${repo}/issues/\${number}/labels\`,
         method: "GET",
@@ -4044,10 +4016,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name KeysDetail
+     * @name KeysList
      * @request GET:/repos/{owner}/{repo}/keys
      */
-    keysDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    keysList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Keys, void>({
         path: \`/repos/\${owner}/\${repo}/keys\`,
         method: "GET",
@@ -4086,12 +4058,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name KeysDetail2
+     * @name KeysDetail
      * @request GET:/repos/{owner}/{repo}/keys/{keyId}
-     * @originalName keysDetail
-     * @duplicate
      */
-    keysDetail2: (owner: string, repo: string, keyId: number, params: RequestParams = {}) =>
+    keysDetail: (owner: string, repo: string, keyId: number, params: RequestParams = {}) =>
       this.request<UserKeysKeyId, void>({
         path: \`/repos/\${owner}/\${repo}/keys/\${keyId}\`,
         method: "GET",
@@ -4102,10 +4072,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name LabelsDetail
+     * @name LabelsList
      * @request GET:/repos/{owner}/{repo}/labels
      */
-    labelsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    labelsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Labels, void>({
         path: \`/repos/\${owner}/\${repo}/labels\`,
         method: "GET",
@@ -4144,12 +4114,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name LabelsDetail2
+     * @name LabelsDetail
      * @request GET:/repos/{owner}/{repo}/labels/{name}
-     * @originalName labelsDetail
-     * @duplicate
      */
-    labelsDetail2: (owner: string, repo: string, name: string, params: RequestParams = {}) =>
+    labelsDetail: (owner: string, repo: string, name: string, params: RequestParams = {}) =>
       this.request<Label, void>({
         path: \`/repos/\${owner}/\${repo}/labels/\${name}\`,
         method: "GET",
@@ -4175,10 +4143,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name LanguagesDetail
+     * @name LanguagesList
      * @request GET:/repos/{owner}/{repo}/languages
      */
-    languagesDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    languagesList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Languages, void>({
         path: \`/repos/\${owner}/\${repo}/languages\`,
         method: "GET",
@@ -4205,10 +4173,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name MilestonesDetail
+     * @name MilestonesList
      * @request GET:/repos/{owner}/{repo}/milestones
      */
-    milestonesDetail: (
+    milestonesList: (
       owner: string,
       repo: string,
       query?: {
@@ -4257,12 +4225,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name MilestonesDetail2
+     * @name MilestonesDetail
      * @request GET:/repos/{owner}/{repo}/milestones/{number}
-     * @originalName milestonesDetail
-     * @duplicate
      */
-    milestonesDetail2: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    milestonesDetail: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<Milestone, void>({
         path: \`/repos/\${owner}/\${repo}/milestones/\${number}\`,
         method: "GET",
@@ -4294,10 +4260,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name MilestonesLabelsDetail
+     * @name MilestonesLabelsList
      * @request GET:/repos/{owner}/{repo}/milestones/{number}/labels
      */
-    milestonesLabelsDetail: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    milestonesLabelsList: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<Labels, void>({
         path: \`/repos/\${owner}/\${repo}/milestones/\${number}/labels\`,
         method: "GET",
@@ -4308,10 +4274,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name NotificationsDetail
+     * @name NotificationsList
      * @request GET:/repos/{owner}/{repo}/notifications
      */
-    notificationsDetail: (
+    notificationsList: (
       owner: string,
       repo: string,
       query?: {
@@ -4346,10 +4312,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name PullsDetail
+     * @name PullsList
      * @request GET:/repos/{owner}/{repo}/pulls
      */
-    pullsDetail: (
+    pullsList: (
       owner: string,
       repo: string,
       query?: {
@@ -4386,10 +4352,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name PullsCommentsDetail
+     * @name PullsCommentsList
      * @request GET:/repos/{owner}/{repo}/pulls/comments
      */
-    pullsCommentsDetail: (
+    pullsCommentsList: (
       owner: string,
       repo: string,
       query?: {
@@ -4423,12 +4389,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name PullsCommentsDetail2
+     * @name PullsCommentsDetail
      * @request GET:/repos/{owner}/{repo}/pulls/comments/{commentId}
-     * @originalName pullsCommentsDetail
-     * @duplicate
      */
-    pullsCommentsDetail2: (owner: string, repo: string, commentId: number, params: RequestParams = {}) =>
+    pullsCommentsDetail: (owner: string, repo: string, commentId: number, params: RequestParams = {}) =>
       this.request<PullsComment, void>({
         path: \`/repos/\${owner}/\${repo}/pulls/comments/\${commentId}\`,
         method: "GET",
@@ -4460,12 +4424,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name PullsDetail2
+     * @name PullsDetail
      * @request GET:/repos/{owner}/{repo}/pulls/{number}
-     * @originalName pullsDetail
-     * @duplicate
      */
-    pullsDetail2: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    pullsDetail: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<PullRequest, void>({
         path: \`/repos/\${owner}/\${repo}/pulls/\${number}\`,
         method: "GET",
@@ -4492,12 +4454,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name PullsCommentsDetail3
+     * @name PullsCommentsList2
      * @request GET:/repos/{owner}/{repo}/pulls/{number}/comments
-     * @originalName pullsCommentsDetail
+     * @originalName pullsCommentsList
      * @duplicate
      */
-    pullsCommentsDetail3: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    pullsCommentsList2: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<PullsComment, void>({
         path: \`/repos/\${owner}/\${repo}/pulls/\${number}/comments\`,
         method: "GET",
@@ -4530,10 +4492,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name PullsCommitsDetail
+     * @name PullsCommitsList
      * @request GET:/repos/{owner}/{repo}/pulls/{number}/commits
      */
-    pullsCommitsDetail: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    pullsCommitsList: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<Commits, void>({
         path: \`/repos/\${owner}/\${repo}/pulls/\${number}/commits\`,
         method: "GET",
@@ -4544,10 +4506,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name PullsFilesDetail
+     * @name PullsFilesList
      * @request GET:/repos/{owner}/{repo}/pulls/{number}/files
      */
-    pullsFilesDetail: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    pullsFilesList: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<Pulls, void>({
         path: \`/repos/\${owner}/\${repo}/pulls/\${number}/files\`,
         method: "GET",
@@ -4558,10 +4520,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name PullsMergeDetail
+     * @name PullsMergeList
      * @request GET:/repos/{owner}/{repo}/pulls/{number}/merge
      */
-    pullsMergeDetail: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    pullsMergeList: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<void, void>({
         path: \`/repos/\${owner}/\${repo}/pulls/\${number}/merge\`,
         method: "GET",
@@ -4587,10 +4549,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ReadmeDetail
+     * @name ReadmeList
      * @request GET:/repos/{owner}/{repo}/readme
      */
-    readmeDetail: (
+    readmeList: (
       owner: string,
       repo: string,
       query?: {
@@ -4609,10 +4571,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ReleasesDetail
+     * @name ReleasesList
      * @request GET:/repos/{owner}/{repo}/releases
      */
-    releasesDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    releasesList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Releases, void>({
         path: \`/repos/\${owner}/\${repo}/releases\`,
         method: "GET",
@@ -4700,12 +4662,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ReleasesDetail2
+     * @name ReleasesDetail
      * @request GET:/repos/{owner}/{repo}/releases/{id}
-     * @originalName releasesDetail
-     * @duplicate
      */
-    releasesDetail2: (owner: string, repo: string, id: string, params: RequestParams = {}) =>
+    releasesDetail: (owner: string, repo: string, id: string, params: RequestParams = {}) =>
       this.request<Release, void>({
         path: \`/repos/\${owner}/\${repo}/releases/\${id}\`,
         method: "GET",
@@ -4731,12 +4691,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ReleasesAssetsDetail2
+     * @name ReleasesAssetsList
      * @request GET:/repos/{owner}/{repo}/releases/{id}/assets
-     * @originalName releasesAssetsDetail
-     * @duplicate
      */
-    releasesAssetsDetail2: (owner: string, repo: string, id: string, params: RequestParams = {}) =>
+    releasesAssetsList: (owner: string, repo: string, id: string, params: RequestParams = {}) =>
       this.request<Assets, void>({
         path: \`/repos/\${owner}/\${repo}/releases/\${id}/assets\`,
         method: "GET",
@@ -4747,10 +4705,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name StargazersDetail
+     * @name StargazersList
      * @request GET:/repos/{owner}/{repo}/stargazers
      */
-    stargazersDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    stargazersList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Users, void>({
         path: \`/repos/\${owner}/\${repo}/stargazers\`,
         method: "GET",
@@ -4761,10 +4719,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name StatsCodeFrequencyDetail
+     * @name StatsCodeFrequencyList
      * @request GET:/repos/{owner}/{repo}/stats/code_frequency
      */
-    statsCodeFrequencyDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    statsCodeFrequencyList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<CodeFrequencyStats, void>({
         path: \`/repos/\${owner}/\${repo}/stats/code_frequency\`,
         method: "GET",
@@ -4775,10 +4733,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name StatsCommitActivityDetail
+     * @name StatsCommitActivityList
      * @request GET:/repos/{owner}/{repo}/stats/commit_activity
      */
-    statsCommitActivityDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    statsCommitActivityList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<CommitActivityStats, void>({
         path: \`/repos/\${owner}/\${repo}/stats/commit_activity\`,
         method: "GET",
@@ -4789,10 +4747,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name StatsContributorsDetail
+     * @name StatsContributorsList
      * @request GET:/repos/{owner}/{repo}/stats/contributors
      */
-    statsContributorsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    statsContributorsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<ContributorsStats, void>({
         path: \`/repos/\${owner}/\${repo}/stats/contributors\`,
         method: "GET",
@@ -4803,10 +4761,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name StatsParticipationDetail
+     * @name StatsParticipationList
      * @request GET:/repos/{owner}/{repo}/stats/participation
      */
-    statsParticipationDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    statsParticipationList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<ParticipationStats, void>({
         path: \`/repos/\${owner}/\${repo}/stats/participation\`,
         method: "GET",
@@ -4817,10 +4775,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name StatsPunchCardDetail
+     * @name StatsPunchCardList
      * @request GET:/repos/{owner}/{repo}/stats/punch_card
      */
-    statsPunchCardDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    statsPunchCardList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<CodeFrequencyStats, void>({
         path: \`/repos/\${owner}/\${repo}/stats/punch_card\`,
         method: "GET",
@@ -4861,10 +4819,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name SubscribersDetail
+     * @name SubscribersList
      * @request GET:/repos/{owner}/{repo}/subscribers
      */
-    subscribersDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    subscribersList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Users, void>({
         path: \`/repos/\${owner}/\${repo}/subscribers\`,
         method: "GET",
@@ -4888,10 +4846,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name SubscriptionDetail
+     * @name SubscriptionList
      * @request GET:/repos/{owner}/{repo}/subscription
      */
-    subscriptionDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    subscriptionList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Subscription, void>({
         path: \`/repos/\${owner}/\${repo}/subscription\`,
         method: "GET",
@@ -4918,10 +4876,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name TagsDetail
+     * @name TagsList
      * @request GET:/repos/{owner}/{repo}/tags
      */
-    tagsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    tagsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Tags, void>({
         path: \`/repos/\${owner}/\${repo}/tags\`,
         method: "GET",
@@ -4932,10 +4890,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name TeamsDetail
+     * @name TeamsList
      * @request GET:/repos/{owner}/{repo}/teams
      */
-    teamsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    teamsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Teams, void>({
         path: \`/repos/\${owner}/\${repo}/teams\`,
         method: "GET",
@@ -4946,10 +4904,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name WatchersDetail
+     * @name WatchersList
      * @request GET:/repos/{owner}/{repo}/watchers
      */
-    watchersDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    watchersList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Users, void>({
         path: \`/repos/\${owner}/\${repo}/watchers\`,
         method: "GET",
@@ -5135,10 +5093,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name MembersDetail
+     * @name MembersList
      * @request GET:/teams/{teamId}/members
      */
-    membersDetail: (teamId: number, params: RequestParams = {}) =>
+    membersList: (teamId: number, params: RequestParams = {}) =>
       this.request<Users, void>({
         path: \`/teams/\${teamId}/members\`,
         method: "GET",
@@ -5162,12 +5120,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name MembersDetail2
+     * @name MembersDetail
      * @request GET:/teams/{teamId}/members/{username}
-     * @originalName membersDetail
-     * @duplicate
      */
-    membersDetail2: (teamId: number, username: string, params: RequestParams = {}) =>
+    membersDetail: (teamId: number, username: string, params: RequestParams = {}) =>
       this.request<void, void>({
         path: \`/teams/\${teamId}/members/\${username}\`,
         method: "GET",
@@ -5231,10 +5187,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ReposDetail
+     * @name ReposList
      * @request GET:/teams/{teamId}/repos
      */
-    reposDetail: (teamId: number, params: RequestParams = {}) =>
+    reposList: (teamId: number, params: RequestParams = {}) =>
       this.request<TeamRepos, void>({
         path: \`/teams/\${teamId}/repos\`,
         method: "GET",
@@ -5258,12 +5214,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ReposDetail2
+     * @name ReposDetail
      * @request GET:/teams/{teamId}/repos/{owner}/{repo}
-     * @originalName reposDetail
-     * @duplicate
      */
-    reposDetail2: (teamId: number, owner: string, repo: string, params: RequestParams = {}) =>
+    reposDetail: (teamId: number, owner: string, repo: string, params: RequestParams = {}) =>
       this.request<any, void>({
         path: \`/teams/\${teamId}/repos/\${owner}/\${repo}\`,
         method: "GET",
@@ -5718,10 +5672,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name EventsDetail
+     * @name EventsList
      * @request GET:/users/{username}/events
      */
-    eventsDetail: (username: string, params: RequestParams = {}) =>
+    eventsList: (username: string, params: RequestParams = {}) =>
       this.request<any, void>({
         path: \`/users/\${username}/events\`,
         method: "GET",
@@ -5744,10 +5698,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name FollowersDetail
+     * @name FollowersList
      * @request GET:/users/{username}/followers
      */
-    followersDetail: (username: string, params: RequestParams = {}) =>
+    followersList: (username: string, params: RequestParams = {}) =>
       this.request<Users, void>({
         path: \`/users/\${username}/followers\`,
         method: "GET",
@@ -5771,10 +5725,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name GistsDetail
+     * @name GistsList
      * @request GET:/users/{username}/gists
      */
-    gistsDetail: (
+    gistsList: (
       username: string,
       query?: {
         since?: string;
@@ -5792,10 +5746,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name KeysDetail
+     * @name KeysList
      * @request GET:/users/{username}/keys
      */
-    keysDetail: (username: string, params: RequestParams = {}) =>
+    keysList: (username: string, params: RequestParams = {}) =>
       this.request<Gitignore, void>({
         path: \`/users/\${username}/keys\`,
         method: "GET",
@@ -5806,10 +5760,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name OrgsDetail
+     * @name OrgsList
      * @request GET:/users/{username}/orgs
      */
-    orgsDetail: (username: string, params: RequestParams = {}) =>
+    orgsList: (username: string, params: RequestParams = {}) =>
       this.request<Gitignore, void>({
         path: \`/users/\${username}/orgs\`,
         method: "GET",
@@ -5820,10 +5774,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ReceivedEventsDetail
+     * @name ReceivedEventsList
      * @request GET:/users/{username}/received_events
      */
-    receivedEventsDetail: (username: string, params: RequestParams = {}) =>
+    receivedEventsList: (username: string, params: RequestParams = {}) =>
       this.request<any, void>({
         path: \`/users/\${username}/received_events\`,
         method: "GET",
@@ -5833,10 +5787,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ReceivedEventsPublicDetail
+     * @name ReceivedEventsPublicList
      * @request GET:/users/{username}/received_events/public
      */
-    receivedEventsPublicDetail: (username: string, params: RequestParams = {}) =>
+    receivedEventsPublicList: (username: string, params: RequestParams = {}) =>
       this.request<any, void>({
         path: \`/users/\${username}/received_events/public\`,
         method: "GET",
@@ -5846,10 +5800,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ReposDetail
+     * @name ReposList
      * @request GET:/users/{username}/repos
      */
-    reposDetail: (
+    reposList: (
       username: string,
       query?: {
         type?: "all" | "public" | "private" | "forks" | "sources" | "member";
@@ -5867,10 +5821,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name StarredDetail
+     * @name StarredList
      * @request GET:/users/{username}/starred
      */
-    starredDetail: (username: string, params: RequestParams = {}) =>
+    starredList: (username: string, params: RequestParams = {}) =>
       this.request<any, void>({
         path: \`/users/\${username}/starred\`,
         method: "GET",
@@ -5880,10 +5834,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name SubscriptionsDetail
+     * @name SubscriptionsList
      * @request GET:/users/{username}/subscriptions
      */
-    subscriptionsDetail: (username: string, params: RequestParams = {}) =>
+    subscriptionsList: (username: string, params: RequestParams = {}) =>
       this.request<any, void>({
         path: \`/users/\${username}/subscriptions\`,
         method: "GET",

--- a/tests/spec/sortTypes/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/sortTypes/__snapshots__/basic.test.ts.snap
@@ -2207,10 +2207,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name CommentsDetail
+     * @name CommentsList
      * @request GET:/gists/{id}/comments
      */
-    commentsDetail: (id: number, params: RequestParams = {}) =>
+    commentsList: (id: number, params: RequestParams = {}) =>
       this.request<Comments, void>({
         path: \`/gists/\${id}/comments\`,
         method: "GET",
@@ -2249,12 +2249,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name CommentsDetail2
+     * @name CommentsDetail
      * @request GET:/gists/{id}/comments/{commentId}
-     * @originalName commentsDetail
-     * @duplicate
      */
-    commentsDetail2: (id: number, commentId: number, params: RequestParams = {}) =>
+    commentsDetail: (id: number, commentId: number, params: RequestParams = {}) =>
       this.request<Comment, void>({
         path: \`/gists/\${id}/comments/\${commentId}\`,
         method: "GET",
@@ -2307,10 +2305,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name StarDetail
+     * @name StarList
      * @request GET:/gists/{id}/star
      */
-    starDetail: (id: number, params: RequestParams = {}) =>
+    starList: (id: number, params: RequestParams = {}) =>
       this.request<void, void>({
         path: \`/gists/\${id}/star\`,
         method: "GET",
@@ -2516,10 +2514,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name EventsDetail
+     * @name EventsList
      * @request GET:/networks/{owner}/{repo}/events
      */
-    eventsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    eventsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Events, void>({
         path: \`/networks/\${owner}/\${repo}/events\`,
         method: "GET",
@@ -2607,10 +2605,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ThreadsSubscriptionDetail
+     * @name ThreadsSubscriptionList
      * @request GET:/notifications/threads/{id}/subscription
      */
-    threadsSubscriptionDetail: (id: number, params: RequestParams = {}) =>
+    threadsSubscriptionList: (id: number, params: RequestParams = {}) =>
       this.request<Subscription, void>({
         path: \`/notifications/threads/\${id}/subscription\`,
         method: "GET",
@@ -2668,10 +2666,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name EventsDetail
+     * @name EventsList
      * @request GET:/orgs/{org}/events
      */
-    eventsDetail: (org: string, params: RequestParams = {}) =>
+    eventsList: (org: string, params: RequestParams = {}) =>
       this.request<Events, void>({
         path: \`/orgs/\${org}/events\`,
         method: "GET",
@@ -2682,10 +2680,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name IssuesDetail
+     * @name IssuesList
      * @request GET:/orgs/{org}/issues
      */
-    issuesDetail: (
+    issuesList: (
       org: string,
       query: {
         direction: "asc" | "desc";
@@ -2708,10 +2706,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name MembersDetail
+     * @name MembersList
      * @request GET:/orgs/{org}/members
      */
-    membersDetail: (org: string, params: RequestParams = {}) =>
+    membersList: (org: string, params: RequestParams = {}) =>
       this.request<Users, void>({
         path: \`/orgs/\${org}/members\`,
         method: "GET",
@@ -2735,12 +2733,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name MembersDetail2
+     * @name MembersDetail
      * @request GET:/orgs/{org}/members/{username}
-     * @originalName membersDetail
-     * @duplicate
      */
-    membersDetail2: (org: string, username: string, params: RequestParams = {}) =>
+    membersDetail: (org: string, username: string, params: RequestParams = {}) =>
       this.request<void, void>({
         path: \`/orgs/\${org}/members/\${username}\`,
         method: "GET",
@@ -2750,10 +2746,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name PublicMembersDetail
+     * @name PublicMembersList
      * @request GET:/orgs/{org}/public_members
      */
-    publicMembersDetail: (org: string, params: RequestParams = {}) =>
+    publicMembersList: (org: string, params: RequestParams = {}) =>
       this.request<Users, void>({
         path: \`/orgs/\${org}/public_members\`,
         method: "GET",
@@ -2777,12 +2773,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name PublicMembersDetail2
+     * @name PublicMembersDetail
      * @request GET:/orgs/{org}/public_members/{username}
-     * @originalName publicMembersDetail
-     * @duplicate
      */
-    publicMembersDetail2: (org: string, username: string, params: RequestParams = {}) =>
+    publicMembersDetail: (org: string, username: string, params: RequestParams = {}) =>
       this.request<void, void>({
         path: \`/orgs/\${org}/public_members/\${username}\`,
         method: "GET",
@@ -2805,10 +2799,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ReposDetail
+     * @name ReposList
      * @request GET:/orgs/{org}/repos
      */
-    reposDetail: (
+    reposList: (
       org: string,
       query?: {
         type?: "all" | "public" | "private" | "forks" | "sources" | "member";
@@ -2841,10 +2835,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name TeamsDetail
+     * @name TeamsList
      * @request GET:/orgs/{org}/teams
      */
-    teamsDetail: (org: string, params: RequestParams = {}) =>
+    teamsList: (org: string, params: RequestParams = {}) =>
       this.request<Teams, void>({
         path: \`/orgs/\${org}/teams\`,
         method: "GET",
@@ -2930,10 +2924,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name AssigneesDetail
+     * @name AssigneesList
      * @request GET:/repos/{owner}/{repo}/assignees
      */
-    assigneesDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    assigneesList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Assignees, void>({
         path: \`/repos/\${owner}/\${repo}/assignees\`,
         method: "GET",
@@ -2944,12 +2938,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name AssigneesDetail2
+     * @name AssigneesDetail
      * @request GET:/repos/{owner}/{repo}/assignees/{assignee}
-     * @originalName assigneesDetail
-     * @duplicate
      */
-    assigneesDetail2: (owner: string, repo: string, assignee: string, params: RequestParams = {}) =>
+    assigneesDetail: (owner: string, repo: string, assignee: string, params: RequestParams = {}) =>
       this.request<void, void>({
         path: \`/repos/\${owner}/\${repo}/assignees/\${assignee}\`,
         method: "GET",
@@ -2959,10 +2951,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name BranchesDetail
+     * @name BranchesList
      * @request GET:/repos/{owner}/{repo}/branches
      */
-    branchesDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    branchesList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Branches, void>({
         path: \`/repos/\${owner}/\${repo}/branches\`,
         method: "GET",
@@ -2973,12 +2965,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name BranchesDetail2
+     * @name BranchesDetail
      * @request GET:/repos/{owner}/{repo}/branches/{branch}
-     * @originalName branchesDetail
-     * @duplicate
      */
-    branchesDetail2: (owner: string, repo: string, branch: string, params: RequestParams = {}) =>
+    branchesDetail: (owner: string, repo: string, branch: string, params: RequestParams = {}) =>
       this.request<Branch, void>({
         path: \`/repos/\${owner}/\${repo}/branches/\${branch}\`,
         method: "GET",
@@ -2989,10 +2979,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name CollaboratorsDetail
+     * @name CollaboratorsList
      * @request GET:/repos/{owner}/{repo}/collaborators
      */
-    collaboratorsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    collaboratorsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Users, void>({
         path: \`/repos/\${owner}/\${repo}/collaborators\`,
         method: "GET",
@@ -3016,12 +3006,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name CollaboratorsDetail2
+     * @name CollaboratorsDetail
      * @request GET:/repos/{owner}/{repo}/collaborators/{user}
-     * @originalName collaboratorsDetail
-     * @duplicate
      */
-    collaboratorsDetail2: (owner: string, repo: string, user: string, params: RequestParams = {}) =>
+    collaboratorsDetail: (owner: string, repo: string, user: string, params: RequestParams = {}) =>
       this.request<void, void>({
         path: \`/repos/\${owner}/\${repo}/collaborators/\${user}\`,
         method: "GET",
@@ -3044,10 +3032,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name CommentsDetail
+     * @name CommentsList
      * @request GET:/repos/{owner}/{repo}/comments
      */
-    commentsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    commentsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<RepoComments, void>({
         path: \`/repos/\${owner}/\${repo}/comments\`,
         method: "GET",
@@ -3071,12 +3059,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name CommentsDetail2
+     * @name CommentsDetail
      * @request GET:/repos/{owner}/{repo}/comments/{commentId}
-     * @originalName commentsDetail
-     * @duplicate
      */
-    commentsDetail2: (owner: string, repo: string, commentId: number, params: RequestParams = {}) =>
+    commentsDetail: (owner: string, repo: string, commentId: number, params: RequestParams = {}) =>
       this.request<CommitComment, void>({
         path: \`/repos/\${owner}/\${repo}/comments/\${commentId}\`,
         method: "GET",
@@ -3108,10 +3094,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name CommitsDetail
+     * @name CommitsList
      * @request GET:/repos/{owner}/{repo}/commits
      */
-    commitsDetail: (
+    commitsList: (
       owner: string,
       repo: string,
       query?: {
@@ -3134,10 +3120,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name CommitsStatusDetail
+     * @name CommitsStatusList
      * @request GET:/repos/{owner}/{repo}/commits/{ref}/status
      */
-    commitsStatusDetail: (owner: string, repo: string, ref: string, params: RequestParams = {}) =>
+    commitsStatusList: (owner: string, repo: string, ref: string, params: RequestParams = {}) =>
       this.request<RefStatus, void>({
         path: \`/repos/\${owner}/\${repo}/commits/\${ref}/status\`,
         method: "GET",
@@ -3148,12 +3134,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name CommitsDetail2
+     * @name CommitsDetail
      * @request GET:/repos/{owner}/{repo}/commits/{shaCode}
-     * @originalName commitsDetail
-     * @duplicate
      */
-    commitsDetail2: (owner: string, repo: string, shaCode: string, params: RequestParams = {}) =>
+    commitsDetail: (owner: string, repo: string, shaCode: string, params: RequestParams = {}) =>
       this.request<Commit, void>({
         path: \`/repos/\${owner}/\${repo}/commits/\${shaCode}\`,
         method: "GET",
@@ -3164,10 +3148,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name CommitsCommentsDetail
+     * @name CommitsCommentsList
      * @request GET:/repos/{owner}/{repo}/commits/{shaCode}/comments
      */
-    commitsCommentsDetail: (owner: string, repo: string, shaCode: string, params: RequestParams = {}) =>
+    commitsCommentsList: (owner: string, repo: string, shaCode: string, params: RequestParams = {}) =>
       this.request<RepoComments, void>({
         path: \`/repos/\${owner}/\${repo}/commits/\${shaCode}/comments\`,
         method: "GET",
@@ -3270,10 +3254,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ContributorsDetail
+     * @name ContributorsList
      * @request GET:/repos/{owner}/{repo}/contributors
      */
-    contributorsDetail: (
+    contributorsList: (
       owner: string,
       repo: string,
       query: {
@@ -3292,10 +3276,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name DeploymentsDetail
+     * @name DeploymentsList
      * @request GET:/repos/{owner}/{repo}/deployments
      */
-    deploymentsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    deploymentsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<RepoDeployments, void>({
         path: \`/repos/\${owner}/\${repo}/deployments\`,
         method: "GET",
@@ -3322,10 +3306,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name DeploymentsStatusesDetail
+     * @name DeploymentsStatusesList
      * @request GET:/repos/{owner}/{repo}/deployments/{id}/statuses
      */
-    deploymentsStatusesDetail: (owner: string, repo: string, id: number, params: RequestParams = {}) =>
+    deploymentsStatusesList: (owner: string, repo: string, id: number, params: RequestParams = {}) =>
       this.request<DeploymentStatuses, void>({
         path: \`/repos/\${owner}/\${repo}/deployments/\${id}/statuses\`,
         method: "GET",
@@ -3357,10 +3341,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name DownloadsDetail
+     * @name DownloadsList
      * @request GET:/repos/{owner}/{repo}/downloads
      */
-    downloadsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    downloadsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Downloads, void>({
         path: \`/repos/\${owner}/\${repo}/downloads\`,
         method: "GET",
@@ -3384,12 +3368,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name DownloadsDetail2
+     * @name DownloadsDetail
      * @request GET:/repos/{owner}/{repo}/downloads/{downloadId}
-     * @originalName downloadsDetail
-     * @duplicate
      */
-    downloadsDetail2: (owner: string, repo: string, downloadId: number, params: RequestParams = {}) =>
+    downloadsDetail: (owner: string, repo: string, downloadId: number, params: RequestParams = {}) =>
       this.request<Download, void>({
         path: \`/repos/\${owner}/\${repo}/downloads/\${downloadId}\`,
         method: "GET",
@@ -3400,10 +3382,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name EventsDetail
+     * @name EventsList
      * @request GET:/repos/{owner}/{repo}/events
      */
-    eventsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    eventsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Events, void>({
         path: \`/repos/\${owner}/\${repo}/events\`,
         method: "GET",
@@ -3414,10 +3396,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ForksDetail
+     * @name ForksList
      * @request GET:/repos/{owner}/{repo}/forks
      */
-    forksDetail: (
+    forksList: (
       owner: string,
       repo: string,
       query?: {
@@ -3512,10 +3494,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name GitRefsDetail
+     * @name GitRefsList
      * @request GET:/repos/{owner}/{repo}/git/refs
      */
-    gitRefsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    gitRefsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Refs, void>({
         path: \`/repos/\${owner}/\${repo}/git/refs\`,
         method: "GET",
@@ -3555,12 +3537,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name GitRefsDetail2
+     * @name GitRefsDetail
      * @request GET:/repos/{owner}/{repo}/git/refs/{ref}
-     * @originalName gitRefsDetail
-     * @duplicate
      */
-    gitRefsDetail2: (owner: string, repo: string, ref: string, params: RequestParams = {}) =>
+    gitRefsDetail: (owner: string, repo: string, ref: string, params: RequestParams = {}) =>
       this.request<HeadBranch, void>({
         path: \`/repos/\${owner}/\${repo}/git/refs/\${ref}\`,
         method: "GET",
@@ -3656,10 +3636,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name HooksDetail
+     * @name HooksList
      * @request GET:/repos/{owner}/{repo}/hooks
      */
-    hooksDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    hooksList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Hook, void>({
         path: \`/repos/\${owner}/\${repo}/hooks\`,
         method: "GET",
@@ -3698,12 +3678,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name HooksDetail2
+     * @name HooksDetail
      * @request GET:/repos/{owner}/{repo}/hooks/{hookId}
-     * @originalName hooksDetail
-     * @duplicate
      */
-    hooksDetail2: (owner: string, repo: string, hookId: number, params: RequestParams = {}) =>
+    hooksDetail: (owner: string, repo: string, hookId: number, params: RequestParams = {}) =>
       this.request<Hook, void>({
         path: \`/repos/\${owner}/\${repo}/hooks/\${hookId}\`,
         method: "GET",
@@ -3742,10 +3720,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name IssuesDetail
+     * @name IssuesList
      * @request GET:/repos/{owner}/{repo}/issues
      */
-    issuesDetail: (
+    issuesList: (
       owner: string,
       repo: string,
       query: {
@@ -3784,10 +3762,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name IssuesCommentsDetail
+     * @name IssuesCommentsList
      * @request GET:/repos/{owner}/{repo}/issues/comments
      */
-    issuesCommentsDetail: (
+    issuesCommentsList: (
       owner: string,
       repo: string,
       query?: {
@@ -3821,12 +3799,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name IssuesCommentsDetail2
+     * @name IssuesCommentsDetail
      * @request GET:/repos/{owner}/{repo}/issues/comments/{commentId}
-     * @originalName issuesCommentsDetail
-     * @duplicate
      */
-    issuesCommentsDetail2: (owner: string, repo: string, commentId: number, params: RequestParams = {}) =>
+    issuesCommentsDetail: (owner: string, repo: string, commentId: number, params: RequestParams = {}) =>
       this.request<IssuesComment, void>({
         path: \`/repos/\${owner}/\${repo}/issues/comments/\${commentId}\`,
         method: "GET",
@@ -3858,10 +3834,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name IssuesEventsDetail
+     * @name IssuesEventsList
      * @request GET:/repos/{owner}/{repo}/issues/events
      */
-    issuesEventsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    issuesEventsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<IssueEvents, void>({
         path: \`/repos/\${owner}/\${repo}/issues/events\`,
         method: "GET",
@@ -3872,12 +3848,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name IssuesEventsDetail2
+     * @name IssuesEventsDetail
      * @request GET:/repos/{owner}/{repo}/issues/events/{eventId}
-     * @originalName issuesEventsDetail
-     * @duplicate
      */
-    issuesEventsDetail2: (owner: string, repo: string, eventId: number, params: RequestParams = {}) =>
+    issuesEventsDetail: (owner: string, repo: string, eventId: number, params: RequestParams = {}) =>
       this.request<IssueEvent, void>({
         path: \`/repos/\${owner}/\${repo}/issues/events/\${eventId}\`,
         method: "GET",
@@ -3888,12 +3862,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name IssuesDetail2
+     * @name IssuesDetail
      * @request GET:/repos/{owner}/{repo}/issues/{number}
-     * @originalName issuesDetail
-     * @duplicate
      */
-    issuesDetail2: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    issuesDetail: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<Issue, void>({
         path: \`/repos/\${owner}/\${repo}/issues/\${number}\`,
         method: "GET",
@@ -3919,12 +3891,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name IssuesCommentsDetail3
+     * @name IssuesCommentsList2
      * @request GET:/repos/{owner}/{repo}/issues/{number}/comments
-     * @originalName issuesCommentsDetail
+     * @originalName issuesCommentsList
      * @duplicate
      */
-    issuesCommentsDetail3: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    issuesCommentsList2: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<IssuesComments, void>({
         path: \`/repos/\${owner}/\${repo}/issues/\${number}/comments\`,
         method: "GET",
@@ -3956,12 +3928,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name IssuesEventsDetail3
+     * @name IssuesEventsList2
      * @request GET:/repos/{owner}/{repo}/issues/{number}/events
-     * @originalName issuesEventsDetail
+     * @originalName issuesEventsList
      * @duplicate
      */
-    issuesEventsDetail3: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    issuesEventsList2: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<IssueEvents, void>({
         path: \`/repos/\${owner}/\${repo}/issues/\${number}/events\`,
         method: "GET",
@@ -3985,10 +3957,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name IssuesLabelsDetail
+     * @name IssuesLabelsList
      * @request GET:/repos/{owner}/{repo}/issues/{number}/labels
      */
-    issuesLabelsDetail: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    issuesLabelsList: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<Labels, void>({
         path: \`/repos/\${owner}/\${repo}/issues/\${number}/labels\`,
         method: "GET",
@@ -4044,10 +4016,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name KeysDetail
+     * @name KeysList
      * @request GET:/repos/{owner}/{repo}/keys
      */
-    keysDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    keysList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Keys, void>({
         path: \`/repos/\${owner}/\${repo}/keys\`,
         method: "GET",
@@ -4086,12 +4058,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name KeysDetail2
+     * @name KeysDetail
      * @request GET:/repos/{owner}/{repo}/keys/{keyId}
-     * @originalName keysDetail
-     * @duplicate
      */
-    keysDetail2: (owner: string, repo: string, keyId: number, params: RequestParams = {}) =>
+    keysDetail: (owner: string, repo: string, keyId: number, params: RequestParams = {}) =>
       this.request<UserKeysKeyId, void>({
         path: \`/repos/\${owner}/\${repo}/keys/\${keyId}\`,
         method: "GET",
@@ -4102,10 +4072,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name LabelsDetail
+     * @name LabelsList
      * @request GET:/repos/{owner}/{repo}/labels
      */
-    labelsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    labelsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Labels, void>({
         path: \`/repos/\${owner}/\${repo}/labels\`,
         method: "GET",
@@ -4144,12 +4114,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name LabelsDetail2
+     * @name LabelsDetail
      * @request GET:/repos/{owner}/{repo}/labels/{name}
-     * @originalName labelsDetail
-     * @duplicate
      */
-    labelsDetail2: (owner: string, repo: string, name: string, params: RequestParams = {}) =>
+    labelsDetail: (owner: string, repo: string, name: string, params: RequestParams = {}) =>
       this.request<Label, void>({
         path: \`/repos/\${owner}/\${repo}/labels/\${name}\`,
         method: "GET",
@@ -4175,10 +4143,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name LanguagesDetail
+     * @name LanguagesList
      * @request GET:/repos/{owner}/{repo}/languages
      */
-    languagesDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    languagesList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Languages, void>({
         path: \`/repos/\${owner}/\${repo}/languages\`,
         method: "GET",
@@ -4205,10 +4173,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name MilestonesDetail
+     * @name MilestonesList
      * @request GET:/repos/{owner}/{repo}/milestones
      */
-    milestonesDetail: (
+    milestonesList: (
       owner: string,
       repo: string,
       query?: {
@@ -4257,12 +4225,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name MilestonesDetail2
+     * @name MilestonesDetail
      * @request GET:/repos/{owner}/{repo}/milestones/{number}
-     * @originalName milestonesDetail
-     * @duplicate
      */
-    milestonesDetail2: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    milestonesDetail: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<Milestone, void>({
         path: \`/repos/\${owner}/\${repo}/milestones/\${number}\`,
         method: "GET",
@@ -4294,10 +4260,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name MilestonesLabelsDetail
+     * @name MilestonesLabelsList
      * @request GET:/repos/{owner}/{repo}/milestones/{number}/labels
      */
-    milestonesLabelsDetail: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    milestonesLabelsList: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<Labels, void>({
         path: \`/repos/\${owner}/\${repo}/milestones/\${number}/labels\`,
         method: "GET",
@@ -4308,10 +4274,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name NotificationsDetail
+     * @name NotificationsList
      * @request GET:/repos/{owner}/{repo}/notifications
      */
-    notificationsDetail: (
+    notificationsList: (
       owner: string,
       repo: string,
       query?: {
@@ -4346,10 +4312,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name PullsDetail
+     * @name PullsList
      * @request GET:/repos/{owner}/{repo}/pulls
      */
-    pullsDetail: (
+    pullsList: (
       owner: string,
       repo: string,
       query?: {
@@ -4386,10 +4352,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name PullsCommentsDetail
+     * @name PullsCommentsList
      * @request GET:/repos/{owner}/{repo}/pulls/comments
      */
-    pullsCommentsDetail: (
+    pullsCommentsList: (
       owner: string,
       repo: string,
       query?: {
@@ -4423,12 +4389,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name PullsCommentsDetail2
+     * @name PullsCommentsDetail
      * @request GET:/repos/{owner}/{repo}/pulls/comments/{commentId}
-     * @originalName pullsCommentsDetail
-     * @duplicate
      */
-    pullsCommentsDetail2: (owner: string, repo: string, commentId: number, params: RequestParams = {}) =>
+    pullsCommentsDetail: (owner: string, repo: string, commentId: number, params: RequestParams = {}) =>
       this.request<PullsComment, void>({
         path: \`/repos/\${owner}/\${repo}/pulls/comments/\${commentId}\`,
         method: "GET",
@@ -4460,12 +4424,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name PullsDetail2
+     * @name PullsDetail
      * @request GET:/repos/{owner}/{repo}/pulls/{number}
-     * @originalName pullsDetail
-     * @duplicate
      */
-    pullsDetail2: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    pullsDetail: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<PullRequest, void>({
         path: \`/repos/\${owner}/\${repo}/pulls/\${number}\`,
         method: "GET",
@@ -4492,12 +4454,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name PullsCommentsDetail3
+     * @name PullsCommentsList2
      * @request GET:/repos/{owner}/{repo}/pulls/{number}/comments
-     * @originalName pullsCommentsDetail
+     * @originalName pullsCommentsList
      * @duplicate
      */
-    pullsCommentsDetail3: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    pullsCommentsList2: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<PullsComment, void>({
         path: \`/repos/\${owner}/\${repo}/pulls/\${number}/comments\`,
         method: "GET",
@@ -4530,10 +4492,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name PullsCommitsDetail
+     * @name PullsCommitsList
      * @request GET:/repos/{owner}/{repo}/pulls/{number}/commits
      */
-    pullsCommitsDetail: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    pullsCommitsList: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<Commits, void>({
         path: \`/repos/\${owner}/\${repo}/pulls/\${number}/commits\`,
         method: "GET",
@@ -4544,10 +4506,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name PullsFilesDetail
+     * @name PullsFilesList
      * @request GET:/repos/{owner}/{repo}/pulls/{number}/files
      */
-    pullsFilesDetail: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    pullsFilesList: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<Pulls, void>({
         path: \`/repos/\${owner}/\${repo}/pulls/\${number}/files\`,
         method: "GET",
@@ -4558,10 +4520,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name PullsMergeDetail
+     * @name PullsMergeList
      * @request GET:/repos/{owner}/{repo}/pulls/{number}/merge
      */
-    pullsMergeDetail: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    pullsMergeList: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<void, void>({
         path: \`/repos/\${owner}/\${repo}/pulls/\${number}/merge\`,
         method: "GET",
@@ -4587,10 +4549,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ReadmeDetail
+     * @name ReadmeList
      * @request GET:/repos/{owner}/{repo}/readme
      */
-    readmeDetail: (
+    readmeList: (
       owner: string,
       repo: string,
       query?: {
@@ -4609,10 +4571,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ReleasesDetail
+     * @name ReleasesList
      * @request GET:/repos/{owner}/{repo}/releases
      */
-    releasesDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    releasesList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Releases, void>({
         path: \`/repos/\${owner}/\${repo}/releases\`,
         method: "GET",
@@ -4700,12 +4662,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ReleasesDetail2
+     * @name ReleasesDetail
      * @request GET:/repos/{owner}/{repo}/releases/{id}
-     * @originalName releasesDetail
-     * @duplicate
      */
-    releasesDetail2: (owner: string, repo: string, id: string, params: RequestParams = {}) =>
+    releasesDetail: (owner: string, repo: string, id: string, params: RequestParams = {}) =>
       this.request<Release, void>({
         path: \`/repos/\${owner}/\${repo}/releases/\${id}\`,
         method: "GET",
@@ -4731,12 +4691,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ReleasesAssetsDetail2
+     * @name ReleasesAssetsList
      * @request GET:/repos/{owner}/{repo}/releases/{id}/assets
-     * @originalName releasesAssetsDetail
-     * @duplicate
      */
-    releasesAssetsDetail2: (owner: string, repo: string, id: string, params: RequestParams = {}) =>
+    releasesAssetsList: (owner: string, repo: string, id: string, params: RequestParams = {}) =>
       this.request<Assets, void>({
         path: \`/repos/\${owner}/\${repo}/releases/\${id}/assets\`,
         method: "GET",
@@ -4747,10 +4705,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name StargazersDetail
+     * @name StargazersList
      * @request GET:/repos/{owner}/{repo}/stargazers
      */
-    stargazersDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    stargazersList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Users, void>({
         path: \`/repos/\${owner}/\${repo}/stargazers\`,
         method: "GET",
@@ -4761,10 +4719,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name StatsCodeFrequencyDetail
+     * @name StatsCodeFrequencyList
      * @request GET:/repos/{owner}/{repo}/stats/code_frequency
      */
-    statsCodeFrequencyDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    statsCodeFrequencyList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<CodeFrequencyStats, void>({
         path: \`/repos/\${owner}/\${repo}/stats/code_frequency\`,
         method: "GET",
@@ -4775,10 +4733,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name StatsCommitActivityDetail
+     * @name StatsCommitActivityList
      * @request GET:/repos/{owner}/{repo}/stats/commit_activity
      */
-    statsCommitActivityDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    statsCommitActivityList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<CommitActivityStats, void>({
         path: \`/repos/\${owner}/\${repo}/stats/commit_activity\`,
         method: "GET",
@@ -4789,10 +4747,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name StatsContributorsDetail
+     * @name StatsContributorsList
      * @request GET:/repos/{owner}/{repo}/stats/contributors
      */
-    statsContributorsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    statsContributorsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<ContributorsStats, void>({
         path: \`/repos/\${owner}/\${repo}/stats/contributors\`,
         method: "GET",
@@ -4803,10 +4761,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name StatsParticipationDetail
+     * @name StatsParticipationList
      * @request GET:/repos/{owner}/{repo}/stats/participation
      */
-    statsParticipationDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    statsParticipationList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<ParticipationStats, void>({
         path: \`/repos/\${owner}/\${repo}/stats/participation\`,
         method: "GET",
@@ -4817,10 +4775,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name StatsPunchCardDetail
+     * @name StatsPunchCardList
      * @request GET:/repos/{owner}/{repo}/stats/punch_card
      */
-    statsPunchCardDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    statsPunchCardList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<CodeFrequencyStats, void>({
         path: \`/repos/\${owner}/\${repo}/stats/punch_card\`,
         method: "GET",
@@ -4861,10 +4819,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name SubscribersDetail
+     * @name SubscribersList
      * @request GET:/repos/{owner}/{repo}/subscribers
      */
-    subscribersDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    subscribersList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Users, void>({
         path: \`/repos/\${owner}/\${repo}/subscribers\`,
         method: "GET",
@@ -4888,10 +4846,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name SubscriptionDetail
+     * @name SubscriptionList
      * @request GET:/repos/{owner}/{repo}/subscription
      */
-    subscriptionDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    subscriptionList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Subscription, void>({
         path: \`/repos/\${owner}/\${repo}/subscription\`,
         method: "GET",
@@ -4918,10 +4876,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name TagsDetail
+     * @name TagsList
      * @request GET:/repos/{owner}/{repo}/tags
      */
-    tagsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    tagsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Tags, void>({
         path: \`/repos/\${owner}/\${repo}/tags\`,
         method: "GET",
@@ -4932,10 +4890,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name TeamsDetail
+     * @name TeamsList
      * @request GET:/repos/{owner}/{repo}/teams
      */
-    teamsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    teamsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Teams, void>({
         path: \`/repos/\${owner}/\${repo}/teams\`,
         method: "GET",
@@ -4946,10 +4904,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name WatchersDetail
+     * @name WatchersList
      * @request GET:/repos/{owner}/{repo}/watchers
      */
-    watchersDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    watchersList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<Users, void>({
         path: \`/repos/\${owner}/\${repo}/watchers\`,
         method: "GET",
@@ -5135,10 +5093,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name MembersDetail
+     * @name MembersList
      * @request GET:/teams/{teamId}/members
      */
-    membersDetail: (teamId: number, params: RequestParams = {}) =>
+    membersList: (teamId: number, params: RequestParams = {}) =>
       this.request<Users, void>({
         path: \`/teams/\${teamId}/members\`,
         method: "GET",
@@ -5162,12 +5120,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name MembersDetail2
+     * @name MembersDetail
      * @request GET:/teams/{teamId}/members/{username}
-     * @originalName membersDetail
-     * @duplicate
      */
-    membersDetail2: (teamId: number, username: string, params: RequestParams = {}) =>
+    membersDetail: (teamId: number, username: string, params: RequestParams = {}) =>
       this.request<void, void>({
         path: \`/teams/\${teamId}/members/\${username}\`,
         method: "GET",
@@ -5231,10 +5187,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ReposDetail
+     * @name ReposList
      * @request GET:/teams/{teamId}/repos
      */
-    reposDetail: (teamId: number, params: RequestParams = {}) =>
+    reposList: (teamId: number, params: RequestParams = {}) =>
       this.request<TeamRepos, void>({
         path: \`/teams/\${teamId}/repos\`,
         method: "GET",
@@ -5258,12 +5214,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ReposDetail2
+     * @name ReposDetail
      * @request GET:/teams/{teamId}/repos/{owner}/{repo}
-     * @originalName reposDetail
-     * @duplicate
      */
-    reposDetail2: (teamId: number, owner: string, repo: string, params: RequestParams = {}) =>
+    reposDetail: (teamId: number, owner: string, repo: string, params: RequestParams = {}) =>
       this.request<any, void>({
         path: \`/teams/\${teamId}/repos/\${owner}/\${repo}\`,
         method: "GET",
@@ -5718,10 +5672,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name EventsDetail
+     * @name EventsList
      * @request GET:/users/{username}/events
      */
-    eventsDetail: (username: string, params: RequestParams = {}) =>
+    eventsList: (username: string, params: RequestParams = {}) =>
       this.request<any, void>({
         path: \`/users/\${username}/events\`,
         method: "GET",
@@ -5744,10 +5698,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name FollowersDetail
+     * @name FollowersList
      * @request GET:/users/{username}/followers
      */
-    followersDetail: (username: string, params: RequestParams = {}) =>
+    followersList: (username: string, params: RequestParams = {}) =>
       this.request<Users, void>({
         path: \`/users/\${username}/followers\`,
         method: "GET",
@@ -5771,10 +5725,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name GistsDetail
+     * @name GistsList
      * @request GET:/users/{username}/gists
      */
-    gistsDetail: (
+    gistsList: (
       username: string,
       query?: {
         since?: string;
@@ -5792,10 +5746,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name KeysDetail
+     * @name KeysList
      * @request GET:/users/{username}/keys
      */
-    keysDetail: (username: string, params: RequestParams = {}) =>
+    keysList: (username: string, params: RequestParams = {}) =>
       this.request<Gitignore, void>({
         path: \`/users/\${username}/keys\`,
         method: "GET",
@@ -5806,10 +5760,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name OrgsDetail
+     * @name OrgsList
      * @request GET:/users/{username}/orgs
      */
-    orgsDetail: (username: string, params: RequestParams = {}) =>
+    orgsList: (username: string, params: RequestParams = {}) =>
       this.request<Gitignore, void>({
         path: \`/users/\${username}/orgs\`,
         method: "GET",
@@ -5820,10 +5774,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ReceivedEventsDetail
+     * @name ReceivedEventsList
      * @request GET:/users/{username}/received_events
      */
-    receivedEventsDetail: (username: string, params: RequestParams = {}) =>
+    receivedEventsList: (username: string, params: RequestParams = {}) =>
       this.request<any, void>({
         path: \`/users/\${username}/received_events\`,
         method: "GET",
@@ -5833,10 +5787,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ReceivedEventsPublicDetail
+     * @name ReceivedEventsPublicList
      * @request GET:/users/{username}/received_events/public
      */
-    receivedEventsPublicDetail: (username: string, params: RequestParams = {}) =>
+    receivedEventsPublicList: (username: string, params: RequestParams = {}) =>
       this.request<any, void>({
         path: \`/users/\${username}/received_events/public\`,
         method: "GET",
@@ -5846,10 +5800,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ReposDetail
+     * @name ReposList
      * @request GET:/users/{username}/repos
      */
-    reposDetail: (
+    reposList: (
       username: string,
       query?: {
         type?: "all" | "public" | "private" | "forks" | "sources" | "member";
@@ -5867,10 +5821,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name StarredDetail
+     * @name StarredList
      * @request GET:/users/{username}/starred
      */
-    starredDetail: (username: string, params: RequestParams = {}) =>
+    starredList: (username: string, params: RequestParams = {}) =>
       this.request<any, void>({
         path: \`/users/\${username}/starred\`,
         method: "GET",
@@ -5880,10 +5834,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name SubscriptionsDetail
+     * @name SubscriptionsList
      * @request GET:/users/{username}/subscriptions
      */
-    subscriptionsDetail: (username: string, params: RequestParams = {}) =>
+    subscriptionsList: (username: string, params: RequestParams = {}) =>
       this.request<any, void>({
         path: \`/users/\${username}/subscriptions\`,
         method: "GET",

--- a/tests/spec/typeSuffixPrefix/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/typeSuffixPrefix/__snapshots__/basic.test.ts.snap
@@ -2264,12 +2264,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name CommentsDetail
+     * @name CommentsList
      * @request GET:/gists/{id}/comments
      * @response \`200\` \`SwaggerTypeCommentsGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    commentsDetail: (id: number, params: RequestParams = {}) =>
+    commentsList: (id: number, params: RequestParams = {}) =>
       this.request<SwaggerTypeCommentsGeneratedDataContract, void>({
         path: \`/gists/\${id}/comments\`,
         method: "GET",
@@ -2312,14 +2312,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name CommentsDetail2
+     * @name CommentsDetail
      * @request GET:/gists/{id}/comments/{commentId}
-     * @originalName commentsDetail
-     * @duplicate
      * @response \`200\` \`SwaggerTypeCommentGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    commentsDetail2: (id: number, commentId: number, params: RequestParams = {}) =>
+    commentsDetail: (id: number, commentId: number, params: RequestParams = {}) =>
       this.request<SwaggerTypeCommentGeneratedDataContract, void>({
         path: \`/gists/\${id}/comments/\${commentId}\`,
         method: "GET",
@@ -2384,13 +2382,13 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name StarDetail
+     * @name StarList
      * @request GET:/gists/{id}/star
      * @response \`204\` \`void\`
      * @response \`403\` \`void\`
      * @response \`404\` \`void\`
      */
-    starDetail: (id: number, params: RequestParams = {}) =>
+    starList: (id: number, params: RequestParams = {}) =>
       this.request<void, void>({
         path: \`/gists/\${id}/star\`,
         method: "GET",
@@ -2628,12 +2626,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name EventsDetail
+     * @name EventsList
      * @request GET:/networks/{owner}/{repo}/events
      * @response \`200\` \`SwaggerTypeEventsGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    eventsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    eventsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<SwaggerTypeEventsGeneratedDataContract, void>({
         path: \`/networks/\${owner}/\${repo}/events\`,
         method: "GET",
@@ -2731,12 +2729,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ThreadsSubscriptionDetail
+     * @name ThreadsSubscriptionList
      * @request GET:/notifications/threads/{id}/subscription
      * @response \`200\` \`SwaggerTypeSubscriptionGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    threadsSubscriptionDetail: (id: number, params: RequestParams = {}) =>
+    threadsSubscriptionList: (id: number, params: RequestParams = {}) =>
       this.request<SwaggerTypeSubscriptionGeneratedDataContract, void>({
         path: \`/notifications/threads/\${id}/subscription\`,
         method: "GET",
@@ -2804,12 +2802,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name EventsDetail
+     * @name EventsList
      * @request GET:/orgs/{org}/events
      * @response \`200\` \`SwaggerTypeEventsGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    eventsDetail: (org: string, params: RequestParams = {}) =>
+    eventsList: (org: string, params: RequestParams = {}) =>
       this.request<SwaggerTypeEventsGeneratedDataContract, void>({
         path: \`/orgs/\${org}/events\`,
         method: "GET",
@@ -2820,12 +2818,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name IssuesDetail
+     * @name IssuesList
      * @request GET:/orgs/{org}/issues
      * @response \`200\` \`SwaggerTypeIssuesGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    issuesDetail: (
+    issuesList: (
       org: string,
       query: {
         /** @default "all" */
@@ -2852,13 +2850,13 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name MembersDetail
+     * @name MembersList
      * @request GET:/orgs/{org}/members
      * @response \`200\` \`SwaggerTypeUsersGeneratedDataContract\`
      * @response \`302\` \`void\`
      * @response \`403\` \`void\`
      */
-    membersDetail: (org: string, params: RequestParams = {}) =>
+    membersList: (org: string, params: RequestParams = {}) =>
       this.request<SwaggerTypeUsersGeneratedDataContract, void>({
         path: \`/orgs/\${org}/members\`,
         method: "GET",
@@ -2884,16 +2882,14 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name MembersDetail2
+     * @name MembersDetail
      * @request GET:/orgs/{org}/members/{username}
-     * @originalName membersDetail
-     * @duplicate
      * @response \`204\` \`void\`
      * @response \`302\` \`void\`
      * @response \`403\` \`void\`
      * @response \`404\` \`void\`
      */
-    membersDetail2: (org: string, username: string, params: RequestParams = {}) =>
+    membersDetail: (org: string, username: string, params: RequestParams = {}) =>
       this.request<void, void>({
         path: \`/orgs/\${org}/members/\${username}\`,
         method: "GET",
@@ -2903,12 +2899,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name PublicMembersDetail
+     * @name PublicMembersList
      * @request GET:/orgs/{org}/public_members
      * @response \`200\` \`SwaggerTypeUsersGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    publicMembersDetail: (org: string, params: RequestParams = {}) =>
+    publicMembersList: (org: string, params: RequestParams = {}) =>
       this.request<SwaggerTypeUsersGeneratedDataContract, void>({
         path: \`/orgs/\${org}/public_members\`,
         method: "GET",
@@ -2934,15 +2930,13 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name PublicMembersDetail2
+     * @name PublicMembersDetail
      * @request GET:/orgs/{org}/public_members/{username}
-     * @originalName publicMembersDetail
-     * @duplicate
      * @response \`204\` \`void\`
      * @response \`403\` \`void\`
      * @response \`404\` \`void\`
      */
-    publicMembersDetail2: (org: string, username: string, params: RequestParams = {}) =>
+    publicMembersDetail: (org: string, username: string, params: RequestParams = {}) =>
       this.request<void, void>({
         path: \`/orgs/\${org}/public_members/\${username}\`,
         method: "GET",
@@ -2967,12 +2961,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ReposDetail
+     * @name ReposList
      * @request GET:/orgs/{org}/repos
      * @response \`200\` \`SwaggerTypeReposGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    reposDetail: (
+    reposList: (
       org: string,
       query?: {
         /** @default "all" */
@@ -3008,12 +3002,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name TeamsDetail
+     * @name TeamsList
      * @request GET:/orgs/{org}/teams
      * @response \`200\` \`SwaggerTypeTeamsGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    teamsDetail: (org: string, params: RequestParams = {}) =>
+    teamsList: (org: string, params: RequestParams = {}) =>
       this.request<SwaggerTypeTeamsGeneratedDataContract, void>({
         path: \`/orgs/\${org}/teams\`,
         method: "GET",
@@ -3114,12 +3108,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name AssigneesDetail
+     * @name AssigneesList
      * @request GET:/repos/{owner}/{repo}/assignees
      * @response \`200\` \`SwaggerTypeAssigneesGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    assigneesDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    assigneesList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<SwaggerTypeAssigneesGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/assignees\`,
         method: "GET",
@@ -3130,15 +3124,13 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name AssigneesDetail2
+     * @name AssigneesDetail
      * @request GET:/repos/{owner}/{repo}/assignees/{assignee}
-     * @originalName assigneesDetail
-     * @duplicate
      * @response \`204\` \`void\`
      * @response \`403\` \`void\`
      * @response \`404\` \`void\`
      */
-    assigneesDetail2: (owner: string, repo: string, assignee: string, params: RequestParams = {}) =>
+    assigneesDetail: (owner: string, repo: string, assignee: string, params: RequestParams = {}) =>
       this.request<void, void>({
         path: \`/repos/\${owner}/\${repo}/assignees/\${assignee}\`,
         method: "GET",
@@ -3148,12 +3140,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name BranchesDetail
+     * @name BranchesList
      * @request GET:/repos/{owner}/{repo}/branches
      * @response \`200\` \`SwaggerTypeBranchesGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    branchesDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    branchesList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<SwaggerTypeBranchesGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/branches\`,
         method: "GET",
@@ -3164,14 +3156,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name BranchesDetail2
+     * @name BranchesDetail
      * @request GET:/repos/{owner}/{repo}/branches/{branch}
-     * @originalName branchesDetail
-     * @duplicate
      * @response \`200\` \`SwaggerTypeBranchGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    branchesDetail2: (owner: string, repo: string, branch: string, params: RequestParams = {}) =>
+    branchesDetail: (owner: string, repo: string, branch: string, params: RequestParams = {}) =>
       this.request<SwaggerTypeBranchGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/branches/\${branch}\`,
         method: "GET",
@@ -3182,12 +3172,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name CollaboratorsDetail
+     * @name CollaboratorsList
      * @request GET:/repos/{owner}/{repo}/collaborators
      * @response \`200\` \`SwaggerTypeUsersGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    collaboratorsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    collaboratorsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<SwaggerTypeUsersGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/collaborators\`,
         method: "GET",
@@ -3213,15 +3203,13 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name CollaboratorsDetail2
+     * @name CollaboratorsDetail
      * @request GET:/repos/{owner}/{repo}/collaborators/{user}
-     * @originalName collaboratorsDetail
-     * @duplicate
      * @response \`204\` \`void\`
      * @response \`403\` \`void\`
      * @response \`404\` \`void\`
      */
-    collaboratorsDetail2: (owner: string, repo: string, user: string, params: RequestParams = {}) =>
+    collaboratorsDetail: (owner: string, repo: string, user: string, params: RequestParams = {}) =>
       this.request<void, void>({
         path: \`/repos/\${owner}/\${repo}/collaborators/\${user}\`,
         method: "GET",
@@ -3246,12 +3234,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name CommentsDetail
+     * @name CommentsList
      * @request GET:/repos/{owner}/{repo}/comments
      * @response \`200\` \`SwaggerTypeRepoCommentsGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    commentsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    commentsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<SwaggerTypeRepoCommentsGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/comments\`,
         method: "GET",
@@ -3277,14 +3265,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name CommentsDetail2
+     * @name CommentsDetail
      * @request GET:/repos/{owner}/{repo}/comments/{commentId}
-     * @originalName commentsDetail
-     * @duplicate
      * @response \`200\` \`SwaggerTypeCommitCommentGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    commentsDetail2: (owner: string, repo: string, commentId: number, params: RequestParams = {}) =>
+    commentsDetail: (owner: string, repo: string, commentId: number, params: RequestParams = {}) =>
       this.request<SwaggerTypeCommitCommentGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/comments/\${commentId}\`,
         method: "GET",
@@ -3318,12 +3304,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name CommitsDetail
+     * @name CommitsList
      * @request GET:/repos/{owner}/{repo}/commits
      * @response \`200\` \`SwaggerTypeCommitsGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    commitsDetail: (
+    commitsList: (
       owner: string,
       repo: string,
       query?: {
@@ -3346,12 +3332,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name CommitsStatusDetail
+     * @name CommitsStatusList
      * @request GET:/repos/{owner}/{repo}/commits/{ref}/status
      * @response \`200\` \`SwaggerTypeRefStatusGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    commitsStatusDetail: (owner: string, repo: string, ref: string, params: RequestParams = {}) =>
+    commitsStatusList: (owner: string, repo: string, ref: string, params: RequestParams = {}) =>
       this.request<SwaggerTypeRefStatusGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/commits/\${ref}/status\`,
         method: "GET",
@@ -3362,14 +3348,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name CommitsDetail2
+     * @name CommitsDetail
      * @request GET:/repos/{owner}/{repo}/commits/{shaCode}
-     * @originalName commitsDetail
-     * @duplicate
      * @response \`200\` \`SwaggerTypeCommitGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    commitsDetail2: (owner: string, repo: string, shaCode: string, params: RequestParams = {}) =>
+    commitsDetail: (owner: string, repo: string, shaCode: string, params: RequestParams = {}) =>
       this.request<SwaggerTypeCommitGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/commits/\${shaCode}\`,
         method: "GET",
@@ -3380,12 +3364,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name CommitsCommentsDetail
+     * @name CommitsCommentsList
      * @request GET:/repos/{owner}/{repo}/commits/{shaCode}/comments
      * @response \`200\` \`SwaggerTypeRepoCommentsGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    commitsCommentsDetail: (owner: string, repo: string, shaCode: string, params: RequestParams = {}) =>
+    commitsCommentsList: (owner: string, repo: string, shaCode: string, params: RequestParams = {}) =>
       this.request<SwaggerTypeRepoCommentsGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/commits/\${shaCode}/comments\`,
         method: "GET",
@@ -3510,12 +3494,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ContributorsDetail
+     * @name ContributorsList
      * @request GET:/repos/{owner}/{repo}/contributors
      * @response \`200\` \`SwaggerTypeUsersGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    contributorsDetail: (
+    contributorsList: (
       owner: string,
       repo: string,
       query: {
@@ -3534,12 +3518,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name DeploymentsDetail
+     * @name DeploymentsList
      * @request GET:/repos/{owner}/{repo}/deployments
      * @response \`200\` \`SwaggerTypeRepoDeploymentsGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    deploymentsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    deploymentsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<SwaggerTypeRepoDeploymentsGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/deployments\`,
         method: "GET",
@@ -3573,12 +3557,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name DeploymentsStatusesDetail
+     * @name DeploymentsStatusesList
      * @request GET:/repos/{owner}/{repo}/deployments/{id}/statuses
      * @response \`200\` \`SwaggerTypeDeploymentStatusesGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    deploymentsStatusesDetail: (owner: string, repo: string, id: number, params: RequestParams = {}) =>
+    deploymentsStatusesList: (owner: string, repo: string, id: number, params: RequestParams = {}) =>
       this.request<SwaggerTypeDeploymentStatusesGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/deployments/\${id}/statuses\`,
         method: "GET",
@@ -3612,13 +3596,13 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name DownloadsDetail
+     * @name DownloadsList
      * @request GET:/repos/{owner}/{repo}/downloads
      * @deprecated
      * @response \`200\` \`SwaggerTypeDownloadsGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    downloadsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    downloadsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<SwaggerTypeDownloadsGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/downloads\`,
         method: "GET",
@@ -3645,15 +3629,13 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name DownloadsDetail2
+     * @name DownloadsDetail
      * @request GET:/repos/{owner}/{repo}/downloads/{downloadId}
      * @deprecated
-     * @originalName downloadsDetail
-     * @duplicate
      * @response \`200\` \`SwaggerTypeDownloadGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    downloadsDetail2: (owner: string, repo: string, downloadId: number, params: RequestParams = {}) =>
+    downloadsDetail: (owner: string, repo: string, downloadId: number, params: RequestParams = {}) =>
       this.request<SwaggerTypeDownloadGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/downloads/\${downloadId}\`,
         method: "GET",
@@ -3664,12 +3646,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name EventsDetail
+     * @name EventsList
      * @request GET:/repos/{owner}/{repo}/events
      * @response \`200\` \`SwaggerTypeEventsGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    eventsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    eventsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<SwaggerTypeEventsGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/events\`,
         method: "GET",
@@ -3680,12 +3662,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ForksDetail
+     * @name ForksList
      * @request GET:/repos/{owner}/{repo}/forks
      * @response \`200\` \`SwaggerTypeForksGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    forksDetail: (
+    forksList: (
       owner: string,
       repo: string,
       query?: {
@@ -3806,12 +3788,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name GitRefsDetail
+     * @name GitRefsList
      * @request GET:/repos/{owner}/{repo}/git/refs
      * @response \`200\` \`SwaggerTypeRefsGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    gitRefsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    gitRefsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<SwaggerTypeRefsGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/git/refs\`,
         method: "GET",
@@ -3860,14 +3842,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name GitRefsDetail2
+     * @name GitRefsDetail
      * @request GET:/repos/{owner}/{repo}/git/refs/{ref}
-     * @originalName gitRefsDetail
-     * @duplicate
      * @response \`200\` \`SwaggerTypeHeadBranchGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    gitRefsDetail2: (owner: string, repo: string, ref: string, params: RequestParams = {}) =>
+    gitRefsDetail: (owner: string, repo: string, ref: string, params: RequestParams = {}) =>
       this.request<SwaggerTypeHeadBranchGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/git/refs/\${ref}\`,
         method: "GET",
@@ -3989,12 +3969,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name HooksDetail
+     * @name HooksList
      * @request GET:/repos/{owner}/{repo}/hooks
      * @response \`200\` \`SwaggerTypeHookGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    hooksDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    hooksList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<SwaggerTypeHookGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/hooks\`,
         method: "GET",
@@ -4042,14 +4022,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name HooksDetail2
+     * @name HooksDetail
      * @request GET:/repos/{owner}/{repo}/hooks/{hookId}
-     * @originalName hooksDetail
-     * @duplicate
      * @response \`200\` \`SwaggerTypeHookGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    hooksDetail2: (owner: string, repo: string, hookId: number, params: RequestParams = {}) =>
+    hooksDetail: (owner: string, repo: string, hookId: number, params: RequestParams = {}) =>
       this.request<SwaggerTypeHookGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/hooks/\${hookId}\`,
         method: "GET",
@@ -4098,12 +4076,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name IssuesDetail
+     * @name IssuesList
      * @request GET:/repos/{owner}/{repo}/issues
      * @response \`200\` \`SwaggerTypeIssuesGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    issuesDetail: (
+    issuesList: (
       owner: string,
       repo: string,
       query: {
@@ -4153,12 +4131,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name IssuesCommentsDetail
+     * @name IssuesCommentsList
      * @request GET:/repos/{owner}/{repo}/issues/comments
      * @response \`200\` \`SwaggerTypeIssuesCommentsGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    issuesCommentsDetail: (
+    issuesCommentsList: (
       owner: string,
       repo: string,
       query?: {
@@ -4194,14 +4172,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name IssuesCommentsDetail2
+     * @name IssuesCommentsDetail
      * @request GET:/repos/{owner}/{repo}/issues/comments/{commentId}
-     * @originalName issuesCommentsDetail
-     * @duplicate
      * @response \`200\` \`SwaggerTypeIssuesCommentGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    issuesCommentsDetail2: (owner: string, repo: string, commentId: number, params: RequestParams = {}) =>
+    issuesCommentsDetail: (owner: string, repo: string, commentId: number, params: RequestParams = {}) =>
       this.request<SwaggerTypeIssuesCommentGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/issues/comments/\${commentId}\`,
         method: "GET",
@@ -4235,12 +4211,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name IssuesEventsDetail
+     * @name IssuesEventsList
      * @request GET:/repos/{owner}/{repo}/issues/events
      * @response \`200\` \`SwaggerTypeIssueEventsGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    issuesEventsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    issuesEventsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<SwaggerTypeIssueEventsGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/issues/events\`,
         method: "GET",
@@ -4251,14 +4227,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name IssuesEventsDetail2
+     * @name IssuesEventsDetail
      * @request GET:/repos/{owner}/{repo}/issues/events/{eventId}
-     * @originalName issuesEventsDetail
-     * @duplicate
      * @response \`200\` \`SwaggerTypeIssueEventGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    issuesEventsDetail2: (owner: string, repo: string, eventId: number, params: RequestParams = {}) =>
+    issuesEventsDetail: (owner: string, repo: string, eventId: number, params: RequestParams = {}) =>
       this.request<SwaggerTypeIssueEventGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/issues/events/\${eventId}\`,
         method: "GET",
@@ -4269,14 +4243,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name IssuesDetail2
+     * @name IssuesDetail
      * @request GET:/repos/{owner}/{repo}/issues/{number}
-     * @originalName issuesDetail
-     * @duplicate
      * @response \`200\` \`SwaggerTypeIssueGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    issuesDetail2: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    issuesDetail: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<SwaggerTypeIssueGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/issues/\${number}\`,
         method: "GET",
@@ -4310,14 +4282,14 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name IssuesCommentsDetail3
+     * @name IssuesCommentsList2
      * @request GET:/repos/{owner}/{repo}/issues/{number}/comments
-     * @originalName issuesCommentsDetail
+     * @originalName issuesCommentsList
      * @duplicate
      * @response \`200\` \`SwaggerTypeIssuesCommentsGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    issuesCommentsDetail3: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    issuesCommentsList2: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<SwaggerTypeIssuesCommentsGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/issues/\${number}/comments\`,
         method: "GET",
@@ -4351,14 +4323,14 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name IssuesEventsDetail3
+     * @name IssuesEventsList2
      * @request GET:/repos/{owner}/{repo}/issues/{number}/events
-     * @originalName issuesEventsDetail
+     * @originalName issuesEventsList
      * @duplicate
      * @response \`200\` \`SwaggerTypeIssueEventsGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    issuesEventsDetail3: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    issuesEventsList2: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<SwaggerTypeIssueEventsGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/issues/\${number}/events\`,
         method: "GET",
@@ -4384,12 +4356,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name IssuesLabelsDetail
+     * @name IssuesLabelsList
      * @request GET:/repos/{owner}/{repo}/issues/{number}/labels
      * @response \`200\` \`SwaggerTypeLabelsGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    issuesLabelsDetail: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    issuesLabelsList: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<SwaggerTypeLabelsGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/issues/\${number}/labels\`,
         method: "GET",
@@ -4463,12 +4435,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name KeysDetail
+     * @name KeysList
      * @request GET:/repos/{owner}/{repo}/keys
      * @response \`200\` \`SwaggerTypeKeysGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    keysDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    keysList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<SwaggerTypeKeysGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/keys\`,
         method: "GET",
@@ -4516,14 +4488,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name KeysDetail2
+     * @name KeysDetail
      * @request GET:/repos/{owner}/{repo}/keys/{keyId}
-     * @originalName keysDetail
-     * @duplicate
      * @response \`200\` \`SwaggerTypeUserKeysKeyIdGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    keysDetail2: (owner: string, repo: string, keyId: number, params: RequestParams = {}) =>
+    keysDetail: (owner: string, repo: string, keyId: number, params: RequestParams = {}) =>
       this.request<SwaggerTypeUserKeysKeyIdGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/keys/\${keyId}\`,
         method: "GET",
@@ -4534,12 +4504,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name LabelsDetail
+     * @name LabelsList
      * @request GET:/repos/{owner}/{repo}/labels
      * @response \`200\` \`SwaggerTypeLabelsGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    labelsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    labelsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<SwaggerTypeLabelsGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/labels\`,
         method: "GET",
@@ -4587,14 +4557,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name LabelsDetail2
+     * @name LabelsDetail
      * @request GET:/repos/{owner}/{repo}/labels/{name}
-     * @originalName labelsDetail
-     * @duplicate
      * @response \`200\` \`SwaggerTypeLabelGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    labelsDetail2: (owner: string, repo: string, name: string, params: RequestParams = {}) =>
+    labelsDetail: (owner: string, repo: string, name: string, params: RequestParams = {}) =>
       this.request<SwaggerTypeLabelGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/labels/\${name}\`,
         method: "GET",
@@ -4628,12 +4596,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name LanguagesDetail
+     * @name LanguagesList
      * @request GET:/repos/{owner}/{repo}/languages
      * @response \`200\` \`SwaggerTypeLanguagesGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    languagesDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    languagesList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<SwaggerTypeLanguagesGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/languages\`,
         method: "GET",
@@ -4673,12 +4641,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name MilestonesDetail
+     * @name MilestonesList
      * @request GET:/repos/{owner}/{repo}/milestones
      * @response \`200\` \`SwaggerTypeMilestoneGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    milestonesDetail: (
+    milestonesList: (
       owner: string,
       repo: string,
       query?: {
@@ -4738,14 +4706,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name MilestonesDetail2
+     * @name MilestonesDetail
      * @request GET:/repos/{owner}/{repo}/milestones/{number}
-     * @originalName milestonesDetail
-     * @duplicate
      * @response \`200\` \`SwaggerTypeMilestoneGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    milestonesDetail2: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    milestonesDetail: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<SwaggerTypeMilestoneGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/milestones/\${number}\`,
         method: "GET",
@@ -4779,12 +4745,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name MilestonesLabelsDetail
+     * @name MilestonesLabelsList
      * @request GET:/repos/{owner}/{repo}/milestones/{number}/labels
      * @response \`200\` \`SwaggerTypeLabelsGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    milestonesLabelsDetail: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    milestonesLabelsList: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<SwaggerTypeLabelsGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/milestones/\${number}/labels\`,
         method: "GET",
@@ -4795,12 +4761,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name NotificationsDetail
+     * @name NotificationsList
      * @request GET:/repos/{owner}/{repo}/notifications
      * @response \`200\` \`SwaggerTypeNotificationsGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    notificationsDetail: (
+    notificationsList: (
       owner: string,
       repo: string,
       query?: {
@@ -4842,12 +4808,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name PullsDetail
+     * @name PullsList
      * @request GET:/repos/{owner}/{repo}/pulls
      * @response \`200\` \`SwaggerTypePullsGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    pullsDetail: (
+    pullsList: (
       owner: string,
       repo: string,
       query?: {
@@ -4892,12 +4858,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name PullsCommentsDetail
+     * @name PullsCommentsList
      * @request GET:/repos/{owner}/{repo}/pulls/comments
      * @response \`200\` \`SwaggerTypeIssuesCommentsGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    pullsCommentsDetail: (
+    pullsCommentsList: (
       owner: string,
       repo: string,
       query?: {
@@ -4933,14 +4899,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name PullsCommentsDetail2
+     * @name PullsCommentsDetail
      * @request GET:/repos/{owner}/{repo}/pulls/comments/{commentId}
-     * @originalName pullsCommentsDetail
-     * @duplicate
      * @response \`200\` \`SwaggerTypePullsCommentGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    pullsCommentsDetail2: (owner: string, repo: string, commentId: number, params: RequestParams = {}) =>
+    pullsCommentsDetail: (owner: string, repo: string, commentId: number, params: RequestParams = {}) =>
       this.request<SwaggerTypePullsCommentGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/pulls/comments/\${commentId}\`,
         method: "GET",
@@ -4974,14 +4938,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name PullsDetail2
+     * @name PullsDetail
      * @request GET:/repos/{owner}/{repo}/pulls/{number}
-     * @originalName pullsDetail
-     * @duplicate
      * @response \`200\` \`SwaggerTypePullRequestGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    pullsDetail2: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    pullsDetail: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<SwaggerTypePullRequestGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/pulls/\${number}\`,
         method: "GET",
@@ -5016,14 +4978,14 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name PullsCommentsDetail3
+     * @name PullsCommentsList2
      * @request GET:/repos/{owner}/{repo}/pulls/{number}/comments
-     * @originalName pullsCommentsDetail
+     * @originalName pullsCommentsList
      * @duplicate
      * @response \`200\` \`SwaggerTypePullsCommentGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    pullsCommentsDetail3: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    pullsCommentsList2: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<SwaggerTypePullsCommentGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/pulls/\${number}/comments\`,
         method: "GET",
@@ -5058,12 +5020,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name PullsCommitsDetail
+     * @name PullsCommitsList
      * @request GET:/repos/{owner}/{repo}/pulls/{number}/commits
      * @response \`200\` \`SwaggerTypeCommitsGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    pullsCommitsDetail: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    pullsCommitsList: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<SwaggerTypeCommitsGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/pulls/\${number}/commits\`,
         method: "GET",
@@ -5074,12 +5036,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name PullsFilesDetail
+     * @name PullsFilesList
      * @request GET:/repos/{owner}/{repo}/pulls/{number}/files
      * @response \`200\` \`SwaggerTypePullsGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    pullsFilesDetail: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    pullsFilesList: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<SwaggerTypePullsGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/pulls/\${number}/files\`,
         method: "GET",
@@ -5090,13 +5052,13 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name PullsMergeDetail
+     * @name PullsMergeList
      * @request GET:/repos/{owner}/{repo}/pulls/{number}/merge
      * @response \`204\` \`void\`
      * @response \`403\` \`void\`
      * @response \`404\` \`void\`
      */
-    pullsMergeDetail: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
+    pullsMergeList: (owner: string, repo: string, number: number, params: RequestParams = {}) =>
       this.request<void, void>({
         path: \`/repos/\${owner}/\${repo}/pulls/\${number}/merge\`,
         method: "GET",
@@ -5131,12 +5093,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ReadmeDetail
+     * @name ReadmeList
      * @request GET:/repos/{owner}/{repo}/readme
      * @response \`200\` \`SwaggerTypeContentsPathGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    readmeDetail: (
+    readmeList: (
       owner: string,
       repo: string,
       query?: {
@@ -5155,12 +5117,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ReleasesDetail
+     * @name ReleasesList
      * @request GET:/repos/{owner}/{repo}/releases
      * @response \`200\` \`SwaggerTypeReleasesGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    releasesDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    releasesList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<SwaggerTypeReleasesGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/releases\`,
         method: "GET",
@@ -5263,14 +5225,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ReleasesDetail2
+     * @name ReleasesDetail
      * @request GET:/repos/{owner}/{repo}/releases/{id}
-     * @originalName releasesDetail
-     * @duplicate
      * @response \`200\` \`SwaggerTypeReleaseGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    releasesDetail2: (owner: string, repo: string, id: string, params: RequestParams = {}) =>
+    releasesDetail: (owner: string, repo: string, id: string, params: RequestParams = {}) =>
       this.request<SwaggerTypeReleaseGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/releases/\${id}\`,
         method: "GET",
@@ -5304,14 +5264,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ReleasesAssetsDetail2
+     * @name ReleasesAssetsList
      * @request GET:/repos/{owner}/{repo}/releases/{id}/assets
-     * @originalName releasesAssetsDetail
-     * @duplicate
      * @response \`200\` \`SwaggerTypeAssetsGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    releasesAssetsDetail2: (owner: string, repo: string, id: string, params: RequestParams = {}) =>
+    releasesAssetsList: (owner: string, repo: string, id: string, params: RequestParams = {}) =>
       this.request<SwaggerTypeAssetsGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/releases/\${id}/assets\`,
         method: "GET",
@@ -5322,12 +5280,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name StargazersDetail
+     * @name StargazersList
      * @request GET:/repos/{owner}/{repo}/stargazers
      * @response \`200\` \`SwaggerTypeUsersGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    stargazersDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    stargazersList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<SwaggerTypeUsersGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/stargazers\`,
         method: "GET",
@@ -5338,12 +5296,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name StatsCodeFrequencyDetail
+     * @name StatsCodeFrequencyList
      * @request GET:/repos/{owner}/{repo}/stats/code_frequency
      * @response \`200\` \`SwaggerTypeCodeFrequencyStatsGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    statsCodeFrequencyDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    statsCodeFrequencyList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<SwaggerTypeCodeFrequencyStatsGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/stats/code_frequency\`,
         method: "GET",
@@ -5354,12 +5312,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name StatsCommitActivityDetail
+     * @name StatsCommitActivityList
      * @request GET:/repos/{owner}/{repo}/stats/commit_activity
      * @response \`200\` \`SwaggerTypeCommitActivityStatsGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    statsCommitActivityDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    statsCommitActivityList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<SwaggerTypeCommitActivityStatsGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/stats/commit_activity\`,
         method: "GET",
@@ -5370,12 +5328,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name StatsContributorsDetail
+     * @name StatsContributorsList
      * @request GET:/repos/{owner}/{repo}/stats/contributors
      * @response \`200\` \`SwaggerTypeContributorsStatsGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    statsContributorsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    statsContributorsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<SwaggerTypeContributorsStatsGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/stats/contributors\`,
         method: "GET",
@@ -5386,12 +5344,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name StatsParticipationDetail
+     * @name StatsParticipationList
      * @request GET:/repos/{owner}/{repo}/stats/participation
      * @response \`200\` \`SwaggerTypeParticipationStatsGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    statsParticipationDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    statsParticipationList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<SwaggerTypeParticipationStatsGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/stats/participation\`,
         method: "GET",
@@ -5402,12 +5360,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name StatsPunchCardDetail
+     * @name StatsPunchCardList
      * @request GET:/repos/{owner}/{repo}/stats/punch_card
      * @response \`200\` \`SwaggerTypeCodeFrequencyStatsGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    statsPunchCardDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    statsPunchCardList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<SwaggerTypeCodeFrequencyStatsGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/stats/punch_card\`,
         method: "GET",
@@ -5458,12 +5416,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name SubscribersDetail
+     * @name SubscribersList
      * @request GET:/repos/{owner}/{repo}/subscribers
      * @response \`200\` \`SwaggerTypeUsersGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    subscribersDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    subscribersList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<SwaggerTypeUsersGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/subscribers\`,
         method: "GET",
@@ -5489,12 +5447,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name SubscriptionDetail
+     * @name SubscriptionList
      * @request GET:/repos/{owner}/{repo}/subscription
      * @response \`200\` \`SwaggerTypeSubscriptionGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    subscriptionDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    subscriptionList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<SwaggerTypeSubscriptionGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/subscription\`,
         method: "GET",
@@ -5528,12 +5486,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name TagsDetail
+     * @name TagsList
      * @request GET:/repos/{owner}/{repo}/tags
      * @response \`200\` \`SwaggerTypeTagsGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    tagsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    tagsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<SwaggerTypeTagsGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/tags\`,
         method: "GET",
@@ -5544,12 +5502,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name TeamsDetail
+     * @name TeamsList
      * @request GET:/repos/{owner}/{repo}/teams
      * @response \`200\` \`SwaggerTypeTeamsGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    teamsDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    teamsList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<SwaggerTypeTeamsGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/teams\`,
         method: "GET",
@@ -5560,12 +5518,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name WatchersDetail
+     * @name WatchersList
      * @request GET:/repos/{owner}/{repo}/watchers
      * @response \`200\` \`SwaggerTypeUsersGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    watchersDetail: (owner: string, repo: string, params: RequestParams = {}) =>
+    watchersList: (owner: string, repo: string, params: RequestParams = {}) =>
       this.request<SwaggerTypeUsersGeneratedDataContract, void>({
         path: \`/repos/\${owner}/\${repo}/watchers\`,
         method: "GET",
@@ -5773,12 +5731,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name MembersDetail
+     * @name MembersList
      * @request GET:/teams/{teamId}/members
      * @response \`200\` \`SwaggerTypeUsersGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    membersDetail: (teamId: number, params: RequestParams = {}) =>
+    membersList: (teamId: number, params: RequestParams = {}) =>
       this.request<SwaggerTypeUsersGeneratedDataContract, void>({
         path: \`/teams/\${teamId}/members\`,
         method: "GET",
@@ -5805,16 +5763,14 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name MembersDetail2
+     * @name MembersDetail
      * @request GET:/teams/{teamId}/members/{username}
      * @deprecated
-     * @originalName membersDetail
-     * @duplicate
      * @response \`204\` \`void\`
      * @response \`403\` \`void\`
      * @response \`404\` \`void\`
      */
-    membersDetail2: (teamId: number, username: string, params: RequestParams = {}) =>
+    membersDetail: (teamId: number, username: string, params: RequestParams = {}) =>
       this.request<void, void>({
         path: \`/teams/\${teamId}/members/\${username}\`,
         method: "GET",
@@ -5893,12 +5849,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ReposDetail
+     * @name ReposList
      * @request GET:/teams/{teamId}/repos
      * @response \`200\` \`SwaggerTypeTeamReposGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    reposDetail: (teamId: number, params: RequestParams = {}) =>
+    reposList: (teamId: number, params: RequestParams = {}) =>
       this.request<SwaggerTypeTeamReposGeneratedDataContract, void>({
         path: \`/teams/\${teamId}/repos\`,
         method: "GET",
@@ -5924,13 +5880,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ReposDetail2
+     * @name ReposDetail
      * @request GET:/teams/{teamId}/repos/{owner}/{repo}
-     * @originalName reposDetail
-     * @duplicate
      * @response \`403\` \`void\`
      */
-    reposDetail2: (teamId: number, owner: string, repo: string, params: RequestParams = {}) =>
+    reposDetail: (teamId: number, owner: string, repo: string, params: RequestParams = {}) =>
       this.request<any, void>({
         path: \`/teams/\${teamId}/repos/\${owner}/\${repo}\`,
         method: "GET",
@@ -6455,11 +6409,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name EventsDetail
+     * @name EventsList
      * @request GET:/users/{username}/events
      * @response \`403\` \`void\`
      */
-    eventsDetail: (username: string, params: RequestParams = {}) =>
+    eventsList: (username: string, params: RequestParams = {}) =>
       this.request<any, void>({
         path: \`/users/\${username}/events\`,
         method: "GET",
@@ -6483,12 +6437,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name FollowersDetail
+     * @name FollowersList
      * @request GET:/users/{username}/followers
      * @response \`200\` \`SwaggerTypeUsersGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    followersDetail: (username: string, params: RequestParams = {}) =>
+    followersList: (username: string, params: RequestParams = {}) =>
       this.request<SwaggerTypeUsersGeneratedDataContract, void>({
         path: \`/users/\${username}/followers\`,
         method: "GET",
@@ -6515,12 +6469,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name GistsDetail
+     * @name GistsList
      * @request GET:/users/{username}/gists
      * @response \`200\` \`SwaggerTypeGistsGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    gistsDetail: (
+    gistsList: (
       username: string,
       query?: {
         since?: string;
@@ -6538,12 +6492,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name KeysDetail
+     * @name KeysList
      * @request GET:/users/{username}/keys
      * @response \`200\` \`SwaggerTypeGitignoreGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    keysDetail: (username: string, params: RequestParams = {}) =>
+    keysList: (username: string, params: RequestParams = {}) =>
       this.request<SwaggerTypeGitignoreGeneratedDataContract, void>({
         path: \`/users/\${username}/keys\`,
         method: "GET",
@@ -6554,12 +6508,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name OrgsDetail
+     * @name OrgsList
      * @request GET:/users/{username}/orgs
      * @response \`200\` \`SwaggerTypeGitignoreGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    orgsDetail: (username: string, params: RequestParams = {}) =>
+    orgsList: (username: string, params: RequestParams = {}) =>
       this.request<SwaggerTypeGitignoreGeneratedDataContract, void>({
         path: \`/users/\${username}/orgs\`,
         method: "GET",
@@ -6570,11 +6524,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ReceivedEventsDetail
+     * @name ReceivedEventsList
      * @request GET:/users/{username}/received_events
      * @response \`403\` \`void\`
      */
-    receivedEventsDetail: (username: string, params: RequestParams = {}) =>
+    receivedEventsList: (username: string, params: RequestParams = {}) =>
       this.request<any, void>({
         path: \`/users/\${username}/received_events\`,
         method: "GET",
@@ -6584,11 +6538,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ReceivedEventsPublicDetail
+     * @name ReceivedEventsPublicList
      * @request GET:/users/{username}/received_events/public
      * @response \`403\` \`void\`
      */
-    receivedEventsPublicDetail: (username: string, params: RequestParams = {}) =>
+    receivedEventsPublicList: (username: string, params: RequestParams = {}) =>
       this.request<any, void>({
         path: \`/users/\${username}/received_events/public\`,
         method: "GET",
@@ -6598,12 +6552,12 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name ReposDetail
+     * @name ReposList
      * @request GET:/users/{username}/repos
      * @response \`200\` \`SwaggerTypeReposGeneratedDataContract\`
      * @response \`403\` \`void\`
      */
-    reposDetail: (
+    reposList: (
       username: string,
       query?: {
         /** @default "all" */
@@ -6622,11 +6576,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name StarredDetail
+     * @name StarredList
      * @request GET:/users/{username}/starred
      * @response \`403\` \`void\`
      */
-    starredDetail: (username: string, params: RequestParams = {}) =>
+    starredList: (username: string, params: RequestParams = {}) =>
       this.request<any, void>({
         path: \`/users/\${username}/starred\`,
         method: "GET",
@@ -6636,11 +6590,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * No description
      *
-     * @name SubscriptionsDetail
+     * @name SubscriptionsList
      * @request GET:/users/{username}/subscriptions
      * @response \`403\` \`void\`
      */
-    subscriptionsDetail: (username: string, params: RequestParams = {}) =>
+    subscriptionsList: (username: string, params: RequestParams = {}) =>
       this.request<any, void>({
         path: \`/users/\${username}/subscriptions\`,
         method: "GET",


### PR DESCRIPTION
`/group/{gid}/user` and `/group/{gid}/user/{uid}` should be generated as `groupUserList` / `groupUserDetail` instead of ` groupUser` / `groupUser2`