### PR TITLE
Use shared FILE_PREFIX

### DIFF
--- a/src/util/file-system.ts
+++ b/src/util/file-system.ts
@@ -2,20 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import * as url from "node:url";
 import { consola } from "consola";
-
-const FILE_PREFIX = `/* eslint-disable */
-/* tslint:disable */
-// @ts-nocheck
-/*
- * ---------------------------------------------------------------
- * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
- * ##                                                           ##
- * ## AUTHOR: acacode                                           ##
- * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
- * ---------------------------------------------------------------
- */
-
-`;
+import { FILE_PREFIX } from "../constants.js";
 
 export class FileSystem {
   getFileContent = (path: string) => {


### PR DESCRIPTION
## Summary
- export FILE_PREFIX constant and reuse it
- refactor file-system util to import FILE_PREFIX

## Testing
- `corepack enable && yarn lint && yarn test` *(fails: Couldn't find the node_modules state file)*