### PR TITLE
bugfix: Use merged request params to get request content-type

### DIFF
--- a/templates/base/http-clients/fetch-http-client.ejs
+++ b/templates/base/http-clients/fetch-http-client.ejs
@@ -183,7 +183,7 @@ export class HttpClient<SecurityDataType = unknown> {
             ...requestParams,
             headers: {
             ...(requestParams.headers || {}),
-            ...(type && type !== ContentType.FormData ? { "Content-Type": type } : {}),
+            ...(requestParams.type && requestParams.type !== ContentType.FormData ? { "Content-Type": requestParams.type } : {}),
             },
             signal: (cancelToken ? this.createAbortSignal(cancelToken) : requestParams.signal) || null,
             body: typeof body === "undefined" || body === null ? null : payloadFormatter(body),

--- a/tests/__snapshots__/extended.test.ts.snap
+++ b/tests/__snapshots__/extended.test.ts.snap
@@ -2551,8 +2551,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -4565,8 +4565,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -4836,8 +4836,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -5142,8 +5142,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -6087,8 +6087,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -6872,8 +6872,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -7221,8 +7221,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -7528,8 +7528,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -7883,8 +7883,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -8685,8 +8685,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -9271,8 +9271,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -9577,8 +9577,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -9925,8 +9925,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -10268,8 +10268,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -10632,8 +10632,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -10968,8 +10968,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -46513,8 +46513,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -62199,8 +62199,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -63216,8 +63216,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -63834,8 +63834,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -64218,8 +64218,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -64521,8 +64521,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -64872,8 +64872,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -65555,8 +65555,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -66118,8 +66118,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -66528,8 +66528,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -66963,8 +66963,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -67452,8 +67452,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -67828,8 +67828,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -68241,8 +68241,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -69093,8 +69093,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -69853,8 +69853,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -70231,8 +70231,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -70533,8 +70533,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -70818,8 +70818,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -71141,8 +71141,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -71849,8 +71849,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -72723,8 +72723,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -74474,8 +74474,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -75200,8 +75200,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -75542,8 +75542,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -75963,8 +75963,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:

--- a/tests/__snapshots__/simple.test.ts.snap
+++ b/tests/__snapshots__/simple.test.ts.snap
@@ -370,8 +370,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -2711,8 +2711,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -2982,8 +2982,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -3262,8 +3262,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -3679,8 +3679,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -4439,8 +4439,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -4770,8 +4770,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -5057,8 +5057,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -5356,8 +5356,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -5729,8 +5729,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -6373,8 +6373,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -6677,8 +6677,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -7025,8 +7025,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -7329,8 +7329,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -7647,8 +7647,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -7963,8 +7963,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -16924,8 +16924,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -38050,8 +38050,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -38615,8 +38615,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -39291,8 +39291,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -39679,8 +39679,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -39956,8 +39956,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -40240,8 +40240,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -40725,8 +40725,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -41212,8 +41212,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -41555,8 +41555,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -41899,8 +41899,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -42279,8 +42279,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -42649,8 +42649,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -42962,8 +42962,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -43367,8 +43367,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -44048,8 +44048,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -44393,8 +44393,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -44702,8 +44702,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -44968,8 +44968,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -45259,8 +45259,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -45673,8 +45673,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -46313,8 +46313,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -47489,8 +47489,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -48271,8 +48271,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -48625,8 +48625,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:
@@ -48916,8 +48916,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:

--- a/tests/spec/another-query-params/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/another-query-params/__snapshots__/basic.test.ts.snap
@@ -241,8 +241,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:

--- a/tests/spec/custom-extensions/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/custom-extensions/__snapshots__/basic.test.ts.snap
@@ -213,8 +213,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:

--- a/tests/spec/defaultAsSuccess/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/defaultAsSuccess/__snapshots__/basic.test.ts.snap
@@ -253,8 +253,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:

--- a/tests/spec/defaultResponse/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/defaultResponse/__snapshots__/basic.test.ts.snap
@@ -213,8 +213,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:

--- a/tests/spec/deprecated/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/deprecated/__snapshots__/basic.test.ts.snap
@@ -213,8 +213,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:

--- a/tests/spec/dot-path-params/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/dot-path-params/__snapshots__/basic.test.ts.snap
@@ -215,8 +215,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:

--- a/tests/spec/enumNamesAsValues/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/enumNamesAsValues/__snapshots__/basic.test.ts.snap
@@ -405,8 +405,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:

--- a/tests/spec/enumNotFirstInComponents/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/enumNotFirstInComponents/__snapshots__/basic.test.ts.snap
@@ -243,8 +243,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:

--- a/tests/spec/extractRequestBody/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/extractRequestBody/__snapshots__/basic.test.ts.snap
@@ -382,8 +382,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:

--- a/tests/spec/extractRequestParams/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/extractRequestParams/__snapshots__/basic.test.ts.snap
@@ -288,8 +288,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:

--- a/tests/spec/extractResponseBody/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/extractResponseBody/__snapshots__/basic.test.ts.snap
@@ -368,8 +368,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:

--- a/tests/spec/extractResponseError/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/extractResponseError/__snapshots__/basic.test.ts.snap
@@ -363,8 +363,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:

--- a/tests/spec/jsAxios/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/jsAxios/__snapshots__/basic.test.ts.snap
@@ -147,8 +147,8 @@ export class HttpClient {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:

--- a/tests/spec/moduleNameFirstTag/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/moduleNameFirstTag/__snapshots__/basic.test.ts.snap
@@ -338,8 +338,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:

--- a/tests/spec/moduleNameIndex/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/moduleNameIndex/__snapshots__/basic.test.ts.snap
@@ -338,8 +338,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:

--- a/tests/spec/on-insert-path-param/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/on-insert-path-param/__snapshots__/basic.test.ts.snap
@@ -213,8 +213,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:

--- a/tests/spec/patch/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/patch/__snapshots__/basic.test.ts.snap
@@ -1970,8 +1970,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:

--- a/tests/spec/responses/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/responses/__snapshots__/basic.test.ts.snap
@@ -253,8 +253,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:

--- a/tests/spec/singleHttpClient/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/singleHttpClient/__snapshots__/basic.test.ts.snap
@@ -213,8 +213,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:

--- a/tests/spec/sortTypes-false/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/sortTypes-false/__snapshots__/basic.test.ts.snap
@@ -1970,8 +1970,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:

--- a/tests/spec/sortTypes/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/sortTypes/__snapshots__/basic.test.ts.snap
@@ -1970,8 +1970,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:

--- a/tests/spec/typeSuffixPrefix/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/typeSuffixPrefix/__snapshots__/basic.test.ts.snap
@@ -1982,8 +1982,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:

--- a/tests/spec/unionEnums/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/unionEnums/__snapshots__/basic.test.ts.snap
@@ -225,8 +225,8 @@ export class HttpClient<SecurityDataType = unknown> {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData
-            ? { "Content-Type": type }
+          ...(requestParams.type && requestParams.type !== ContentType.FormData
+            ? { "Content-Type": requestParams.type }
             : {}),
         },
         signal:


### PR DESCRIPTION
Hello 👋 

I just noticed that to determine the content-type of a request, only the `type` parameter from the `request` method itself is used. A `type` parameter provided in the `baseApiParams` when instantiating the `HttpClient` is ignored. Imho it's a good idea to pull the `type` from the merged request params, which also contain the global defaults.

Best,
Ben