### PR TITLE
Fix typos in messages

### DIFF
--- a/.changeset/small-birds-smile.md
+++ b/.changeset/small-birds-smile.md
@@ -1,0 +1,5 @@
+---
+"swagger-typescript-api": patch
+---
+
+Fix typos in CLI option description and warning message.

--- a/index.ts
+++ b/index.ts
@@ -230,7 +230,7 @@ const generateCommand = defineCommand({
     path: {
       type: "string",
       alias: "p",
-      description: "path/url to swagger scheme",
+      description: "path/url to swagger schema",
       required: true,
     },
     responses: {

--- a/src/type-name-formatter.ts
+++ b/src/type-name-formatter.ts
@@ -27,7 +27,7 @@ export class TypeNameFormatter {
     const hashKey = `${typePrefix}_${name}_${typeSuffix}`;
 
     if (typeof name !== "string") {
-      consola.warn("wrong name of the model name", name);
+      consola.warn("wrong model name", name);
       return name;
     }
 


### PR DESCRIPTION
## Summary
- correct CLI description for `path` option
- clarify warning message for wrong model name
- document these fixes in a changeset

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: biome not found)*
- `npm run format:check` *(fails: biome not found)*