### PR TITLE
Revert "Integrate `generateCommand` arguments and run method into main command (#1198)"

### DIFF
--- a/.changeset/tame-poets-act.md
+++ b/.changeset/tame-poets-act.md
@@ -1,0 +1,5 @@
+---
+"swagger-typescript-api": patch
+---
+
+Revert "Integrate `generateCommand` arguments and run method into main command (#1198)".

--- a/index.ts
+++ b/index.ts
@@ -342,8 +342,6 @@ const main = defineCommand({
     description: packageJson.description,
     version: packageJson.version,
   },
-  args: generateCommand.args,
-  run: generateCommand.run,
   subCommands: {
     generate: generateCommand,
     "generate-templates": generateTemplatesCommand,


### PR DESCRIPTION
See https://github.com/acacode/swagger-typescript-api/commit/1cb1c9c0d39dacefb89a6b44eaf2a6266334f3c6#r159310334