### PR TITLE
Fix default value for `no-client` argument in command configuration

### DIFF
--- a/.changeset/easy-paths-check.md
+++ b/.changeset/easy-paths-check.md
@@ -2,4 +2,4 @@
 "swagger-typescript-api": patch
 ---
 
-Fix generateClient logic to exclude only 'no-client' argument.
+Fix generateClient logic to exclude only `no-client` argument.

--- a/.changeset/five-moles-wonder.md
+++ b/.changeset/five-moles-wonder.md
@@ -1,0 +1,5 @@
+---
+"swagger-typescript-api": patch
+---
+
+Fix default value for `no-client` argument in command configuration.

--- a/index.ts
+++ b/index.ts
@@ -137,7 +137,7 @@ const generateCommand = defineCommand({
     "no-client": {
       type: "boolean",
       description: "do not generate an API class",
-      default: codeGenBaseConfig.generateClient,
+      default: !codeGenBaseConfig.generateClient,
     },
     "enum-names-as-values": {
       type: "boolean",


### PR DESCRIPTION
Fixes https://github.com/acacode/swagger-typescript-api/issues/1105
Fixes https://github.com/acacode/swagger-typescript-api/issues/1099