### PR TITLE
Allow partial extractingOptions in generateApi configuration

### DIFF
--- a/.changeset/partial-extracting-options.md
+++ b/.changeset/partial-extracting-options.md
@@ -1,0 +1,6 @@
+---
+"swagger-typescript-api": patch
+---
+
+Allow partial `extractingOptions` in `generateApi` configuration.
+

--- a/types/index.ts
+++ b/types/index.ts
@@ -671,7 +671,7 @@ export interface GenerateApiConfiguration {
     /** configuration for fetching swagger schema requests */
     requestOptions?: Partial<RequestInit>;
     /** extra configuration for extracting type names operations */
-    extractingOptions: ExtractingOptions;
+    extractingOptions: Partial<ExtractingOptions>;
     /** update configuration object during generation */
     update: (update: Partial<GenerateApiConfiguration["config"]>) => void;
   };


### PR DESCRIPTION
## Summary
- allow partial `extractingOptions` when calling `generateApi`
- add changeset

## Testing
- `yarn lint types/index.ts`
- `yarn test`

Fixes #1183

------
https://chatgpt.com/codex/tasks/task_e_68aff6dba7cc832785c24f224afebcd0