### PR TITLE
Fix default value for `no-client` option in `generateCommand` to `false`

### DIFF
--- a/.changeset/dark-memes-help.md
+++ b/.changeset/dark-memes-help.md
@@ -1,0 +1,5 @@
+---
+"swagger-typescript-api": patch
+---
+
+Fix default value for `no-client` option in `generateCommand` to `false`.

--- a/index.ts
+++ b/index.ts
@@ -138,7 +138,7 @@ const generateCommand = defineCommand({
     "no-client": {
       type: "boolean",
       description: "do not generate an API class",
-      default: !codeGenBaseConfig.generateClient,
+      default: false,
     },
     "enum-names-as-values": {
       type: "boolean",


### PR DESCRIPTION
Closes https://github.com/acacode/swagger-typescript-api/issues/1117