### PR TITLE
Remove unused Jekyll config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-minimal


### PR DESCRIPTION
## Summary
- remove the obsolete Jekyll configuration file

## Testing
- `corepack enable`
- `yarn install --immutable` *(fails: RequestError EHOSTUNREACH)*
- `yarn test` *(fails: Couldn't find the node_modules state file)*