### PR TITLE
fix: ensure ext parameter includes leading dot in path formatting

### DIFF
--- a/src/code-formatter.ts
+++ b/src/code-formatter.ts
@@ -44,7 +44,7 @@ export class CodeFormatter {
       formatter: { indentStyle: "space" },
     });
     const formatted = biome.formatContent(biomeProject.projectKey, content, {
-      filePath: path.format({ name: nanoid.nanoid(), ext: "ts" }),
+      filePath: path.format({ name: nanoid.nanoid(), ext: ".ts" }),
     });
     return formatted.content;
   };


### PR DESCRIPTION
- Explicitly prepend '.' to ext if missing (e.g., "ts" → ".ts")