### PR TITLE
fix: Ensure enums are at the top of the components to avoid issue on recursive schema parsing

### DIFF
--- a/.changeset/mean-ghosts-post.md
+++ b/.changeset/mean-ghosts-post.md
@@ -1,0 +1,5 @@
+---
+"swagger-typescript-api": patch
+---
+
+Ensure enums are at the top of the components to avoid issue on recursive schema parsing

--- a/.changeset/mean-ghosts-post.md
+++ b/.changeset/mean-ghosts-post.md
@@ -2,4 +2,4 @@
 "swagger-typescript-api": patch
 ---
 
-Ensure enums are at the top of the components to avoid issue on recursive schema parsing
+Ensure enums are at the top of the components to avoid issue on recursive schema parsing.

--- a/src/code-gen-process.ts
+++ b/src/code-gen-process.ts
@@ -127,6 +127,8 @@ export class CodeGenProcess {
       }),
     );
 
+    this.schemaComponentsMap.enumsFirst();
+
     const componentsToParse: SchemaComponent[] =
       this.schemaComponentsMap.filter(
         lodash.compact([

--- a/src/schema-components-map.ts
+++ b/src/schema-components-map.ts
@@ -68,4 +68,13 @@ export class SchemaComponentsMap {
   get($ref: string) {
     return this._data.find((c) => c.$ref === $ref) || null;
   }
+
+  // Ensure enums are at the top of components list
+  enumsFirst() {
+    this._data.sort((a, b) => {
+      if (Object.keys(a.rawTypeData || {}).includes("enum")) return -1;
+      if (Object.keys(b.rawTypeData || {}).includes("enum")) return 1;
+      return 0;
+    });
+  }
 }

--- a/tests/spec/discriminator/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/discriminator/__snapshots__/basic.test.ts.snap
@@ -13,6 +13,18 @@ exports[`basic > discriminator 1`] = `
  * ---------------------------------------------------------------
  */
 
+export enum PetEnum {
+  Dog = "dog",
+  Lizard = "lizard",
+  Cat = "cat",
+}
+
+export enum BlockDTOEnum {
+  Csv = "csv",
+  File = "file",
+  Kek = "kek",
+}
+
 export type SimpleDiscriminator = SimpleObject | ComplexObject;
 
 export interface SimpleObject {
@@ -21,12 +33,6 @@ export interface SimpleObject {
 
 export interface ComplexObject {
   objectType: string;
-}
-
-export enum BlockDTOEnum {
-  Csv = "csv",
-  File = "file",
-  Kek = "kek",
 }
 
 export type BlockDTOWithEnum = BaseBlockDtoWithEnum &
@@ -92,12 +98,6 @@ export type Dog = BasePet & {
 export type Lizard = BasePet & {
   lovesRocks?: boolean;
 };
-
-export enum PetEnum {
-  Dog = "dog",
-  Lizard = "lizard",
-  Cat = "cat",
-}
 
 export type PetWithEnum = BasePetWithEnum &
   (

--- a/tests/spec/enumNotFirstInComponents/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/enumNotFirstInComponents/__snapshots__/basic.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`basic > --enum-names-as-values 1`] = `
+exports[`basic > enum not first in components 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
 // @ts-nocheck
@@ -13,197 +13,35 @@ exports[`basic > --enum-names-as-values 1`] = `
  * ---------------------------------------------------------------
  */
 
-export enum JobKind {
-  COMPANY = "COMPANY",
-  PERSONAL = "PERSONAL",
-  FREELANCE = "FREELANCE",
-  OPEN_SOURCE = "OPEN_SOURCE",
+export enum ExampleEnum {
+  Example1 = "Example1",
+  Example2 = "Example2",
 }
 
-export enum PetIdsWithWrongEnum {
-  Value10 = 10,
-  Value20 = 20,
-  Value30 = 30,
-  Value40 = 40,
+export interface DtoExample1 {
+  name: string;
+  age: number;
+  toto?: DtoExample2;
 }
 
-export enum PetIds {
-  Value10 = 10,
-  Value20 = 20,
-  Value30 = 30,
-  Value40 = 40,
-}
-
-/**
- * FooBar
- * @format int32
- */
-export enum IntEnumWithNames {
-  Unknown = "Unknown",
-  String = "String",
-  Int32 = "Int32",
-  Int64 = "Int64",
-  Double = "Double",
-  DateTime = "DateTime",
-  Test2 = "Test2",
-  Test23 = "Test23",
-  Tess44 = "Tess44",
-  BooFar = "BooFar",
-}
-
-export type TestAllOfDc = (FooBarBaz & FooBar) & {
-  prop?: string;
-};
-
-export type TestAllOfDc2 = FooBarBaz & {
-  prop?: string;
-};
-
-export type TestAnyOfDc = (FooBarBaz | FooBar) & {
-  prop?: string;
-};
-
-export type TestOneOfDc = (FooBarBaz | FooBar) & {
-  prop?: string;
-};
-
-/** Information about job */
-export interface FooBarBaz {
-  id?: string;
-  kind?: JobKind;
-  name?: string;
-  link?: string;
-}
-
-/** Information about job */
-export interface FooBar {
-  kind?: JobKind;
-}
-
-/** Information about job */
-export interface FooBaz {
-  name?: string;
-  link?: string;
-}
-
-/** From T, pick a set of properties whose keys are in the union K */
-export interface PickUserTypeExcludeKeysIdOrId {
-  username: string;
-  password: string;
-}
-
-export type OmitUserTypeIdOrId = PickUserTypeExcludeKeysIdOrId;
-
-export type OmitIdUserType = OmitUserTypeIdOrId;
-
-export type AuthUserType = OmitIdUserType;
-
-/** Information about job */
-export interface JobType {
-  id: string;
-  kind: JobKind;
-  name?: string;
-  link?: string;
-  /**
-   * Exist only in open source jobs
-   * Format: \`\${username}/\${projectName}\`
-   */
-  github?: string;
-  /**
-   * Exist only in open source jobs
-   * Format: \`\${orgname}/\${projectName}\`
-   */
-  npm?: string;
-  /**
-   * Exist only in open source jobs
-   * Means project is dev. tool (like swagger code generator)
-   */
-  isTool?: boolean;
-  /** web site address */
-  address?: string;
-}
-
-/** From T, pick a set of properties whose keys are in the union K */
-export interface PickJobTypeExcludeKeysIdOrId {
-  kind: JobKind;
-  name?: string;
-  link?: string;
-  /**
-   * Exist only in open source jobs
-   * Format: \`\${username}/\${projectName}\`
-   */
-  github?: string;
-  /**
-   * Exist only in open source jobs
-   * Format: \`\${orgname}/\${projectName}\`
-   */
-  npm?: string;
-  /**
-   * Exist only in open source jobs
-   * Means project is dev. tool (like swagger code generator)
-   */
-  isTool?: boolean;
-  /** web site address */
-  address?: string;
-}
-
-export type OmitJobTypeIdOrId = PickJobTypeExcludeKeysIdOrId;
-
-export type OmitIdJobType = OmitJobTypeIdOrId;
-
-export type JobUpdateType = OmitIdJobType;
-
-/** From T, pick a set of properties whose keys are in the union K */
-export interface PickProjectTypeExcludeKeysJob {
-  id: string;
-  name?: string;
-  /** @format double */
-  year: number;
+export interface DtoExample2 {
+  title: string;
   description: string;
-  notImportant?: boolean;
-  prefix?: string;
-  tags: string[];
-  teamSize: string;
 }
 
-export type OmitProjectTypeJob = PickProjectTypeExcludeKeysJob;
+export type ExampleObject = BaseExampleObject &
+  (
+    | BaseExampleObjectTypeMapping<ExampleEnum.Example1, DtoExample1>
+    | BaseExampleObjectTypeMapping<ExampleEnum.Example2, DtoExample2>
+  );
 
-export type ExtractedProjectType = OmitProjectTypeJob & {
-  /** Information about job */
-  job: JobType;
-};
-
-/** From T, pick a set of properties whose keys are in the union K */
-export interface PickProjectTypeExcludeKeysIdOrId {
-  name?: string;
-  job: string;
-  /** @format double */
-  year: number;
-  description: string;
-  notImportant?: boolean;
-  prefix?: string;
-  tags: string[];
-  teamSize: string;
+interface BaseExampleObject {
+  type?: ExampleEnum;
 }
 
-export type OmitProjectTypeIdOrId = PickProjectTypeExcludeKeysIdOrId;
-
-export type OmitIdProjectType = OmitProjectTypeIdOrId;
-
-export type ProjectUpdateType = OmitIdProjectType;
-
-export interface ProjectType {
-  id: string;
-  /** @format double */
-  year: number;
-  description: string;
-  job: string;
-  name?: string;
-  notImportant?: boolean;
-  prefix?: string;
-  tags: string[];
-  teamSize: string;
-}
+type BaseExampleObjectTypeMapping<Key, Type> = {
+  type: Key;
+} & Type;
 
 export type QueryParamsType = Record<string | number, any>;
 export type ResponseFormat = keyof Omit<Body, "body" | "bodyUsed">;
@@ -450,206 +288,27 @@ export class HttpClient<SecurityDataType = unknown> {
 }
 
 /**
- * @title No title
+ * @title example-service
+ * @version 0.0.1
  * @baseUrl http://localhost:8080/api/v1
+ *
+ * API definition for example service
  */
 export class Api<
   SecurityDataType extends unknown,
 > extends HttpClient<SecurityDataType> {
-  auth = {
+  api = {
     /**
      * No description
      *
-     * @tags Auth
-     * @name Login
-     * @request POST:/auth
+     * @tags test-api
+     * @name GetExample
+     * @request GET:/api/example
      */
-    login: (data: AuthUserType, params: RequestParams = {}) =>
-      this.request<string, any>({
-        path: \`/auth\`,
-        method: "POST",
-        body: data,
-        type: ContentType.Json,
-        format: "json",
-        ...params,
-      }),
-
-    /**
-     * No description
-     *
-     * @tags Auth
-     * @name Refresh
-     * @request POST:/auth/refresh
-     * @secure
-     */
-    refresh: (params: RequestParams = {}) =>
-      this.request<string, any>({
-        path: \`/auth/refresh\`,
-        method: "POST",
-        secure: true,
-        format: "json",
-        ...params,
-      }),
-  };
-  jobs = {
-    /**
-     * No description
-     *
-     * @tags Jobs
-     * @name GetJobs
-     * @request GET:/jobs
-     * @secure
-     */
-    getJobs: (params: RequestParams = {}) =>
-      this.request<JobType[], any>({
-        path: \`/jobs\`,
+    getExample: (params: RequestParams = {}) =>
+      this.request<ExampleObject, any>({
+        path: \`/api/example\`,
         method: "GET",
-        secure: true,
-        format: "json",
-        ...params,
-      }),
-
-    /**
-     * No description
-     *
-     * @tags Jobs
-     * @name AddJob
-     * @request POST:/jobs
-     * @secure
-     */
-    addJob: (data: JobUpdateType, params: RequestParams = {}) =>
-      this.request<string, any>({
-        path: \`/jobs\`,
-        method: "POST",
-        body: data,
-        secure: true,
-        type: ContentType.Json,
-        format: "json",
-        ...params,
-      }),
-
-    /**
-     * No description
-     *
-     * @tags Jobs
-     * @name GetJob
-     * @request GET:/jobs/{id}
-     * @secure
-     */
-    getJob: (id: string, params: RequestParams = {}) =>
-      this.request<JobType, void>({
-        path: \`/jobs/\${id}\`,
-        method: "GET",
-        secure: true,
-        format: "json",
-        ...params,
-      }),
-
-    /**
-     * No description
-     *
-     * @tags Jobs
-     * @name UpdateJob
-     * @request PATCH:/jobs/{id}
-     * @secure
-     */
-    updateJob: (id: string, data: JobUpdateType, params: RequestParams = {}) =>
-      this.request<JobType, any>({
-        path: \`/jobs/\${id}\`,
-        method: "PATCH",
-        body: data,
-        secure: true,
-        type: ContentType.Json,
-        format: "json",
-        ...params,
-      }),
-
-    /**
-     * No description
-     *
-     * @tags Jobs
-     * @name DeleteJob
-     * @request DELETE:/jobs/{id}
-     * @secure
-     */
-    deleteJob: (id: string, params: RequestParams = {}) =>
-      this.request<void, any>({
-        path: \`/jobs/\${id}\`,
-        method: "DELETE",
-        secure: true,
-        format: "json",
-        ...params,
-      }),
-  };
-  projects = {
-    /**
-     * No description
-     *
-     * @tags Projects
-     * @name GetProjects
-     * @request GET:/projects
-     */
-    getProjects: (params: RequestParams = {}) =>
-      this.request<ExtractedProjectType[], any>({
-        path: \`/projects\`,
-        method: "GET",
-        format: "json",
-        ...params,
-      }),
-
-    /**
-     * No description
-     *
-     * @tags Projects
-     * @name AddProjects
-     * @request POST:/projects
-     * @secure
-     */
-    addProjects: (data: ProjectUpdateType, params: RequestParams = {}) =>
-      this.request<string, any>({
-        path: \`/projects\`,
-        method: "POST",
-        body: data,
-        secure: true,
-        type: ContentType.Json,
-        format: "json",
-        ...params,
-      }),
-
-    /**
-     * No description
-     *
-     * @tags Projects
-     * @name UpdateProject
-     * @request PATCH:/projects/{id}
-     * @secure
-     */
-    updateProject: (
-      id: string,
-      data: ProjectUpdateType,
-      params: RequestParams = {},
-    ) =>
-      this.request<ProjectType, any>({
-        path: \`/projects/\${id}\`,
-        method: "PATCH",
-        body: data,
-        secure: true,
-        type: ContentType.Json,
-        format: "json",
-        ...params,
-      }),
-
-    /**
-     * No description
-     *
-     * @tags Projects
-     * @name DeleteProject
-     * @request DELETE:/projects/{id}
-     */
-    deleteProject: (id: string, params: RequestParams = {}) =>
-      this.request<void, any>({
-        path: \`/projects/\${id}\`,
-        method: "DELETE",
         format: "json",
         ...params,
       }),

--- a/tests/spec/enumNotFirstInComponents/basic.test.ts
+++ b/tests/spec/enumNotFirstInComponents/basic.test.ts
@@ -1,0 +1,35 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+
+import { generateApi } from "../../../src/index.js";
+
+describe("basic", async () => {
+  let tmpdir = "";
+
+  beforeAll(async () => {
+    tmpdir = await fs.mkdtemp(path.join(os.tmpdir(), "swagger-typescript-api"));
+  });
+
+  afterAll(async () => {
+    await fs.rm(tmpdir, { recursive: true });
+  });
+
+  test("enum not first in components", async () => {
+    await generateApi({
+      fileName: "schema",
+      input: path.resolve(import.meta.dirname, "schema.json"),
+      output: tmpdir,
+      silent: true,
+      enumNamesAsValues: true,
+    });
+
+    const content = await fs.readFile(path.join(tmpdir, "schema.ts"), {
+      encoding: "utf8",
+    });
+
+    expect(content).toMatchSnapshot();
+  });
+});

--- a/tests/spec/enumNotFirstInComponents/schema.json
+++ b/tests/spec/enumNotFirstInComponents/schema.json
@@ -1,0 +1,83 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "description": "API definition for example service",
+    "version": "0.0.1",
+    "title": "example-service"
+  },
+  "paths": {
+    "/api/example": {
+      "get": {
+        "operationId": "getExample",
+        "tags": ["test-api"],
+        "responses": {
+          "200": {
+            "description": "Return example",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExampleObject"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "examples": {},
+    "headers": {},
+    "parameters": {},
+    "requestBodies": {},
+    "responses": {},
+    "schemas": {
+      "DtoExample1": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "age": {
+            "type": "integer"
+          },
+          "toto": {
+            "$ref": "#/components/schemas/DtoExample2"
+          }
+        },
+        "required": ["name", "age"]
+      },
+      "DtoExample2": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "required": ["title", "description"]
+      },
+      "ExampleObject": {
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/ExampleEnum"
+          }
+        },
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "Example1": "#/components/schemas/DtoExample1",
+            "Example2": "#/components/schemas/DtoExample2"
+          }
+        }
+      },
+      "ExampleEnum": {
+        "type": "string",
+        "enum": ["Example1", "Example2"]
+      }
+    }
+  },
+  "servers": [{ "url": "http://localhost:8080/api/v1" }]
+}

--- a/tests/spec/enums-2.0/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/enums-2.0/__snapshots__/basic.test.ts.snap
@@ -13,67 +13,6 @@ exports[`basic > enums-2.0 1`] = `
  * ---------------------------------------------------------------
  */
 
-export interface ObjWithEnum {
-  "prop-enum-nullable"?: 0 | 1 | 2 | 3 | 4 | 5 | null;
-  "prop-enum"?: 0 | 1 | 2 | 3 | 4 | 5;
-}
-
-export enum XNullableEnum {
-  Value0 = 0,
-  Value1 = 1,
-  Value2 = 2,
-  Value3 = 3,
-  Value4 = 4,
-  Value5 = 5,
-}
-
-export enum SimpleEnumNonNullable {
-  Value0 = 0,
-  Value1 = 1,
-  Value2 = 2,
-  Value3 = 3,
-  Value4 = 4,
-  Value5 = 5,
-}
-
-export enum OnlyEnumNames {
-  Bla = "Bla",
-  Blabla = "Blabla",
-  Boiler = "Boiler",
-}
-
-export enum StringOnlyEnumNames {
-  Bla = "Bla",
-  Blabla = "Blabla",
-  Boiler = "Boiler",
-}
-
-export enum StringEnums {
-  Bla = "foo",
-  Blabla = "bar",
-  Boiler = "Boiler",
-}
-
-export enum StringCompleteEnums {
-  Bla = "foo",
-  Blabla = "bar",
-  Boiler = "baz",
-}
-
-/** @format int32 */
-export enum EmptyEnum {
-  Bla = "Bla",
-  Blabla = "Blabla",
-  Boiler = "Boiler",
-}
-
-/** @format int32 */
-export enum EnumWithMoreNames {
-  Bla = 1,
-  Blabla = "Blabla",
-  Boiler = "Boiler",
-}
-
 /** @format int32 */
 export enum SomeInterestEnum {
   Bla = 6,
@@ -93,6 +32,67 @@ export enum SomeInterestEnum {
   ASdsdsa = "ASdsdsa",
   ASDds = "ASDds",
   HSDFDS = "HSDFDS",
+}
+
+/** @format int32 */
+export enum EnumWithMoreNames {
+  Bla = 1,
+  Blabla = "Blabla",
+  Boiler = "Boiler",
+}
+
+export enum StringCompleteEnums {
+  Bla = "foo",
+  Blabla = "bar",
+  Boiler = "baz",
+}
+
+export enum StringEnums {
+  Bla = "foo",
+  Blabla = "bar",
+  Boiler = "Boiler",
+}
+
+export enum SimpleEnumNonNullable {
+  Value0 = 0,
+  Value1 = 1,
+  Value2 = 2,
+  Value3 = 3,
+  Value4 = 4,
+  Value5 = 5,
+}
+
+export enum XNullableEnum {
+  Value0 = 0,
+  Value1 = 1,
+  Value2 = 2,
+  Value3 = 3,
+  Value4 = 4,
+  Value5 = 5,
+}
+
+export interface ObjWithEnum {
+  "prop-enum-nullable"?: 0 | 1 | 2 | 3 | 4 | 5 | null;
+  "prop-enum"?: 0 | 1 | 2 | 3 | 4 | 5;
+}
+
+export enum OnlyEnumNames {
+  Bla = "Bla",
+  Blabla = "Blabla",
+  Boiler = "Boiler",
+}
+
+export enum StringOnlyEnumNames {
+  Bla = "Bla",
+  Blabla = "Blabla",
+  Boiler = "Boiler",
+}
+
+/** @format int32 */
+export enum EmptyEnum {
+  Bla = "Bla",
+  Blabla = "Blabla",
+  Boiler = "Boiler",
 }
 
 export interface PostFooPayload {

--- a/tests/spec/extractRequestBody/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/extractRequestBody/__snapshots__/basic.test.ts.snap
@@ -13,6 +13,27 @@ exports[`basic > --extract-request-body 1`] = `
  * ---------------------------------------------------------------
  */
 
+export enum PetIdsWithWrongEnumTTT {
+  Value10 = 10,
+  Value20 = 20,
+  Value30 = 30,
+  Value40 = 40,
+}
+
+export enum PetIdsTTT {
+  Value10 = 10,
+  Value20 = 20,
+  Value30 = 30,
+  Value40 = 40,
+}
+
+export enum PetNamesTTT {
+  FluffyHero = "Fluffy Hero",
+  PiggyPo = "Piggy Po",
+  SwaggerTypescriptApi = "Swagger Typescript Api",
+  UPPER_CASE = "UPPER_CASE",
+}
+
 /**
  * Pet Order
  * An order for a pets from the pet store
@@ -74,27 +95,6 @@ export interface TagTTT {
   /** @format int64 */
   id?: number;
   name?: string;
-}
-
-export enum PetNamesTTT {
-  FluffyHero = "Fluffy Hero",
-  PiggyPo = "Piggy Po",
-  SwaggerTypescriptApi = "Swagger Typescript Api",
-  UPPER_CASE = "UPPER_CASE",
-}
-
-export enum PetIdsTTT {
-  Value10 = 10,
-  Value20 = 20,
-  Value30 = 30,
-  Value40 = 40,
-}
-
-export enum PetIdsWithWrongEnumTTT {
-  Value10 = 10,
-  Value20 = 20,
-  Value30 = 30,
-  Value40 = 40,
 }
 
 /**

--- a/tests/spec/extractResponseBody/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/extractResponseBody/__snapshots__/basic.test.ts.snap
@@ -13,6 +13,27 @@ exports[`basic > --extract-response-body 1`] = `
  * ---------------------------------------------------------------
  */
 
+export enum PetIdsWithWrongEnumTTT {
+  Value10 = 10,
+  Value20 = 20,
+  Value30 = 30,
+  Value40 = 40,
+}
+
+export enum PetIdsTTT {
+  Value10 = 10,
+  Value20 = 20,
+  Value30 = 30,
+  Value40 = 40,
+}
+
+export enum PetNamesTTT {
+  FluffyHero = "Fluffy Hero",
+  PiggyPo = "Piggy Po",
+  SwaggerTypescriptApi = "Swagger Typescript Api",
+  UPPER_CASE = "UPPER_CASE",
+}
+
 /**
  * Pet Order
  * An order for a pets from the pet store
@@ -74,27 +95,6 @@ export interface TagTTT {
   /** @format int64 */
   id?: number;
   name?: string;
-}
-
-export enum PetNamesTTT {
-  FluffyHero = "Fluffy Hero",
-  PiggyPo = "Piggy Po",
-  SwaggerTypescriptApi = "Swagger Typescript Api",
-  UPPER_CASE = "UPPER_CASE",
-}
-
-export enum PetIdsTTT {
-  Value10 = 10,
-  Value20 = 20,
-  Value30 = 30,
-  Value40 = 40,
-}
-
-export enum PetIdsWithWrongEnumTTT {
-  Value10 = 10,
-  Value20 = 20,
-  Value30 = 30,
-  Value40 = 40,
 }
 
 /**

--- a/tests/spec/extractResponseError/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/extractResponseError/__snapshots__/basic.test.ts.snap
@@ -13,6 +13,27 @@ exports[`basic > --extract-response-body 1`] = `
  * ---------------------------------------------------------------
  */
 
+export enum PetIdsWithWrongEnumTTT {
+  Value10 = 10,
+  Value20 = 20,
+  Value30 = 30,
+  Value40 = 40,
+}
+
+export enum PetIdsTTT {
+  Value10 = 10,
+  Value20 = 20,
+  Value30 = 30,
+  Value40 = 40,
+}
+
+export enum PetNamesTTT {
+  FluffyHero = "Fluffy Hero",
+  PiggyPo = "Piggy Po",
+  SwaggerTypescriptApi = "Swagger Typescript Api",
+  UPPER_CASE = "UPPER_CASE",
+}
+
 /**
  * Pet Order
  * An order for a pets from the pet store
@@ -74,27 +95,6 @@ export interface TagTTT {
   /** @format int64 */
   id?: number;
   name?: string;
-}
-
-export enum PetNamesTTT {
-  FluffyHero = "Fluffy Hero",
-  PiggyPo = "Piggy Po",
-  SwaggerTypescriptApi = "Swagger Typescript Api",
-  UPPER_CASE = "UPPER_CASE",
-}
-
-export enum PetIdsTTT {
-  Value10 = 10,
-  Value20 = 20,
-  Value30 = 30,
-  Value40 = 40,
-}
-
-export enum PetIdsWithWrongEnumTTT {
-  Value10 = 10,
-  Value20 = 20,
-  Value30 = 30,
-  Value40 = 40,
 }
 
 /**

--- a/tests/spec/moduleNameFirstTag/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/moduleNameFirstTag/__snapshots__/basic.test.ts.snap
@@ -13,6 +13,19 @@ exports[`basic > --module-name-first-tag 1`] = `
  * ---------------------------------------------------------------
  */
 
+export enum PetIds {
+  Value10 = 10,
+  Value20 = 20,
+  Value30 = 30,
+  Value40 = 40,
+}
+
+export enum PetNames {
+  FluffyHero = "Fluffy Hero",
+  PiggyPo = "Piggy Po",
+  SwaggerTypescriptApi = "Swagger Typescript Api",
+}
+
 /**
  * Pet Order
  * An order for a pets from the pet store
@@ -74,19 +87,6 @@ export interface Tag {
   /** @format int64 */
   id?: number;
   name?: string;
-}
-
-export enum PetNames {
-  FluffyHero = "Fluffy Hero",
-  PiggyPo = "Piggy Po",
-  SwaggerTypescriptApi = "Swagger Typescript Api",
-}
-
-export enum PetIds {
-  Value10 = 10,
-  Value20 = 20,
-  Value30 = 30,
-  Value40 = 40,
 }
 
 /**

--- a/tests/spec/moduleNameIndex/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/moduleNameIndex/__snapshots__/basic.test.ts.snap
@@ -13,6 +13,19 @@ exports[`basic > --module-name-index 1`] = `
  * ---------------------------------------------------------------
  */
 
+export enum PetIds {
+  Value10 = 10,
+  Value20 = 20,
+  Value30 = 30,
+  Value40 = 40,
+}
+
+export enum PetNames {
+  FluffyHero = "Fluffy Hero",
+  PiggyPo = "Piggy Po",
+  SwaggerTypescriptApi = "Swagger Typescript Api",
+}
+
 /**
  * Pet Order
  * An order for a pets from the pet store
@@ -74,19 +87,6 @@ export interface Tag {
   /** @format int64 */
   id?: number;
   name?: string;
-}
-
-export enum PetNames {
-  FluffyHero = "Fluffy Hero",
-  PiggyPo = "Piggy Po",
-  SwaggerTypescriptApi = "Swagger Typescript Api",
-}
-
-export enum PetIds {
-  Value10 = 10,
-  Value20 = 20,
-  Value30 = 30,
-  Value40 = 40,
 }
 
 /**

--- a/tests/spec/unionEnums/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/unionEnums/__snapshots__/basic.test.ts.snap
@@ -13,17 +13,17 @@ exports[`basic > --generate-union-enums 1`] = `
  * ---------------------------------------------------------------
  */
 
-export type StringEnum = "String1" | "String2" | "String3" | "String4";
-
-export type NumberEnum = 1 | 2 | 3 | 4;
-
-export type BooleanEnum = true | false;
-
 /**
  * FooBar
  * @format int32
  */
 export type IntEnumWithNames = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
+
+export type BooleanEnum = true | false;
+
+export type NumberEnum = 1 | 2 | 3 | 4;
+
+export type StringEnum = "String1" | "String2" | "String3" | "String4";
 
 export type QueryParamsType = Record<string | number, any>;
 export type ResponseFormat = keyof Omit<Body, "body" | "bodyUsed">;


### PR DESCRIPTION
The schema parser is recursive. When we parse the discriminators if the enums aren't yet parsed so they aren't used.

We have to be sure enums are at the top of the components list to ensure there are parsed before other components.

This fix #699.