### PR TITLE
Search `swagger-typescript-api.config` instead of `config` by default

### DIFF
--- a/.changeset/spicy-cougars-travel.md
+++ b/.changeset/spicy-cougars-travel.md
@@ -1,0 +1,5 @@
+---
+"swagger-typescript-api": patch
+---
+
+Search `swagger-typescript-api.config` instead of `config` by default.

--- a/index.ts
+++ b/index.ts
@@ -288,6 +288,7 @@ const generateCommand = defineCommand({
   },
   run: async ({ args }) => {
     const customConfig = await loadConfig<GenerateApiParams>({
+      name: "swagger-typescript-api",
       configFile: args["custom-config"],
     });
 


### PR DESCRIPTION
Closes https://github.com/acacode/swagger-typescript-api/issues/1181