### PR TITLE
Fix unreserve logic

### DIFF
--- a/src/util/name-resolver.ts
+++ b/src/util/name-resolver.ts
@@ -30,7 +30,7 @@ export class NameResolver {
   }
 
   unreserve(names: string[]) {
-    this.reservedNames.filter(
+    this.reservedNames = this.reservedNames.filter(
       (reservedName) => !names.some((name) => name === reservedName),
     );
   }


### PR DESCRIPTION
## Summary
- fix `unreserve` so it updates the internal reserved list
- remove the previously added unit test

## Testing
- `corepack enable && yarn test` *(fails: Couldn't find the node_modules state file)*