### PR TITLE
Fix to not use "no-" prefix in options

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Options:
   --union-enums                 generate all "enum" types as union types (T1 | T2 | TN) (default: false)
   --add-readonly                generate readonly properties (default: false)
   --route-types                 generate type definitions for API routes (default: false)
-  --no-client                   do not generate an API class
+  --[no-]client                 generate an API class (default: true)
   --enum-names-as-values        use values in 'x-enumNames' as enum values (not only as keys) (default: false)
   --extract-request-params      extract request params to data contract (Also combine path params and query params into one object) (default: false)
   --extract-request-body        extract request body type to data contract (default: false)

--- a/index.ts
+++ b/index.ts
@@ -135,10 +135,10 @@ const generateCommand = defineCommand({
       description: "generate type definitions for API routes",
       default: codeGenBaseConfig.generateRouteTypes,
     },
-    "no-client": {
+    "client": {
       type: "boolean",
-      description: "do not generate an API class",
-      default: false,
+      description: "generate an API class",
+      default: true,
     },
     "enum-names-as-values": {
       type: "boolean",
@@ -316,7 +316,7 @@ const generateCommand = defineCommand({
       extractResponseError: args["extract-response-error"],
       extractResponses: args["extract-responses"],
       fileName: args.name,
-      generateClient: !args["no-client"],
+      generateClient: args.client,
       generateResponses: args.responses,
       generateRouteTypes: args["route-types"],
       generateUnionEnums: args["union-enums"],


### PR DESCRIPTION
Fixes #1117

It seems an option with "no-" prefix will be treated as special case. https://github.com/unjs/citty/issues/176#issuecomment-2580742774

Note that some how option text in my local environment keep showing me '--no-client' even though I removed it from the code. I haven't dig deeper for this.

```
OPTIONS

      -p, --path (required)    path/url to swagger scheme                                                                                                                              
          -o, --output="./"    output path of typescript api file                                                                                                                      
...                                                                                                           
                --no-client    generate an API class # I don't know why but this shows "no-client" option instead of "client" in my local
...                       
              --sort-routes    sort routes in alphabetical order                                                                                                                       
            --custom-config    custom config: primitiveTypeConstructs, hooks, ...                                                                                                      
```