### PR TITLE
fix_CannotFindModule

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,9 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noPropertyAccessFromIndexSignature": false,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
   },
   "exclude": ["dist"]
 }


### PR DESCRIPTION
### **Many `Cannot find module` errors**

You're getting a *wall of TS2307* errors like:

```
TS2307: Cannot find module './configuration.js'
```

These happen because the package is trying to import JS files (`*.js`), but:
- TypeScript can't resolve them because the typings (`*.d.ts`) are missing,
- or you're using a **hybrid ESM/NodeNext setup** that needs special handling.

This is also happening in:
- `vite`
- `emoji-mart`
- `swagger-typescript-api`

---

### 🔧 Fix Suggestions

#### ✅ A. Add this to `tsconfig.json`
Update your `compilerOptions` with these two flags:

```json
"compilerOptions": {
  ...
  "allowSyntheticDefaultImports": true,
  "esModuleInterop": true,
  ...
}
```

This will fix errors like:
```
TS1259: Module 'lodash' can only be default-imported using the 'esModuleInterop' flag
```
