### PR TITLE
Fix route param parsing when the param begins with just one letter (rebased original PR #686 by @ahoseinian)

### DIFF
--- a/.changeset/honest-bears-stay.md
+++ b/.changeset/honest-bears-stay.md
@@ -1,0 +1,5 @@
+---
+"swagger-typescript-api": patch
+---
+
+Fix query params detection on route name parsing

--- a/src/schema-routes/schema-routes.ts
+++ b/src/schema-routes/schema-routes.ts
@@ -97,7 +97,7 @@ export class SchemaRoutes {
 
     // TODO forbid leading symbols [\]^` in a major release (allowed yet for backwards compatibility)
     const pathParamMatches = (routeName || "").match(
-      /({[a-zA-Z_[\\\]^`]([-_.]*[a-zA-Z0-9])*})|(:[a-zA-Z_[\\\]^`]([-_.]*[a-zA-Z0-9])*:?)/g,
+      /({[\w[\\\]^`][-_.\w]*})|(:[\w[\\\]^`][-_.\w]*:?)/g,
     );
 
     // used in case when path parameters is not declared in requestInfo.parameters ("in": "path")

--- a/src/schema-routes/schema-routes.ts
+++ b/src/schema-routes/schema-routes.ts
@@ -96,7 +96,7 @@ export class SchemaRoutes {
       originalRouteName;
 
     const pathParamMatches = (routeName || "").match(
-      /({(([A-z]){1}([a-zA-Z0-9-_.]-?_?\.?)+)([0-9]+)?})|(:(([A-z]){1}([a-zA-Z0-9-_.]-?_?\.?)+)([0-9]+)?:?)/g,
+      /({[a-zA-Z]([a-zA-Z0-9-_.])*})|(:[a-zA-Z]([-_.]?[a-zA-Z0-9-_.])*:?)/g,
     );
 
     // used in case when path parameters is not declared in requestInfo.parameters ("in": "path")

--- a/src/schema-routes/schema-routes.ts
+++ b/src/schema-routes/schema-routes.ts
@@ -96,7 +96,7 @@ export class SchemaRoutes {
       originalRouteName;
 
     const pathParamMatches = (routeName || "").match(
-      /({(([A-z]){1}([a-zA-Z0-9]-?_?\.?)+)([0-9]+)?})|(:(([A-z]){1}([a-zA-Z0-9]-?_?\.?)+)([0-9]+)?:?)/g,
+      /({(([A-z]){1}([a-zA-Z0-9-_.]-?_?\.?)+)([0-9]+)?})|(:(([A-z]){1}([a-zA-Z0-9-_.]-?_?\.?)+)([0-9]+)?:?)/g,
     );
 
     // used in case when path parameters is not declared in requestInfo.parameters ("in": "path")

--- a/src/schema-routes/schema-routes.ts
+++ b/src/schema-routes/schema-routes.ts
@@ -96,7 +96,7 @@ export class SchemaRoutes {
       originalRouteName;
 
     const pathParamMatches = (routeName || "").match(
-      /({[a-zA-Z]([a-zA-Z0-9-_.])*})|(:[a-zA-Z]([-_.]?[a-zA-Z0-9-_.])*:?)/g,
+      /({[a-zA-Z]([-_.]*[a-zA-Z0-9])*})|(:[a-zA-Z]([-_.]*[a-zA-Z0-9])*:?)/g,
     );
 
     // used in case when path parameters is not declared in requestInfo.parameters ("in": "path")

--- a/src/schema-routes/schema-routes.ts
+++ b/src/schema-routes/schema-routes.ts
@@ -95,8 +95,9 @@ export class SchemaRoutes {
       this.config.hooks.onPreBuildRoutePath(originalRouteName) ||
       originalRouteName;
 
+    // TODO forbid leading symbols [\]^` in a major release (allowed yet for backwards compatibility)
     const pathParamMatches = (routeName || "").match(
-      /({[a-zA-Z]([-_.]*[a-zA-Z0-9])*})|(:[a-zA-Z]([-_.]*[a-zA-Z0-9])*:?)/g,
+      /({[a-zA-Z_[\\\]^`]([-_.]*[a-zA-Z0-9])*})|(:[a-zA-Z_[\\\]^`]([-_.]*[a-zA-Z0-9])*:?)/g,
     );
 
     // used in case when path parameters is not declared in requestInfo.parameters ("in": "path")

--- a/tests/spec/defaultAsSuccess/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/defaultAsSuccess/__snapshots__/basic.test.ts.snap
@@ -466,6 +466,27 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         format: "json",
         ...params,
       }),
+
+    /**
+     * @description Get public details of an Authentiq ID.
+     *
+     * @tags key, get
+     * @name UnderlinesDetail
+     * @request GET:/i_key/underlines/{i__UK}
+     */
+    underlinesDetail: (iUk: string, params: RequestParams = {}) =>
+      this.request<
+        {
+          /** base64safe encoded public signing key */
+          sub?: string;
+        },
+        Error
+      >({
+        path: `/i_key/underlines/${iUk}`,
+        method: "GET",
+        format: "json",
+        ...params,
+      }),
   };
   login = {
     /**

--- a/tests/spec/defaultAsSuccess/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/defaultAsSuccess/__snapshots__/basic.test.ts.snap
@@ -442,52 +442,6 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         ...params,
       }),
   };
-  iKey = {
-    /**
-     * @description Get public details of an Authentiq ID.
-     *
-     * @tags key, get
-     * @name IKeyDetail
-     * @request GET:/i_key/{i_PK}
-     */
-    iKeyDetail: (iPk: string, params: RequestParams = {}) =>
-      this.request<
-        {
-          /** @format date-time */
-          since?: string;
-          status?: string;
-          /** base64safe encoded public signing key */
-          sub?: string;
-        },
-        Error
-      >({
-        path: `/i_key/${iPk}`,
-        method: "GET",
-        format: "json",
-        ...params,
-      }),
-
-    /**
-     * @description Get public details of an Authentiq ID.
-     *
-     * @tags key, get
-     * @name UnderlinesDetail
-     * @request GET:/i_key/underlines/{i__UK}
-     */
-    underlinesDetail: (iUk: string, params: RequestParams = {}) =>
-      this.request<
-        {
-          /** base64safe encoded public signing key */
-          sub?: string;
-        },
-        Error
-      >({
-        path: `/i_key/underlines/${iUk}`,
-        method: "GET",
-        format: "json",
-        ...params,
-      }),
-  };
   login = {
     /**
      * @description push sign-in request See: https://github.com/skion/authentiq/wiki/JWT-Examples

--- a/tests/spec/defaultAsSuccess/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/defaultAsSuccess/__snapshots__/basic.test.ts.snap
@@ -442,6 +442,31 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         ...params,
       }),
   };
+  iKey = {
+    /**
+     * @description Get public details of an Authentiq ID.
+     *
+     * @tags key, get
+     * @name IKeyDetail
+     * @request GET:/i_key/{i_PK}
+     */
+    iKeyDetail: (iPk: string, params: RequestParams = {}) =>
+      this.request<
+        {
+          /** @format date-time */
+          since?: string;
+          status?: string;
+          /** base64safe encoded public signing key */
+          sub?: string;
+        },
+        Error
+      >({
+        path: `/i_key/${iPk}`,
+        method: "GET",
+        format: "json",
+        ...params,
+      }),
+  };
   login = {
     /**
      * @description push sign-in request See: https://github.com/skion/authentiq/wiki/JWT-Examples

--- a/tests/spec/extractRequestParams/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/extractRequestParams/__snapshots__/basic.test.ts.snap
@@ -500,6 +500,27 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         format: "json",
         ...params,
       }),
+
+    /**
+     * @description Get public details of an Authentiq ID.
+     *
+     * @tags key, get
+     * @name UnderlinesDetail
+     * @request GET:/i_key/underlines/{i__UK}
+     */
+    underlinesDetail: (iUk: string, params: RequestParams = {}) =>
+      this.request<
+        {
+          /** base64safe encoded public signing key */
+          sub?: string;
+        },
+        Error
+      >({
+        path: `/i_key/underlines/${iUk}`,
+        method: "GET",
+        format: "json",
+        ...params,
+      }),
   };
   login = {
     /**

--- a/tests/spec/extractRequestParams/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/extractRequestParams/__snapshots__/basic.test.ts.snap
@@ -476,6 +476,31 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         ...params,
       }),
   };
+  iKey = {
+    /**
+     * @description Get public details of an Authentiq ID.
+     *
+     * @tags key, get
+     * @name IKeyDetail
+     * @request GET:/i_key/{i_PK}
+     */
+    iKeyDetail: (iPk: string, params: RequestParams = {}) =>
+      this.request<
+        {
+          /** @format date-time */
+          since?: string;
+          status?: string;
+          /** base64safe encoded public signing key */
+          sub?: string;
+        },
+        Error
+      >({
+        path: `/i_key/${iPk}`,
+        method: "GET",
+        format: "json",
+        ...params,
+      }),
+  };
   login = {
     /**
      * @description push sign-in request See: https://github.com/skion/authentiq/wiki/JWT-Examples

--- a/tests/spec/extractRequestParams/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/extractRequestParams/__snapshots__/basic.test.ts.snap
@@ -495,7 +495,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         },
         Error
       >({
-        path: `/i_key/${iPk}`,
+        path: \`/i_key/\${iPk}\`,
         method: "GET",
         format: "json",
         ...params,
@@ -516,7 +516,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         },
         Error
       >({
-        path: `/i_key/underlines/${iUk}`,
+        path: \`/i_key/underlines/\${iUk}\`,
         method: "GET",
         format: "json",
         ...params,

--- a/tests/spec/extractRequestParams/schema.json
+++ b/tests/spec/extractRequestParams/schema.json
@@ -56,6 +56,13 @@
       "required": true,
       "type": "string"
     },
+    "i_PK": {
+      "description": "Public Signing Key - Authentiq ID (43 chars)",
+      "in": "path",
+      "name": "i_PK",
+      "required": true,
+      "type": "string"
+    },
     "BarBaz": {
       "description": "bar baz",
       "in": "path",
@@ -422,6 +429,55 @@
           }
         },
         "tags": ["key", "put"]
+      }
+    },
+    "/i_key/{i_PK}": {
+      "get": {
+        "description": "Get public details of an Authentiq ID.\n",
+        "parameters": [
+          {
+            "$ref": "#/parameters/i_PK"
+          }
+        ],
+        "produces": ["application/json"],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved",
+            "schema": {
+              "properties": {
+                "since": {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                "status": {
+                  "type": "string"
+                },
+                "sub": {
+                  "description": "base64safe encoded public signing key",
+                  "type": "string"
+                }
+              },
+              "title": "JWT",
+              "type": "object"
+            }
+          },
+          "404": {
+            "description": "Unknown key `unknown-key`",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "410": {
+            "description": "Key is revoked (gone). `revoked-key`",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/ErrorResponse"
+          }
+        },
+        "tags": ["key", "get"]
       }
     },
     "/login": {

--- a/tests/spec/extractRequestParams/schema.json
+++ b/tests/spec/extractRequestParams/schema.json
@@ -56,6 +56,13 @@
       "required": true,
       "type": "string"
     },
+    "i__UK": {
+      "description": "Variable with double __ in it.",
+      "in": "path",
+      "name": "i__UK",
+      "required": true,
+      "type": "string"
+    },
     "i_PK": {
       "description": "Public Signing Key - Authentiq ID (43 chars)",
       "in": "path",
@@ -471,6 +478,36 @@
             "description": "Key is revoked (gone). `revoked-key`",
             "schema": {
               "$ref": "#/definitions/Error"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/ErrorResponse"
+          }
+        },
+        "tags": ["key", "get"]
+      }
+    },
+    "/i_key/underlines/{i__UK}": {
+      "get": {
+        "description": "Get public details of an Authentiq ID.\n",
+        "parameters": [
+          {
+            "$ref": "#/parameters/i__UK"
+          }
+        ],
+        "produces": ["application/json"],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved",
+            "schema": {
+              "properties": {
+                "sub": {
+                  "description": "base64safe encoded public signing key",
+                  "type": "string"
+                }
+              },
+              "title": "JWT",
+              "type": "object"
             }
           },
           "default": {


### PR DESCRIPTION
Fixes the way how query params are parsed when they consist of one letter or the first letter is followed by underscore.

Original #686 by @ahoseinian was needed to be rebased.

So I did it myself because of no activity there.