### PR TITLE
Revert back to require for use in templates

### DIFF
--- a/src/templates-worker.ts
+++ b/src/templates-worker.ts
@@ -74,21 +74,21 @@ export class TemplatesWorker {
     );
   };
 
-  requireFnFromTemplate = async (packageOrPath: string) => {
+  requireFnFromTemplate = (packageOrPath: string) => {
     const isPath =
       packageOrPath.startsWith("./") || packageOrPath.startsWith("../");
 
     if (isPath) {
-      return await import(
+      return require(
         path.resolve(
           this.config.templatePaths.custom ||
             this.config.templatePaths.original,
           packageOrPath,
-        )
+        ),
       );
     }
 
-    return await import(packageOrPath);
+    return require(packageOrPath);
   };
 
   getTemplate = (name: string, fileName: string, path?: string) => {


### PR DESCRIPTION
This [PR](https://github.com/acacode/swagger-typescript-api/pull/807/files) aimed to remove `require` in favour of `import`.

A side effect of this was that `require` no longer works correctly inside templates because it is now an async function. Since the template is rendered synchronously, it is no longer possible to import anything from inside a template.

This PR restores that functionality, which was introduced in version 4.0.4.

Thanks!