### PR TITLE
Add ts-nocheck comment to auto-generated file

### DIFF
--- a/.changeset/sour-lamps-heal.md
+++ b/.changeset/sour-lamps-heal.md
@@ -1,0 +1,5 @@
+---
+"swagger-typescript-api": patch
+---
+
+Add ts-nocheck comment to auto-generated file.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,6 +4,7 @@ export const DEFAULT_BODY_ARG_NAME = "data";
 
 export const FILE_PREFIX = `/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/src/util/file-system.ts
+++ b/src/util/file-system.ts
@@ -5,6 +5,7 @@ import { consola } from "consola";
 
 const FILE_PREFIX = `/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/__snapshots__/extended.test.ts.snap
+++ b/tests/__snapshots__/extended.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`extended > 'adafruit' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -4284,6 +4285,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`extended > 'additional-properties' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -4521,6 +4523,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`extended > 'additional-properties2' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -4754,6 +4757,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`extended > 'allof-example' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -5041,6 +5045,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`extended > 'another-example' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -6348,6 +6353,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`extended > 'another-schema' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -6705,6 +6711,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`extended > 'anyof-example' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -6986,6 +6993,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`extended > 'api-with-examples' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -7268,6 +7276,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`extended > 'api-with-examples' 2`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -7620,6 +7629,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`extended > 'authentiq' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -8579,6 +8589,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`extended > 'callback-example' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -8868,6 +8879,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`extended > 'components-responses' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -9142,6 +9154,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`extended > 'enums' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -9431,6 +9444,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`extended > 'example1' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -9763,6 +9777,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`extended > 'explode-param-3' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -10095,6 +10110,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`extended > 'file-formdata-example' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -10373,6 +10389,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`extended > 'full-swagger-scheme' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -59205,6 +59222,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`extended > 'furkot-example' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -59595,6 +59613,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`extended > 'giphy' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -60732,6 +60751,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`extended > 'link-example' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -61198,6 +61218,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`extended > 'no-definitions-schema' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -61442,6 +61463,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`extended > 'oneof-example' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -61725,6 +61747,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`extended > 'path-args' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -62040,6 +62063,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`extended > 'personal-api-example' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -62857,6 +62881,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`extended > 'petstore' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -63232,6 +63257,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`extended > 'petstore' 2`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -63605,6 +63631,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`extended > 'petstore-expanded' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -64017,6 +64044,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`extended > 'petstore-expanded' 2`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -64483,6 +64511,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`extended > 'petstore-minimal' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -64760,6 +64789,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`extended > 'petstore-simple' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -65180,6 +65210,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`extended > 'petstore-swagger-io' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -66285,6 +66316,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`extended > 'petstore-with-external-docs' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -66698,6 +66730,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`extended > 'query-path-param' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -66993,6 +67026,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`extended > 'recursive-schema' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -67233,6 +67267,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`extended > 'responses' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -67500,6 +67535,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`extended > 'swaggerhub-template' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -67803,6 +67839,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`extended > 'tsoa-odd-types-3' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -68728,6 +68765,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`extended > 'uber' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -69365,6 +69403,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`extended > 'up-banking' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -71315,6 +71354,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`extended > 'uspto' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -71713,6 +71753,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`extended > 'wrong-enum-subtypes' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -71953,6 +71994,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`extended > 'wrong-schema-names' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/__snapshots__/simple.test.ts.snap
+++ b/tests/__snapshots__/simple.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`simple > 'adafruit' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -2317,6 +2318,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`simple > 'additional-properties' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -2554,6 +2556,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`simple > 'additional-properties2' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -2787,6 +2790,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`simple > 'allof-example' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -3048,6 +3052,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`simple > 'another-example' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -3883,6 +3888,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`simple > 'another-schema' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -4188,6 +4194,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`simple > 'anyof-example' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -4445,6 +4452,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`simple > 'api-with-examples' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -4707,6 +4715,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`simple > 'api-with-examples' 2`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -5003,6 +5012,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`simple > 'authentiq' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -5650,6 +5660,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`simple > 'callback-example' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -5917,6 +5928,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`simple > 'components-responses' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -6169,6 +6181,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`simple > 'enums' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -6458,6 +6471,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`simple > 'example1' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -6757,6 +6771,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`simple > 'explode-param-3' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -7055,6 +7070,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`simple > 'file-formdata-example' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -7315,6 +7331,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`simple > 'full-swagger-scheme' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -35803,6 +35820,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`simple > 'furkot-example' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -36147,6 +36165,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`simple > 'giphy' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -37026,6 +37045,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`simple > 'link-example' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -37366,6 +37386,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`simple > 'no-definitions-schema' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -37610,6 +37631,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`simple > 'oneof-example' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -37867,6 +37889,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`simple > 'path-args' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -38130,6 +38153,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`simple > 'personal-api-example' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -38740,6 +38764,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`simple > 'petstore' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -39048,6 +39073,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`simple > 'petstore' 2`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -39354,6 +39380,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`simple > 'petstore-expanded' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -39677,6 +39704,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`simple > 'petstore-expanded' 2`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -40034,6 +40062,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`simple > 'petstore-minimal' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -40294,6 +40323,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`simple > 'petstore-simple' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -40625,6 +40655,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`simple > 'petstore-swagger-io' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -41314,6 +41345,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`simple > 'petstore-with-external-docs' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -41638,6 +41670,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`simple > 'query-path-param' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -41899,6 +41932,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`simple > 'recursive-schema' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -42139,6 +42173,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`simple > 'responses' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -42392,6 +42427,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`simple > 'swaggerhub-template' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -42658,6 +42694,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`simple > 'tsoa-odd-types-3' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -43289,6 +43326,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`simple > 'uber' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -43765,6 +43803,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`simple > 'up-banking' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -45212,6 +45251,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`simple > 'uspto' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -45551,6 +45591,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`simple > 'wrong-enum-subtypes' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -45787,6 +45828,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
 exports[`simple > 'wrong-schema-names' 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/spec/additional-properties-2.0/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/additional-properties-2.0/__snapshots__/basic.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`basic > additional properties 2.0 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/spec/another-array-type/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/another-array-type/__snapshots__/basic.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`basic > --another-array-type 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/spec/another-query-params/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/another-query-params/__snapshots__/basic.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`basic > another-query-params 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/spec/axios/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/axios/__snapshots__/basic.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`basic > --axios option 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/spec/axiosSingleHttpClient/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/axiosSingleHttpClient/__snapshots__/basic.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`basic > --axios --single-http-client 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/spec/const-keyword/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/const-keyword/__snapshots__/basic.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`basic > const-keyword 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/spec/custom-extensions/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/custom-extensions/__snapshots__/basic.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`basic > custom extensions 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/spec/defaultAsSuccess/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/defaultAsSuccess/__snapshots__/basic.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`basic > --default-as-success 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/spec/defaultResponse/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/defaultResponse/__snapshots__/basic.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`basic > --default-response 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/spec/deprecated/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/deprecated/__snapshots__/basic.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`basic > @deprecated 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/spec/discriminator/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/discriminator/__snapshots__/basic.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`basic > discriminator 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/spec/dot-path-params/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/dot-path-params/__snapshots__/basic.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`basic > --dot-path-params 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/spec/enumNamesAsValues/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/enumNamesAsValues/__snapshots__/basic.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`basic > --enum-names-as-values 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/spec/enums-2.0/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/enums-2.0/__snapshots__/basic.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`basic > enums-2.0 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/spec/extractRequestBody/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/extractRequestBody/__snapshots__/basic.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`basic > --extract-request-body 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/spec/extractRequestParams/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/extractRequestParams/__snapshots__/basic.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`basic > --extract-request-params 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/spec/extractResponseBody/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/extractResponseBody/__snapshots__/basic.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`basic > --extract-response-body 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/spec/extractResponseError/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/extractResponseError/__snapshots__/basic.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`basic > --extract-response-body 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/spec/js/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/js/__snapshots__/basic.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`basic > --js --axios 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/spec/jsAxios/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/jsAxios/__snapshots__/basic.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`basic > --js 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/spec/moduleNameFirstTag/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/moduleNameFirstTag/__snapshots__/basic.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`basic > --module-name-first-tag 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/spec/moduleNameIndex/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/moduleNameIndex/__snapshots__/basic.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`basic > --module-name-index 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/spec/noClient/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/noClient/__snapshots__/basic.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`basic > --no-client 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/spec/nullable-2.0/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/nullable-2.0/__snapshots__/basic.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`basic > nullable-2.0 refs 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/spec/nullable-3.0/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/nullable-3.0/__snapshots__/basic.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`basic > nullable-3.0 refs 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/spec/object-types/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/object-types/__snapshots__/basic.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`basic > object-types 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/spec/on-insert-path-param/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/on-insert-path-param/__snapshots__/basic.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`basic > on-insert-path-param 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/spec/patch/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/patch/__snapshots__/basic.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`basic > --patch 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/spec/readonly/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/readonly/__snapshots__/basic.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`basic > readonly 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/spec/responses/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/responses/__snapshots__/basic.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`basic > responses 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/spec/routeTypes/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/routeTypes/__snapshots__/basic.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`basic > --route-types 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/spec/singleHttpClient/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/singleHttpClient/__snapshots__/basic.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`basic > --single-http-client 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/spec/sortTypes-false/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/sortTypes-false/__snapshots__/basic.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`basic > --sort-types=false 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/spec/sortTypes/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/sortTypes/__snapshots__/basic.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`basic > --sort-types 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/spec/specProperty/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/specProperty/__snapshots__/basic.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`basic > specProperty 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/spec/typeSuffixPrefix/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/typeSuffixPrefix/__snapshots__/basic.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`basic > --type-prefix and --type-suffix 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##

--- a/tests/spec/unionEnums/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/unionEnums/__snapshots__/basic.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`basic > --union-enums 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##


### PR DESCRIPTION
This is useful when the openapi contains unused variables.
Otherwise the TSC type checking crash on auto generated code...