### PR TITLE
fix regex related parsing route name

### DIFF
--- a/src/schema-routes/schema-routes.ts
+++ b/src/schema-routes/schema-routes.ts
@@ -98,7 +98,7 @@ export class SchemaRoutes {
 
     // TODO forbid leading symbols [\]^` in a major release (allowed yet for backwards compatibility)
     const pathParamMatches = (routeName || "").match(
-      /({[\w[\\\]^`][-_.\w]*})|(:[\w[\\\]^`][-_.\w]*:?)/g,
+      /(?<=\/|\.\.\.)({[\w[\\\]^`][-_.\w]*})|(?<=\/|\.\.\.)(:[\w[\\\]^`][-_.\w]*:?)/g,
     );
 
     // used in case when path parameters is not declared in requestInfo.parameters ("in": "path")


### PR DESCRIPTION
We used swagger-typescript-api to parse and encountered the same issue as this developer (https://github.com/acacode/swagger-typescript-api/issues/532). Is it possible to modify the regex in parseRouteName to ensure that there is always a "/" or "..." at the beginning before treating it as a parameter?