### PR TITLE
fix: keep underscores in enum names with numbers (like ENUM_123_VALUE)

### DIFF
--- a/.changeset/big-sheep-see.md
+++ b/.changeset/big-sheep-see.md
@@ -2,4 +2,4 @@
 "swagger-typescript-api": patch
 ---
 
-Fix enum key generation for values like `ENUM_123_VALUE_456`
+Fix enum key generation for values like `ENUM_123_VALUE_456`.

--- a/.changeset/big-sheep-see.md
+++ b/.changeset/big-sheep-see.md
@@ -1,0 +1,5 @@
+---
+"swagger-typescript-api": patch
+---
+
+Fix enum key generation for values like `ENUM_123_VALUE_456`

--- a/src/type-name-formatter.ts
+++ b/src/type-name-formatter.ts
@@ -32,7 +32,7 @@ export class TypeNameFormatter {
     }
 
     // constant names like LEFT_ARROW, RIGHT_FORWARD, ETC_KEY, _KEY_NUM_
-    if (/^([A-Z_]{1,})$/g.test(name)) {
+    if (/^(?!\d)([A-Z0-9_]{1,})$/g.test(name)) {
       return lodash.compact([typePrefix, name, typeSuffix]).join("_");
     }
 

--- a/tests/spec/enumIncludesNumber/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/enumIncludesNumber/__snapshots__/basic.test.ts.snap
@@ -13,11 +13,14 @@ exports[`basic > use x-enumNames as the key for enum 1`] = `
  * ---------------------------------------------------------------
  */
 
-export enum StringEnumWithoutKey {
+export enum StringEnumIncludesNumbersAndUnderscore {
   VAL_1 = "VAL_1",
   VAL_2 = "VAL_2",
   VAL_3 = "VAL_3",
   _1_VAL = "_1_VAL",
+  A_1_B_2_C_3 = "A_1_B_2_C_3",
+  _A_1_B_2_C_3 = "_A_1_B_2_C_3",
+  _1_A_2_B_3_C = "_1_A_2_B_3_C",
 }
 "
 `;

--- a/tests/spec/enumIncludesNumber/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/enumIncludesNumber/__snapshots__/basic.test.ts.snap
@@ -1,0 +1,23 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`basic > use x-enumNames as the key for enum 1`] = `
+"/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+export enum StringEnumWithoutKey {
+  VAL_1 = "VAL_1",
+  VAL_2 = "VAL_2",
+  VAL_3 = "VAL_3",
+  _1_VAL = "_1_VAL",
+}
+"
+`;

--- a/tests/spec/enumIncludesNumber/basic.test.ts
+++ b/tests/spec/enumIncludesNumber/basic.test.ts
@@ -1,0 +1,37 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+
+import { generateApi } from "../../../src/index.js";
+
+describe("basic", async () => {
+  let tmpdir = "";
+
+  beforeAll(async () => {
+    tmpdir = await fs.mkdtemp(path.join(os.tmpdir(), "swagger-typescript-api"));
+  });
+
+  afterAll(async () => {
+    await fs.rm(tmpdir, { recursive: true });
+  });
+
+  test("use x-enumNames as the key for enum", async () => {
+    await generateApi({
+      fileName: "schema",
+      input: path.resolve(import.meta.dirname, "schema.json"),
+      output: tmpdir,
+      silent: true,
+      enumNamesAsValues: false,
+      generateClient: false,
+    });
+
+    const content = await fs.readFile(path.join(tmpdir, "schema.ts"), {
+      encoding: "utf8",
+    });
+    console.log(path.join(tmpdir, "schema.ts"));
+
+    expect(content).toMatchSnapshot();
+  });
+});

--- a/tests/spec/enumIncludesNumber/schema.json
+++ b/tests/spec/enumIncludesNumber/schema.json
@@ -1,0 +1,13 @@
+{
+  "openapi": "3.0.0",
+  "tags": [],
+  "servers": [],
+  "components": {
+    "schemas": {
+      "StringEnumWithoutKey": {
+        "type": "string",
+        "enum": ["VAL_1", "VAL_2", "VAL_3", "_1_VAL"]
+      }
+    }
+  }
+}

--- a/tests/spec/enumIncludesNumber/schema.json
+++ b/tests/spec/enumIncludesNumber/schema.json
@@ -4,9 +4,17 @@
   "servers": [],
   "components": {
     "schemas": {
-      "StringEnumWithoutKey": {
+      "StringEnumIncludesNumbersAndUnderscore": {
         "type": "string",
-        "enum": ["VAL_1", "VAL_2", "VAL_3", "_1_VAL"]
+        "enum": [
+          "VAL_1",
+          "VAL_2",
+          "VAL_3",
+          "_1_VAL",
+          "A_1_B_2_C_3",
+          "_A_1_B_2_C_3",
+          "_1_A_2_B_3_C"
+        ]
       }
     }
   }


### PR DESCRIPTION
Hi :wave: 

Before, enum names like ENUM_123_VALUE lost their underscores and became ENUM123VALUE.  
This change keeps the underscores so the names stay correct. (Fixes #276)

Best,
Parsa