### PR TITLE
Fix swagger2openapi typo

### DIFF
--- a/src/schema-routes/schema-routes.ts
+++ b/src/schema-routes/schema-routes.ts
@@ -376,7 +376,7 @@ export class SchemaRoutes {
       // const refTypeWithoutOpId = refType.replace(operationId, '');
       // const foundedSchemaByName = _.find(parsedSchemas, ({ name }) => name === refType || name === refTypeWithoutOpId)
 
-      // TODO:HACK fix problem of swagger2opeanpi
+      // TODO:HACK fix problem of swagger2openapi
       const typeNameWithoutOpId = refTypeInfo.typeName.replace(operationId, "");
       if (parsedSchemas.find((schema) => schema.name === typeNameWithoutOpId)) {
         return this.typeNameFormatter.format(typeNameWithoutOpId);


### PR DESCRIPTION
## Summary
- fix a typo in schema-routes comment

## Testing
- `yarn test` *(fails: Couldn't find the node_modules state file)*