### PR TITLE
Support v3.1 typed arrays

### DIFF
--- a/src/schema-parser/base-schema-parsers/object.ts
+++ b/src/schema-parser/base-schema-parsers/object.ts
@@ -36,6 +36,17 @@ export class ObjectSchemaParser extends MonoSchemaParser {
         "rawTypeData",
         {},
       );
+      // In OpenAPI v3.1 the nullable property was replaced with a "typed
+      // array", that is an array that can either be of type T or null.
+      if (Array.isArray(property.type) && property.type.length == 2) {
+        if (property.type[0] == "null") {
+          property.type = property.type[1];
+          property.nullable = true;
+        } else if (property.type[1] == "null") {
+          property.type = property.type[0];
+          property.nullable = true;
+        }
+      }
       const nullable = !!(rawTypeData.nullable || property.nullable);
       const fieldName = this.typeNameFormatter.isValidName(name)
         ? name


### PR DESCRIPTION
In OpenAPI v3.1 the nullable property was replaced with a "typed array", that is an array that can either be of type T or null.

To make the minimal amount of changes this commit converts a type array back into what a 3.0 parser would expect.

Closes #991