### PR TITLE
Remove `required` field from command definitions for now

### DIFF
--- a/.changeset/violet-terms-hear.md
+++ b/.changeset/violet-terms-hear.md
@@ -1,0 +1,5 @@
+---
+"swagger-typescript-api": patch
+---
+
+Remove `required` field from command definitions for now.

--- a/index.ts
+++ b/index.ts
@@ -47,7 +47,6 @@ const generateTemplatesCommand = defineCommand({
       alias: "o",
       description: "output path of generated templates",
       default: templateGenBaseConfig.output,
-      required: true,
     },
     rewrite: {
       type: "boolean",
@@ -231,7 +230,6 @@ const generateCommand = defineCommand({
       type: "string",
       alias: "p",
       description: "path/url to swagger schema",
-      required: true,
     },
     responses: {
       type: "boolean",


### PR DESCRIPTION
Closes https://github.com/acacode/swagger-typescript-api/issues/1228