### PR TITLE
Ensure anyOf preserves primitive types

### DIFF
--- a/.changeset/primitive-anyof-test.md
+++ b/.changeset/primitive-anyof-test.md
@@ -1,0 +1,5 @@
+---
+"swagger-typescript-api": patch
+---
+
+Add test verifying primitive + object anyOf unions.

--- a/tests/spec/object-types/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/object-types/__snapshots__/basic.test.ts.snap
@@ -60,6 +60,14 @@ export type Test1 = {
   multiple: string | number;
 } | null;
 
+export interface AddressCreationRequest {
+  city?: string;
+}
+
+export interface ContainerWithPrimitiveAnyOf {
+  origin?: string | AddressCreationRequest;
+}
+
 export interface AdditionalObjectProperties {
   id?: string;
   [key: string]: any;

--- a/tests/spec/object-types/schema.json
+++ b/tests/spec/object-types/schema.json
@@ -83,6 +83,29 @@
         }
       }
     },
+    "AddressCreationRequest": {
+      "type": "object",
+      "properties": {
+        "city": {
+          "type": "string"
+        }
+      }
+    },
+    "ContainerWithPrimitiveAnyOf": {
+      "type": "object",
+      "properties": {
+        "origin": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/AddressCreationRequest"
+            }
+          ]
+        }
+      }
+    },
     "AdditionalObjectProperties": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
## Summary
- add schema and snapshot demonstrating primitive + object anyOf union
- add changeset documenting test

## Testing
- `yarn format:check`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68affbe4595883278383a9cdcd57044e