### PR TITLE
Handle extraction of path-only request parameters

### DIFF
--- a/.changeset/extract-request-params-delete.md
+++ b/.changeset/extract-request-params-delete.md
@@ -1,0 +1,5 @@
+---
+"swagger-typescript-api": patch
+---
+
+Support extracting request parameters for routes that only declare path parameters, such as DELETE methods.

--- a/src/schema-routes/schema-routes.ts
+++ b/src/schema-routes/schema-routes.ts
@@ -645,7 +645,11 @@ export class SchemaRoutes {
     extractRequestParams,
     routeName,
   }) => {
-    if (!queryParams || !queryParams.length) return null;
+    if (
+      (!queryParams || !queryParams.length) &&
+      (!pathArgsSchemas || !pathArgsSchemas.length)
+    )
+      return null;
 
     const pathParams = pathArgsSchemas.reduce((acc, pathArgSchema) => {
       if (pathArgSchema.name) {

--- a/tests/__snapshots__/extended.test.ts.snap
+++ b/tests/__snapshots__/extended.test.ts.snap
@@ -55,7 +55,18 @@ export interface AllActivitiesParams {
 
 export type AllBlocksData = Block[];
 
+export interface AllBlocksParams {
+  dashboardId: string;
+  /** a valid username string */
+  username: string;
+}
+
 export type AllDashboardsData = Dashboard[];
+
+export interface AllDashboardsParams {
+  /** a valid username string */
+  username: string;
+}
 
 export type AllDataData = DataResponse[];
 
@@ -82,6 +93,11 @@ export interface AllDataParams {
 
 export type AllFeedsData = Feed[];
 
+export interface AllFeedsParams {
+  /** a valid username string */
+  username: string;
+}
+
 export type AllGroupFeedDataData = DataResponse[];
 
 export interface AllGroupFeedDataParams {
@@ -106,15 +122,50 @@ export interface AllGroupFeedDataParams {
 
 export type AllGroupFeedsData = Feed[];
 
+export interface AllGroupFeedsParams {
+  groupKey: string;
+  /** a valid username string */
+  username: string;
+}
+
 export type AllGroupsData = Group[];
+
+export interface AllGroupsParams {
+  /** a valid username string */
+  username: string;
+}
 
 export type AllPermissionsData = Permission[];
 
+export interface AllPermissionsParams {
+  type: string;
+  typeId: string;
+  /** a valid username string */
+  username: string;
+}
+
 export type AllTokensData = Token[];
+
+export interface AllTokensParams {
+  /** a valid username string */
+  username: string;
+}
 
 export type AllTriggersData = Trigger[];
 
+export interface AllTriggersParams {
+  /** a valid username string */
+  username: string;
+}
+
 export type BatchCreateDataData = DataResponse[];
+
+export interface BatchCreateDataParams {
+  /** a valid feed key */
+  feedKey: string;
+  /** a valid username string */
+  username: string;
+}
 
 /** A collection of data records including \`value\` (required) and optionally including: \`lat\`, \`lon\`, \`ele\` (latitude, longitude, and elevation values), and \`created_at\` (a date/time string). */
 export type BatchCreateDataPayload = {
@@ -128,6 +179,14 @@ export type BatchCreateDataPayload = {
 }[];
 
 export type BatchCreateGroupFeedDataData = DataResponse[];
+
+export interface BatchCreateGroupFeedDataParams {
+  /** a valid feed key */
+  feedKey: string;
+  groupKey: string;
+  /** a valid username string */
+  username: string;
+}
 
 /** A collection of data records including \`value\` (required) and optionally including: \`lat\`, \`lon\`, \`ele\` (latitude, longitude, and elevation values), and \`created_at\` (a date/time string). */
 export type BatchCreateGroupFeedDataPayload = {
@@ -200,6 +259,12 @@ export interface ChartDataParams {
 
 export type CreateBlockData = Block;
 
+export interface CreateBlockParams {
+  dashboardId: string;
+  /** a valid username string */
+  username: string;
+}
+
 export interface CreateBlockPayload {
   block_feeds?: {
     feed_id?: string;
@@ -219,6 +284,11 @@ export interface CreateBlockPayload {
 
 export type CreateDashboardData = Dashboard;
 
+export interface CreateDashboardParams {
+  /** a valid username string */
+  username: string;
+}
+
 export interface CreateDashboardPayload {
   description?: string;
   key?: string;
@@ -226,6 +296,13 @@ export interface CreateDashboardPayload {
 }
 
 export type CreateDataData = Data;
+
+export interface CreateDataParams {
+  /** a valid feed key */
+  feedKey: string;
+  /** a valid username string */
+  username: string;
+}
 
 /** Data record including a \`value\` field (required) and optionally including: \`lat\`, \`lon\`, \`ele\` (latitude, longitude, and elevation values), and \`created_at\` (a date/time string). */
 export interface CreateDataPayload {
@@ -257,6 +334,12 @@ export type CreateGroupData = Group;
 
 export type CreateGroupDataData = DataResponse[];
 
+export interface CreateGroupDataParams {
+  groupKey: string;
+  /** a valid username string */
+  username: string;
+}
+
 export interface CreateGroupDataPayload {
   /** Optional created_at timestamp which will be applied to all feed values created. */
   created_at?: string;
@@ -277,6 +360,14 @@ export type CreateGroupFeedData = Feed;
 
 export type CreateGroupFeedDataData = DataResponse;
 
+export interface CreateGroupFeedDataParams {
+  /** a valid feed key */
+  feedKey: string;
+  groupKey: string;
+  /** a valid username string */
+  username: string;
+}
+
 /** Data record including a \`value\` field (required) and optionally including: \`lat\`, \`lon\`, \`ele\` (latitude, longitude, and elevation values), and \`created_at\` (a date/time string). */
 export interface CreateGroupFeedDataPayload {
   /** @format dateTime */
@@ -288,11 +379,22 @@ export interface CreateGroupFeedDataPayload {
   value?: string;
 }
 
+export interface CreateGroupFeedParams {
+  groupKey: string;
+  /** a valid username string */
+  username: string;
+}
+
 export interface CreateGroupFeedPayload {
   description?: string;
   key?: string;
   license?: string;
   name?: string;
+}
+
+export interface CreateGroupParams {
+  /** a valid username string */
+  username: string;
 }
 
 export interface CreateGroupPayload {
@@ -308,6 +410,13 @@ export enum CreatePermissionModeEnum {
   R = "r",
   W = "w",
   Rw = "rw",
+}
+
+export interface CreatePermissionParams {
+  type: string;
+  typeId: string;
+  /** a valid username string */
+  username: string;
 }
 
 export interface CreatePermissionPayload {
@@ -328,7 +437,16 @@ export enum CreatePermissionScopeEnum {
 
 export type CreateRawWebhookFeedDataData = Data;
 
+export interface CreateRawWebhookFeedDataParams {
+  token: string;
+}
+
 export type CreateTokenData = Token;
+
+export interface CreateTokenParams {
+  /** a valid username string */
+  username: string;
+}
 
 export interface CreateTokenPayload {
   token?: string;
@@ -336,11 +454,20 @@ export interface CreateTokenPayload {
 
 export type CreateTriggerData = Trigger;
 
+export interface CreateTriggerParams {
+  /** a valid username string */
+  username: string;
+}
+
 export interface CreateTriggerPayload {
   name?: string;
 }
 
 export type CreateWebhookFeedDataData = Data;
+
+export interface CreateWebhookFeedDataParams {
+  token: string;
+}
 
 /** Webhook payload containing data \`value\` parameter. */
 export interface CreateWebhookFeedDataPayload {
@@ -388,21 +515,80 @@ export interface DataResponse {
 
 export type DestroyActivitiesData = any;
 
+export interface DestroyActivitiesParams {
+  /** a valid username string */
+  username: string;
+}
+
 export type DestroyBlockData = string;
+
+export interface DestroyBlockParams {
+  dashboardId: string;
+  id: string;
+  /** a valid username string */
+  username: string;
+}
 
 export type DestroyDashboardData = string;
 
+export interface DestroyDashboardParams {
+  id: string;
+  /** a valid username string */
+  username: string;
+}
+
 export type DestroyDataData = string;
+
+export interface DestroyDataParams {
+  /** a valid feed key */
+  feedKey: string;
+  id: string;
+  /** a valid username string */
+  username: string;
+}
 
 export type DestroyFeedData = any;
 
+export interface DestroyFeedParams {
+  /** a valid feed key */
+  feedKey: string;
+  /** a valid username string */
+  username: string;
+}
+
 export type DestroyGroupData = string;
+
+export interface DestroyGroupParams {
+  groupKey: string;
+  /** a valid username string */
+  username: string;
+}
 
 export type DestroyPermissionData = string;
 
+export interface DestroyPermissionParams {
+  id: string;
+  type: string;
+  typeId: string;
+  /** a valid username string */
+  username: string;
+}
+
 export type DestroyTokenData = string;
 
+export interface DestroyTokenParams {
+  id: string;
+  /** a valid username string */
+  username: string;
+}
+
 export type DestroyTriggerData = string;
+
+export interface DestroyTriggerParams {
+  id: string;
+  /** a valid username string */
+  username: string;
+}
 
 export interface Error {
   code?: string;
@@ -485,6 +671,13 @@ export interface GetActivityParams {
 
 export type GetBlockData = Block;
 
+export interface GetBlockParams {
+  dashboardId: string;
+  id: string;
+  /** a valid username string */
+  username: string;
+}
+
 export interface GetCurrentUserThrottleData {
   /** Actions taken inside the time window. */
   active_data_rate?: number;
@@ -492,7 +685,18 @@ export interface GetCurrentUserThrottleData {
   data_rate_limit?: number;
 }
 
+export interface GetCurrentUserThrottleParams {
+  /** a valid username string */
+  username: string;
+}
+
 export type GetDashboardData = Dashboard;
+
+export interface GetDashboardParams {
+  id: string;
+  /** a valid username string */
+  username: string;
+}
 
 export type GetDataData = DataResponse;
 
@@ -510,13 +714,53 @@ export type GetFeedData = Feed;
 
 export type GetFeedDetailsData = Feed;
 
+export interface GetFeedDetailsParams {
+  /** a valid feed key */
+  feedKey: string;
+  /** a valid username string */
+  username: string;
+}
+
+export interface GetFeedParams {
+  /** a valid feed key */
+  feedKey: string;
+  /** a valid username string */
+  username: string;
+}
+
 export type GetGroupData = Group;
+
+export interface GetGroupParams {
+  groupKey: string;
+  /** a valid username string */
+  username: string;
+}
 
 export type GetPermissionData = Permission;
 
+export interface GetPermissionParams {
+  id: string;
+  type: string;
+  typeId: string;
+  /** a valid username string */
+  username: string;
+}
+
 export type GetTokenData = Token;
 
+export interface GetTokenParams {
+  id: string;
+  /** a valid username string */
+  username: string;
+}
+
 export type GetTriggerData = Trigger;
+
+export interface GetTriggerParams {
+  id: string;
+  /** a valid username string */
+  username: string;
+}
 
 export interface Group {
   created_at?: string;
@@ -599,6 +843,13 @@ export interface RemoveFeedFromGroupParams {
 
 export type ReplaceBlockData = Block;
 
+export interface ReplaceBlockParams {
+  dashboardId: string;
+  id: string;
+  /** a valid username string */
+  username: string;
+}
+
 export interface ReplaceBlockPayload {
   block_feeds?: {
     feed_id?: string;
@@ -618,6 +869,12 @@ export interface ReplaceBlockPayload {
 
 export type ReplaceDashboardData = Dashboard;
 
+export interface ReplaceDashboardParams {
+  id: string;
+  /** a valid username string */
+  username: string;
+}
+
 export interface ReplaceDashboardPayload {
   description?: string;
   key?: string;
@@ -625,6 +882,14 @@ export interface ReplaceDashboardPayload {
 }
 
 export type ReplaceDataData = DataResponse;
+
+export interface ReplaceDataParams {
+  /** a valid feed key */
+  feedKey: string;
+  id: string;
+  /** a valid username string */
+  username: string;
+}
 
 /** Data record including a \`value\` field (required) and optionally including: \`lat\`, \`lon\`, \`ele\` (latitude, longitude, and elevation values), and \`created_at\` (a date/time string). */
 export interface ReplaceDataPayload {
@@ -639,6 +904,13 @@ export interface ReplaceDataPayload {
 
 export type ReplaceFeedData = Feed;
 
+export interface ReplaceFeedParams {
+  /** a valid feed key */
+  feedKey: string;
+  /** a valid username string */
+  username: string;
+}
+
 export interface ReplaceFeedPayload {
   description?: string;
   key?: string;
@@ -647,6 +919,12 @@ export interface ReplaceFeedPayload {
 }
 
 export type ReplaceGroupData = Group;
+
+export interface ReplaceGroupParams {
+  groupKey: string;
+  /** a valid username string */
+  username: string;
+}
 
 export interface ReplaceGroupPayload {
   description?: string;
@@ -661,6 +939,14 @@ export enum ReplacePermissionModeEnum {
   R = "r",
   W = "w",
   Rw = "rw",
+}
+
+export interface ReplacePermissionParams {
+  id: string;
+  type: string;
+  typeId: string;
+  /** a valid username string */
+  username: string;
 }
 
 export interface ReplacePermissionPayload {
@@ -681,17 +967,36 @@ export enum ReplacePermissionScopeEnum {
 
 export type ReplaceTokenData = Token;
 
+export interface ReplaceTokenParams {
+  id: string;
+  /** a valid username string */
+  username: string;
+}
+
 export interface ReplaceTokenPayload {
   token?: string;
 }
 
 export type ReplaceTriggerData = Trigger;
 
+export interface ReplaceTriggerParams {
+  id: string;
+  /** a valid username string */
+  username: string;
+}
+
 export interface ReplaceTriggerPayload {
   name?: string;
 }
 
 export type RetainDataData = string;
+
+export interface RetainDataParams {
+  /** a valid feed key */
+  feedKey: string;
+  /** a valid username string */
+  username: string;
+}
 
 export interface ShallowGroup {
   created_at?: string;
@@ -710,6 +1015,13 @@ export interface Trigger {
 }
 
 export type UpdateBlockData = Block;
+
+export interface UpdateBlockParams {
+  dashboardId: string;
+  id: string;
+  /** a valid username string */
+  username: string;
+}
 
 export interface UpdateBlockPayload {
   block_feeds?: {
@@ -730,6 +1042,12 @@ export interface UpdateBlockPayload {
 
 export type UpdateDashboardData = Dashboard;
 
+export interface UpdateDashboardParams {
+  id: string;
+  /** a valid username string */
+  username: string;
+}
+
 export interface UpdateDashboardPayload {
   description?: string;
   key?: string;
@@ -737,6 +1055,14 @@ export interface UpdateDashboardPayload {
 }
 
 export type UpdateDataData = DataResponse;
+
+export interface UpdateDataParams {
+  /** a valid feed key */
+  feedKey: string;
+  id: string;
+  /** a valid username string */
+  username: string;
+}
 
 /** Data record including a \`value\` field (required) and optionally including: \`lat\`, \`lon\`, \`ele\` (latitude, longitude, and elevation values), and \`created_at\` (a date/time string). */
 export interface UpdateDataPayload {
@@ -751,6 +1077,13 @@ export interface UpdateDataPayload {
 
 export type UpdateFeedData = Feed;
 
+export interface UpdateFeedParams {
+  /** a valid feed key */
+  feedKey: string;
+  /** a valid username string */
+  username: string;
+}
+
 export interface UpdateFeedPayload {
   description?: string;
   key?: string;
@@ -759,6 +1092,12 @@ export interface UpdateFeedPayload {
 }
 
 export type UpdateGroupData = Group;
+
+export interface UpdateGroupParams {
+  groupKey: string;
+  /** a valid username string */
+  username: string;
+}
 
 export interface UpdateGroupPayload {
   description?: string;
@@ -773,6 +1112,14 @@ export enum UpdatePermissionModeEnum {
   R = "r",
   W = "w",
   Rw = "rw",
+}
+
+export interface UpdatePermissionParams {
+  id: string;
+  type: string;
+  typeId: string;
+  /** a valid username string */
+  username: string;
 }
 
 export interface UpdatePermissionPayload {
@@ -793,11 +1140,23 @@ export enum UpdatePermissionScopeEnum {
 
 export type UpdateTokenData = Token;
 
+export interface UpdateTokenParams {
+  id: string;
+  /** a valid username string */
+  username: string;
+}
+
 export interface UpdateTokenPayload {
   token?: string;
 }
 
 export type UpdateTriggerData = Trigger;
+
+export interface UpdateTriggerParams {
+  id: string;
+  /** a valid username string */
+  username: string;
+}
 
 export interface UpdateTriggerPayload {
   name?: string;
@@ -2771,7 +3130,10 @@ export class Api<
      * @request POST:/webhooks/feed/:token/raw
      * @secure
      */
-    createRawWebhookFeedData: (token: string, params: RequestParams = {}) =>
+    createRawWebhookFeedData: (
+      { token, ...query }: CreateRawWebhookFeedDataParams,
+      params: RequestParams = {},
+    ) =>
       this.request<CreateRawWebhookFeedDataData, void>({
         path: \`/webhooks/feed/\${token}/raw\`,
         method: "POST",
@@ -2791,7 +3153,7 @@ export class Api<
      * @secure
      */
     createWebhookFeedData: (
-      token: string,
+      { token, ...query }: CreateWebhookFeedDataParams,
       payload: CreateWebhookFeedDataPayload,
       params: RequestParams = {},
     ) =>
@@ -2860,8 +3222,7 @@ export class Api<
      * @secure
      */
     allBlocks: (
-      username: string,
-      dashboardId: string,
+      { username, dashboardId, ...query }: AllBlocksParams,
       params: RequestParams = {},
     ) =>
       this.request<AllBlocksData, void>({
@@ -2881,7 +3242,10 @@ export class Api<
      * @request GET:/{username}/dashboards
      * @secure
      */
-    allDashboards: (username: string, params: RequestParams = {}) =>
+    allDashboards: (
+      { username, ...query }: AllDashboardsParams,
+      params: RequestParams = {},
+    ) =>
       this.request<AllDashboardsData, void>({
         path: \`/\${username}/dashboards\`,
         method: "GET",
@@ -2921,7 +3285,10 @@ export class Api<
      * @request GET:/{username}/feeds
      * @secure
      */
-    allFeeds: (username: string, params: RequestParams = {}) =>
+    allFeeds: (
+      { username, ...query }: AllFeedsParams,
+      params: RequestParams = {},
+    ) =>
       this.request<AllFeedsData, void>({
         path: \`/\${username}/feeds\`,
         method: "GET",
@@ -2962,8 +3329,7 @@ export class Api<
      * @secure
      */
     allGroupFeeds: (
-      groupKey: string,
-      username: string,
+      { groupKey, username, ...query }: AllGroupFeedsParams,
       params: RequestParams = {},
     ) =>
       this.request<AllGroupFeedsData, void>({
@@ -2983,7 +3349,10 @@ export class Api<
      * @request GET:/{username}/groups
      * @secure
      */
-    allGroups: (username: string, params: RequestParams = {}) =>
+    allGroups: (
+      { username, ...query }: AllGroupsParams,
+      params: RequestParams = {},
+    ) =>
       this.request<AllGroupsData, void>({
         path: \`/\${username}/groups\`,
         method: "GET",
@@ -3002,9 +3371,7 @@ export class Api<
      * @secure
      */
     allPermissions: (
-      username: string,
-      type: string,
-      typeId: string,
+      { username, type, typeId, ...query }: AllPermissionsParams,
       params: RequestParams = {},
     ) =>
       this.request<AllPermissionsData, void>({
@@ -3024,7 +3391,10 @@ export class Api<
      * @request GET:/{username}/tokens
      * @secure
      */
-    allTokens: (username: string, params: RequestParams = {}) =>
+    allTokens: (
+      { username, ...query }: AllTokensParams,
+      params: RequestParams = {},
+    ) =>
       this.request<AllTokensData, void>({
         path: \`/\${username}/tokens\`,
         method: "GET",
@@ -3042,7 +3412,10 @@ export class Api<
      * @request GET:/{username}/triggers
      * @secure
      */
-    allTriggers: (username: string, params: RequestParams = {}) =>
+    allTriggers: (
+      { username, ...query }: AllTriggersParams,
+      params: RequestParams = {},
+    ) =>
       this.request<AllTriggersData, void>({
         path: \`/\${username}/triggers\`,
         method: "GET",
@@ -3061,8 +3434,7 @@ export class Api<
      * @secure
      */
     batchCreateData: (
-      username: string,
-      feedKey: string,
+      { username, feedKey, ...query }: BatchCreateDataParams,
       data: BatchCreateDataPayload,
       params: RequestParams = {},
     ) =>
@@ -3086,9 +3458,7 @@ export class Api<
      * @secure
      */
     batchCreateGroupFeedData: (
-      username: string,
-      groupKey: string,
-      feedKey: string,
+      { username, groupKey, feedKey, ...query }: BatchCreateGroupFeedDataParams,
       data: BatchCreateGroupFeedDataPayload,
       params: RequestParams = {},
     ) =>
@@ -3134,8 +3504,7 @@ export class Api<
      * @secure
      */
     createBlock: (
-      username: string,
-      dashboardId: string,
+      { username, dashboardId, ...query }: CreateBlockParams,
       block: CreateBlockPayload,
       params: RequestParams = {},
     ) =>
@@ -3159,7 +3528,7 @@ export class Api<
      * @secure
      */
     createDashboard: (
-      username: string,
+      { username, ...query }: CreateDashboardParams,
       dashboard: CreateDashboardPayload,
       params: RequestParams = {},
     ) =>
@@ -3183,8 +3552,7 @@ export class Api<
      * @secure
      */
     createData: (
-      username: string,
-      feedKey: string,
+      { username, feedKey, ...query }: CreateDataParams,
       datum: CreateDataPayload,
       params: RequestParams = {},
     ) =>
@@ -3233,7 +3601,7 @@ export class Api<
      * @secure
      */
     createGroup: (
-      username: string,
+      { username, ...query }: CreateGroupParams,
       group: CreateGroupPayload,
       params: RequestParams = {},
     ) =>
@@ -3257,8 +3625,7 @@ export class Api<
      * @secure
      */
     createGroupData: (
-      username: string,
-      groupKey: string,
+      { username, groupKey, ...query }: CreateGroupDataParams,
       group_feed_data: CreateGroupDataPayload,
       params: RequestParams = {},
     ) =>
@@ -3282,8 +3649,7 @@ export class Api<
      * @secure
      */
     createGroupFeed: (
-      username: string,
-      groupKey: string,
+      { username, groupKey, ...query }: CreateGroupFeedParams,
       feed: CreateGroupFeedPayload,
       params: RequestParams = {},
     ) =>
@@ -3307,9 +3673,7 @@ export class Api<
      * @secure
      */
     createGroupFeedData: (
-      username: string,
-      groupKey: string,
-      feedKey: string,
+      { username, groupKey, feedKey, ...query }: CreateGroupFeedDataParams,
       datum: CreateGroupFeedDataPayload,
       params: RequestParams = {},
     ) =>
@@ -3333,9 +3697,7 @@ export class Api<
      * @secure
      */
     createPermission: (
-      username: string,
-      type: string,
-      typeId: string,
+      { username, type, typeId, ...query }: CreatePermissionParams,
       permission: CreatePermissionPayload,
       params: RequestParams = {},
     ) =>
@@ -3359,7 +3721,7 @@ export class Api<
      * @secure
      */
     createToken: (
-      username: string,
+      { username, ...query }: CreateTokenParams,
       token: CreateTokenPayload,
       params: RequestParams = {},
     ) =>
@@ -3383,7 +3745,7 @@ export class Api<
      * @secure
      */
     createTrigger: (
-      username: string,
+      { username, ...query }: CreateTriggerParams,
       trigger: CreateTriggerPayload,
       params: RequestParams = {},
     ) =>
@@ -3406,7 +3768,10 @@ export class Api<
      * @request DELETE:/{username}/activities
      * @secure
      */
-    destroyActivities: (username: string, params: RequestParams = {}) =>
+    destroyActivities: (
+      { username, ...query }: DestroyActivitiesParams,
+      params: RequestParams = {},
+    ) =>
       this.request<DestroyActivitiesData, void>({
         path: \`/\${username}/activities\`,
         method: "DELETE",
@@ -3424,9 +3789,7 @@ export class Api<
      * @secure
      */
     destroyBlock: (
-      username: string,
-      dashboardId: string,
-      id: string,
+      { username, dashboardId, id, ...query }: DestroyBlockParams,
       params: RequestParams = {},
     ) =>
       this.request<DestroyBlockData, void>({
@@ -3447,8 +3810,7 @@ export class Api<
      * @secure
      */
     destroyDashboard: (
-      username: string,
-      id: string,
+      { username, id, ...query }: DestroyDashboardParams,
       params: RequestParams = {},
     ) =>
       this.request<DestroyDashboardData, void>({
@@ -3469,9 +3831,7 @@ export class Api<
      * @secure
      */
     destroyData: (
-      username: string,
-      feedKey: string,
-      id: string,
+      { username, feedKey, id, ...query }: DestroyDataParams,
       params: RequestParams = {},
     ) =>
       this.request<DestroyDataData, void>({
@@ -3492,8 +3852,7 @@ export class Api<
      * @secure
      */
     destroyFeed: (
-      username: string,
-      feedKey: string,
+      { username, feedKey, ...query }: DestroyFeedParams,
       params: RequestParams = {},
     ) =>
       this.request<DestroyFeedData, void>({
@@ -3513,8 +3872,7 @@ export class Api<
      * @secure
      */
     destroyGroup: (
-      username: string,
-      groupKey: string,
+      { username, groupKey, ...query }: DestroyGroupParams,
       params: RequestParams = {},
     ) =>
       this.request<DestroyGroupData, void>({
@@ -3535,10 +3893,7 @@ export class Api<
      * @secure
      */
     destroyPermission: (
-      username: string,
-      type: string,
-      typeId: string,
-      id: string,
+      { username, type, typeId, id, ...query }: DestroyPermissionParams,
       params: RequestParams = {},
     ) =>
       this.request<DestroyPermissionData, void>({
@@ -3558,7 +3913,10 @@ export class Api<
      * @request DELETE:/{username}/tokens/{id}
      * @secure
      */
-    destroyToken: (username: string, id: string, params: RequestParams = {}) =>
+    destroyToken: (
+      { username, id, ...query }: DestroyTokenParams,
+      params: RequestParams = {},
+    ) =>
       this.request<DestroyTokenData, void>({
         path: \`/\${username}/tokens/\${id}\`,
         method: "DELETE",
@@ -3577,8 +3935,7 @@ export class Api<
      * @secure
      */
     destroyTrigger: (
-      username: string,
-      id: string,
+      { username, id, ...query }: DestroyTriggerParams,
       params: RequestParams = {},
     ) =>
       this.request<DestroyTriggerData, void>({
@@ -3644,9 +4001,7 @@ export class Api<
      * @secure
      */
     getBlock: (
-      username: string,
-      dashboardId: string,
-      id: string,
+      { username, dashboardId, id, ...query }: GetBlockParams,
       params: RequestParams = {},
     ) =>
       this.request<GetBlockData, void>({
@@ -3666,7 +4021,10 @@ export class Api<
      * @request GET:/{username}/throttle
      * @secure
      */
-    getCurrentUserThrottle: (username: string, params: RequestParams = {}) =>
+    getCurrentUserThrottle: (
+      { username, ...query }: GetCurrentUserThrottleParams,
+      params: RequestParams = {},
+    ) =>
       this.request<GetCurrentUserThrottleData, void>({
         path: \`/\${username}/throttle\`,
         method: "GET",
@@ -3684,7 +4042,10 @@ export class Api<
      * @request GET:/{username}/dashboards/{id}
      * @secure
      */
-    getDashboard: (username: string, id: string, params: RequestParams = {}) =>
+    getDashboard: (
+      { username, id, ...query }: GetDashboardParams,
+      params: RequestParams = {},
+    ) =>
       this.request<GetDashboardData, void>({
         path: \`/\${username}/dashboards/\${id}\`,
         method: "GET",
@@ -3724,7 +4085,10 @@ export class Api<
      * @request GET:/{username}/feeds/{feed_key}
      * @secure
      */
-    getFeed: (username: string, feedKey: string, params: RequestParams = {}) =>
+    getFeed: (
+      { username, feedKey, ...query }: GetFeedParams,
+      params: RequestParams = {},
+    ) =>
       this.request<GetFeedData, void>({
         path: \`/\${username}/feeds/\${feedKey}\`,
         method: "GET",
@@ -3743,8 +4107,7 @@ export class Api<
      * @secure
      */
     getFeedDetails: (
-      username: string,
-      feedKey: string,
+      { username, feedKey, ...query }: GetFeedDetailsParams,
       params: RequestParams = {},
     ) =>
       this.request<GetFeedDetailsData, void>({
@@ -3765,8 +4128,7 @@ export class Api<
      * @secure
      */
     getGroup: (
-      username: string,
-      groupKey: string,
+      { username, groupKey, ...query }: GetGroupParams,
       params: RequestParams = {},
     ) =>
       this.request<GetGroupData, void>({
@@ -3787,10 +4149,7 @@ export class Api<
      * @secure
      */
     getPermission: (
-      username: string,
-      type: string,
-      typeId: string,
-      id: string,
+      { username, type, typeId, id, ...query }: GetPermissionParams,
       params: RequestParams = {},
     ) =>
       this.request<GetPermissionData, void>({
@@ -3810,7 +4169,10 @@ export class Api<
      * @request GET:/{username}/tokens/{id}
      * @secure
      */
-    getToken: (username: string, id: string, params: RequestParams = {}) =>
+    getToken: (
+      { username, id, ...query }: GetTokenParams,
+      params: RequestParams = {},
+    ) =>
       this.request<GetTokenData, void>({
         path: \`/\${username}/tokens/\${id}\`,
         method: "GET",
@@ -3828,7 +4190,10 @@ export class Api<
      * @request GET:/{username}/triggers/{id}
      * @secure
      */
-    getTrigger: (username: string, id: string, params: RequestParams = {}) =>
+    getTrigger: (
+      { username, id, ...query }: GetTriggerParams,
+      params: RequestParams = {},
+    ) =>
       this.request<GetTriggerData, void>({
         path: \`/\${username}/triggers/\${id}\`,
         method: "GET",
@@ -3938,9 +4303,7 @@ export class Api<
      * @secure
      */
     replaceBlock: (
-      username: string,
-      dashboardId: string,
-      id: string,
+      { username, dashboardId, id, ...query }: ReplaceBlockParams,
       block: ReplaceBlockPayload,
       params: RequestParams = {},
     ) =>
@@ -3964,8 +4327,7 @@ export class Api<
      * @secure
      */
     replaceDashboard: (
-      username: string,
-      id: string,
+      { username, id, ...query }: ReplaceDashboardParams,
       dashboard: ReplaceDashboardPayload,
       params: RequestParams = {},
     ) =>
@@ -3989,9 +4351,7 @@ export class Api<
      * @secure
      */
     replaceData: (
-      username: string,
-      feedKey: string,
-      id: string,
+      { username, feedKey, id, ...query }: ReplaceDataParams,
       datum: ReplaceDataPayload,
       params: RequestParams = {},
     ) =>
@@ -4015,8 +4375,7 @@ export class Api<
      * @secure
      */
     replaceFeed: (
-      username: string,
-      feedKey: string,
+      { username, feedKey, ...query }: ReplaceFeedParams,
       feed: ReplaceFeedPayload,
       params: RequestParams = {},
     ) =>
@@ -4040,8 +4399,7 @@ export class Api<
      * @secure
      */
     replaceGroup: (
-      username: string,
-      groupKey: string,
+      { username, groupKey, ...query }: ReplaceGroupParams,
       group: ReplaceGroupPayload,
       params: RequestParams = {},
     ) =>
@@ -4065,10 +4423,7 @@ export class Api<
      * @secure
      */
     replacePermission: (
-      username: string,
-      type: string,
-      typeId: string,
-      id: string,
+      { username, type, typeId, id, ...query }: ReplacePermissionParams,
       permission: ReplacePermissionPayload,
       params: RequestParams = {},
     ) =>
@@ -4092,8 +4447,7 @@ export class Api<
      * @secure
      */
     replaceToken: (
-      username: string,
-      id: string,
+      { username, id, ...query }: ReplaceTokenParams,
       token: ReplaceTokenPayload,
       params: RequestParams = {},
     ) =>
@@ -4117,8 +4471,7 @@ export class Api<
      * @secure
      */
     replaceTrigger: (
-      username: string,
-      id: string,
+      { username, id, ...query }: ReplaceTriggerParams,
       trigger: ReplaceTriggerPayload,
       params: RequestParams = {},
     ) =>
@@ -4142,8 +4495,7 @@ export class Api<
      * @secure
      */
     retainData: (
-      username: string,
-      feedKey: string,
+      { username, feedKey, ...query }: RetainDataParams,
       params: RequestParams = {},
     ) =>
       this.request<RetainDataData, void>({
@@ -4164,9 +4516,7 @@ export class Api<
      * @secure
      */
     updateBlock: (
-      username: string,
-      dashboardId: string,
-      id: string,
+      { username, dashboardId, id, ...query }: UpdateBlockParams,
       block: UpdateBlockPayload,
       params: RequestParams = {},
     ) =>
@@ -4190,8 +4540,7 @@ export class Api<
      * @secure
      */
     updateDashboard: (
-      username: string,
-      id: string,
+      { username, id, ...query }: UpdateDashboardParams,
       dashboard: UpdateDashboardPayload,
       params: RequestParams = {},
     ) =>
@@ -4215,9 +4564,7 @@ export class Api<
      * @secure
      */
     updateData: (
-      username: string,
-      feedKey: string,
-      id: string,
+      { username, feedKey, id, ...query }: UpdateDataParams,
       datum: UpdateDataPayload,
       params: RequestParams = {},
     ) =>
@@ -4241,8 +4588,7 @@ export class Api<
      * @secure
      */
     updateFeed: (
-      username: string,
-      feedKey: string,
+      { username, feedKey, ...query }: UpdateFeedParams,
       feed: UpdateFeedPayload,
       params: RequestParams = {},
     ) =>
@@ -4266,8 +4612,7 @@ export class Api<
      * @secure
      */
     updateGroup: (
-      username: string,
-      groupKey: string,
+      { username, groupKey, ...query }: UpdateGroupParams,
       group: UpdateGroupPayload,
       params: RequestParams = {},
     ) =>
@@ -4291,10 +4636,7 @@ export class Api<
      * @secure
      */
     updatePermission: (
-      username: string,
-      type: string,
-      typeId: string,
-      id: string,
+      { username, type, typeId, id, ...query }: UpdatePermissionParams,
       permission: UpdatePermissionPayload,
       params: RequestParams = {},
     ) =>
@@ -4318,8 +4660,7 @@ export class Api<
      * @secure
      */
     updateToken: (
-      username: string,
-      id: string,
+      { username, id, ...query }: UpdateTokenParams,
       token: UpdateTokenPayload,
       params: RequestParams = {},
     ) =>
@@ -4343,8 +4684,7 @@ export class Api<
      * @secure
      */
     updateTrigger: (
-      username: string,
-      id: string,
+      { username, id, ...query }: UpdateTriggerParams,
       trigger: UpdateTriggerPayload,
       params: RequestParams = {},
     ) =>
@@ -5324,6 +5664,24 @@ export type CreateUsersWithListInputPayload = User[];
  */
 export type Currency = string;
 
+export interface DeleteOrderParams {
+  /** ID of the order that needs to be deleted */
+  orderId: string;
+}
+
+export interface DeletePetParams {
+  /**
+   * Pet id to delete
+   * @format int64
+   */
+  petId: number;
+}
+
+export interface DeleteUserParams {
+  /** The name that needs to be deleted */
+  username: string;
+}
+
 export type FindPetsByStatusData = Pet[];
 
 export interface FindPetsByStatusParams {
@@ -5365,9 +5723,32 @@ export type GetInventoryData = Record<string, number>;
 
 export type GetOrderByIdData = Order;
 
+export interface GetOrderByIdParams {
+  /**
+   * ID of pet that needs to be fetched
+   * @format int64
+   * @min 1
+   * @max 5
+   */
+  orderId: number;
+}
+
 export type GetPetByIdData = Pet;
 
+export interface GetPetByIdParams {
+  /**
+   * ID of pet to return
+   * @format int64
+   */
+  petId: number;
+}
+
 export type GetUserByNameData = User;
+
+export interface GetUserByNameParams {
+  /** The name that needs to be fetched. Use user1 for testing. */
+  username: string;
+}
 
 export type LoginUserData = string;
 
@@ -5479,6 +5860,14 @@ export interface Tag {
   name?: string;
 }
 
+export interface UpdatePetWithFormParams {
+  /**
+   * ID of pet that needs to be updated
+   * @format int64
+   */
+  petId: number;
+}
+
 export interface UpdatePetWithFormPayload {
   /** Updated name of the pet */
   name?: string;
@@ -5486,7 +5875,20 @@ export interface UpdatePetWithFormPayload {
   status?: string;
 }
 
+export interface UpdateUserParams {
+  /** name that need to be deleted */
+  username: string;
+}
+
 export type UploadFileData = ApiResponse;
+
+export interface UploadFileParams {
+  /**
+   * ID of pet to update
+   * @format int64
+   */
+  petId: number;
+}
 
 export interface UploadFilePayload {
   /** Additional data to pass to server */
@@ -6233,7 +6635,10 @@ export class Api<
      * @request DELETE:/pet/{petId}
      * @secure
      */
-    deletePet: (petId: number, params: RequestParams = {}) =>
+    deletePet: (
+      { petId, ...query }: DeletePetParams,
+      params: RequestParams = {},
+    ) =>
       this.request<any, void>({
         path: \`/pet/\${petId}\`,
         method: "DELETE",
@@ -6334,7 +6739,10 @@ export class Api<
      * @request GET:/pet/{petId}
      * @secure
      */
-    getPetById: (petId: number, params: RequestParams = {}) =>
+    getPetById: (
+      { petId, ...query }: GetPetByIdParams,
+      params: RequestParams = {},
+    ) =>
       this.request<GetPetByIdData, void>({
         path: \`/pet/\${petId}\`,
         method: "GET",
@@ -6392,7 +6800,7 @@ export class Api<
      * @secure
      */
     updatePetWithForm: (
-      petId: number,
+      { petId, ...query }: UpdatePetWithFormParams,
       data: UpdatePetWithFormPayload,
       params: RequestParams = {},
     ) =>
@@ -6415,7 +6823,7 @@ export class Api<
      * @secure
      */
     uploadFile: (
-      petId: number,
+      { petId, ...query }: UploadFileParams,
       data: UploadFilePayload,
       params: RequestParams = {},
     ) =>
@@ -6438,7 +6846,10 @@ export class Api<
      * @summary Delete purchase order by ID
      * @request DELETE:/store/order/{orderId}
      */
-    deleteOrder: (orderId: string, params: RequestParams = {}) =>
+    deleteOrder: (
+      { orderId, ...query }: DeleteOrderParams,
+      params: RequestParams = {},
+    ) =>
       this.request<any, void>({
         path: \`/store/order/\${orderId}\`,
         method: "DELETE",
@@ -6471,7 +6882,10 @@ export class Api<
      * @summary Find purchase order by ID
      * @request GET:/store/order/{orderId}
      */
-    getOrderById: (orderId: number, params: RequestParams = {}) =>
+    getOrderById: (
+      { orderId, ...query }: GetOrderByIdParams,
+      params: RequestParams = {},
+    ) =>
       this.request<GetOrderByIdData, void>({
         path: \`/store/order/\${orderId}\`,
         method: "GET",
@@ -6563,7 +6977,10 @@ export class Api<
      * @summary Delete user
      * @request DELETE:/user/{username}
      */
-    deleteUser: (username: string, params: RequestParams = {}) =>
+    deleteUser: (
+      { username, ...query }: DeleteUserParams,
+      params: RequestParams = {},
+    ) =>
       this.request<any, void>({
         path: \`/user/\${username}\`,
         method: "DELETE",
@@ -6578,7 +6995,10 @@ export class Api<
      * @summary Get user by user name
      * @request GET:/user/{username}
      */
-    getUserByName: (username: string, params: RequestParams = {}) =>
+    getUserByName: (
+      { username, ...query }: GetUserByNameParams,
+      params: RequestParams = {},
+    ) =>
       this.request<GetUserByNameData, void>({
         path: \`/user/\${username}\`,
         method: "GET",
@@ -6626,7 +7046,11 @@ export class Api<
      * @summary Updated user
      * @request PUT:/user/{username}
      */
-    updateUser: (username: string, body: User, params: RequestParams = {}) =>
+    updateUser: (
+      { username, ...query }: UpdateUserParams,
+      body: User,
+      params: RequestParams = {},
+    ) =>
       this.request<any, void>({
         path: \`/user/\${username}\`,
         method: "PUT",
@@ -8159,9 +8583,19 @@ export interface GetKeyData {
 
 export type GetKeyError = Error;
 
+export interface GetKeyParams {
+  /** Public Signing Key - Authentiq ID (43 chars) */
+  pk: string;
+}
+
 export type HeadKeyData = any;
 
 export type HeadKeyError = Error;
+
+export interface HeadKeyParams {
+  /** Public Signing Key - Authentiq ID (43 chars) */
+  pk: string;
+}
 
 export interface KeyBindData {
   /** confirmed */
@@ -8169,6 +8603,11 @@ export interface KeyBindData {
 }
 
 export type KeyBindError = Error;
+
+export interface KeyBindParams {
+  /** Public Signing Key - Authentiq ID (43 chars) */
+  pk: string;
+}
 
 export interface KeyRegisterData {
   /** revoke key */
@@ -8216,6 +8655,11 @@ export interface KeyUpdateData {
 
 export type KeyUpdateError = Error;
 
+export interface KeyUpdateParams {
+  /** Public Signing Key - Authentiq ID (43 chars) */
+  pk: string;
+}
+
 export interface PushLoginRequestData {
   /** sent */
   status?: string;
@@ -8248,12 +8692,22 @@ export interface SignConfirmData {
 
 export type SignConfirmError = Error;
 
+export interface SignConfirmParams {
+  /** Job ID (20 chars) */
+  job: string;
+}
+
 export interface SignDeleteData {
   /** done */
   status?: string;
 }
 
 export type SignDeleteError = Error;
+
+export interface SignDeleteParams {
+  /** Job ID (20 chars) */
+  job: string;
+}
 
 export interface SignRequestData {
   /** 20-character ID */
@@ -8283,6 +8737,16 @@ export type SignRetrieveHeadData = any;
 
 export type SignRetrieveHeadError = Error;
 
+export interface SignRetrieveHeadParams {
+  /** Job ID (20 chars) */
+  job: string;
+}
+
+export interface SignRetrieveParams {
+  /** Job ID (20 chars) */
+  job: string;
+}
+
 export interface SignUpdateData {
   /** result is JWT or JSON?? */
   jwt?: string;
@@ -8292,9 +8756,26 @@ export interface SignUpdateData {
 
 export type SignUpdateError = Error;
 
+export interface SignUpdateParams {
+  /** Job ID (20 chars) */
+  job: string;
+}
+
 export type WrongPathParams1Data = any;
 
+export interface WrongPathParams1Params {
+  pathParam1: string;
+  pathParam2: string;
+  pathParam3: string;
+  pathParam4: string;
+}
+
 export type WrongPathParams2Data = any;
+
+export interface WrongPathParams2Params {
+  /** DDD */
+  pathParam1: string;
+}
 
 export namespace WrongPathParams1 {
   /**
@@ -8860,10 +9341,13 @@ export class Api<
      * @request DELETE:/wrong-path-params1/{pathParam1}/{path_param2}/{path_param3}/:pathParam4
      */
     wrongPathParams1: (
-      pathParam1: string,
-      pathParam2: string,
-      pathParam3: string,
-      pathParam4: string,
+      {
+        pathParam1,
+        pathParam2,
+        pathParam3,
+        pathParam4,
+        ...query
+      }: WrongPathParams1Params,
       params: RequestParams = {},
     ) =>
       this.request<WrongPathParams1Data, any>({
@@ -8880,7 +9364,10 @@ export class Api<
      * @name WrongPathParams2
      * @request DELETE:/wrong-path-params2
      */
-    wrongPathParams2: (pathParam1: string, params: RequestParams = {}) =>
+    wrongPathParams2: (
+      { pathParam1, ...query }: WrongPathParams2Params,
+      params: RequestParams = {},
+    ) =>
       this.request<WrongPathParams2Data, any>({
         path: \`/wrong-path-params2\`,
         method: "DELETE",
@@ -8895,7 +9382,7 @@ export class Api<
      * @name GetKey
      * @request GET:/key/{PK}
      */
-    getKey: (pk: string, params: RequestParams = {}) =>
+    getKey: ({ pk, ...query }: GetKeyParams, params: RequestParams = {}) =>
       this.request<GetKeyData, GetKeyError>({
         path: \`/key/\${pk}\`,
         method: "GET",
@@ -8910,7 +9397,7 @@ export class Api<
      * @name HeadKey
      * @request HEAD:/key/{PK}
      */
-    headKey: (pk: string, params: RequestParams = {}) =>
+    headKey: ({ pk, ...query }: HeadKeyParams, params: RequestParams = {}) =>
       this.request<HeadKeyData, HeadKeyError>({
         path: \`/key/\${pk}\`,
         method: "HEAD",
@@ -8924,7 +9411,11 @@ export class Api<
      * @name KeyBind
      * @request PUT:/key/{PK}
      */
-    keyBind: (pk: string, body: AuthentiqID, params: RequestParams = {}) =>
+    keyBind: (
+      { pk, ...query }: KeyBindParams,
+      body: AuthentiqID,
+      params: RequestParams = {},
+    ) =>
       this.request<KeyBindData, KeyBindError>({
         path: \`/key/\${pk}\`,
         method: "PUT",
@@ -8994,7 +9485,11 @@ export class Api<
      * @name KeyUpdate
      * @request POST:/key/{PK}
      */
-    keyUpdate: (pk: string, body: AuthentiqID, params: RequestParams = {}) =>
+    keyUpdate: (
+      { pk, ...query }: KeyUpdateParams,
+      body: AuthentiqID,
+      params: RequestParams = {},
+    ) =>
       this.request<KeyUpdateData, KeyUpdateError>({
         path: \`/key/\${pk}\`,
         method: "POST",
@@ -9033,7 +9528,10 @@ export class Api<
      * @name SignConfirm
      * @request POST:/scope/{job}
      */
-    signConfirm: (job: string, params: RequestParams = {}) =>
+    signConfirm: (
+      { job, ...query }: SignConfirmParams,
+      params: RequestParams = {},
+    ) =>
       this.request<SignConfirmData, SignConfirmError>({
         path: \`/scope/\${job}\`,
         method: "POST",
@@ -9049,7 +9547,10 @@ export class Api<
      * @name SignDelete
      * @request DELETE:/scope/{job}
      */
-    signDelete: (job: string, params: RequestParams = {}) =>
+    signDelete: (
+      { job, ...query }: SignDeleteParams,
+      params: RequestParams = {},
+    ) =>
       this.request<SignDeleteData, SignDeleteError>({
         path: \`/scope/\${job}\`,
         method: "DELETE",
@@ -9085,7 +9586,10 @@ export class Api<
      * @name SignRetrieve
      * @request GET:/scope/{job}
      */
-    signRetrieve: (job: string, params: RequestParams = {}) =>
+    signRetrieve: (
+      { job, ...query }: SignRetrieveParams,
+      params: RequestParams = {},
+    ) =>
       this.request<SignRetrieveData, SignRetrieveError>({
         path: \`/scope/\${job}\`,
         method: "GET",
@@ -9100,7 +9604,10 @@ export class Api<
      * @name SignRetrieveHead
      * @request HEAD:/scope/{job}
      */
-    signRetrieveHead: (job: string, params: RequestParams = {}) =>
+    signRetrieveHead: (
+      { job, ...query }: SignRetrieveHeadParams,
+      params: RequestParams = {},
+    ) =>
       this.request<SignRetrieveHeadData, SignRetrieveHeadError>({
         path: \`/scope/\${job}\`,
         method: "HEAD",
@@ -9114,7 +9621,10 @@ export class Api<
      * @name SignUpdate
      * @request PUT:/scope/{job}
      */
-    signUpdate: (job: string, params: RequestParams = {}) =>
+    signUpdate: (
+      { job, ...query }: SignUpdateParams,
+      params: RequestParams = {},
+    ) =>
       this.request<SignUpdateData, SignUpdateError>({
         path: \`/scope/\${job}\`,
         method: "PUT",
@@ -10517,6 +11027,10 @@ exports[`extended > 'explode-param-3' 1`] = `
 
 export type CreateFileData = Floop;
 
+export interface CreateFileParams {
+  user: string;
+}
+
 export interface CreateFilePayload {
   /** @default "" */
   meme: string;
@@ -10853,7 +11367,7 @@ export class Api<
      * @request POST:/{user}/foos
      */
     createFile: (
-      user: string,
+      { user, ...query }: CreateFileParams,
       data: CreateFilePayload,
       params: RequestParams = {},
     ) =>
@@ -11225,9 +11739,31 @@ exports[`extended > 'full-swagger-scheme' 1`] = `
 
 export type ActionsAddRepoAccessToSelfHostedRunnerGroupInOrgData = any;
 
+export interface ActionsAddRepoAccessToSelfHostedRunnerGroupInOrgParams {
+  org: string;
+  repositoryId: number;
+  /** Unique identifier of the self-hosted runner group. */
+  runnerGroupId: number;
+}
+
 export type ActionsAddSelectedRepoToOrgSecretData = any;
 
+export interface ActionsAddSelectedRepoToOrgSecretParams {
+  org: string;
+  repositoryId: number;
+  /** secret_name parameter */
+  secretName: string;
+}
+
 export type ActionsAddSelfHostedRunnerToGroupForOrgData = any;
+
+export interface ActionsAddSelfHostedRunnerToGroupForOrgParams {
+  org: string;
+  /** Unique identifier of the self-hosted runner group. */
+  runnerGroupId: number;
+  /** Unique identifier of the self-hosted runner. */
+  runnerId: number;
+}
 
 export interface ActionsBillingUsage {
   /** The amount of free GitHub Actions minutes available. */
@@ -11248,7 +11784,19 @@ export interface ActionsBillingUsage {
 
 export type ActionsCancelWorkflowRunData = any;
 
+export interface ActionsCancelWorkflowRunParams {
+  owner: string;
+  repo: string;
+  runId: number;
+}
+
 export type ActionsCreateOrUpdateOrgSecretData = any;
+
+export interface ActionsCreateOrUpdateOrgSecretParams {
+  org: string;
+  /** secret_name parameter */
+  secretName: string;
+}
 
 export interface ActionsCreateOrUpdateOrgSecretPayload {
   /** Value for your secret, encrypted with [LibSodium](https://libsodium.gitbook.io/doc/bindings_for_other_languages) using the public key retrieved from the [Get an organization public key](https://docs.github.com/rest/reference/actions#get-an-organization-public-key) endpoint. */
@@ -11280,6 +11828,13 @@ export enum ActionsCreateOrUpdateOrgSecretVisibilityEnum {
 
 export type ActionsCreateOrUpdateRepoSecretData = any;
 
+export interface ActionsCreateOrUpdateRepoSecretParams {
+  owner: string;
+  repo: string;
+  /** secret_name parameter */
+  secretName: string;
+}
+
 export interface ActionsCreateOrUpdateRepoSecretPayload {
   /** Value for your secret, encrypted with [LibSodium](https://libsodium.gitbook.io/doc/bindings_for_other_languages) using the public key retrieved from the [Get a repository public key](https://docs.github.com/rest/reference/actions#get-a-repository-public-key) endpoint. */
   encrypted_value?: string;
@@ -11289,13 +11844,35 @@ export interface ActionsCreateOrUpdateRepoSecretPayload {
 
 export type ActionsCreateRegistrationTokenForOrgData = AuthenticationToken;
 
+export interface ActionsCreateRegistrationTokenForOrgParams {
+  org: string;
+}
+
 export type ActionsCreateRegistrationTokenForRepoData = AuthenticationToken;
+
+export interface ActionsCreateRegistrationTokenForRepoParams {
+  owner: string;
+  repo: string;
+}
 
 export type ActionsCreateRemoveTokenForOrgData = AuthenticationToken;
 
+export interface ActionsCreateRemoveTokenForOrgParams {
+  org: string;
+}
+
 export type ActionsCreateRemoveTokenForRepoData = AuthenticationToken;
 
+export interface ActionsCreateRemoveTokenForRepoParams {
+  owner: string;
+  repo: string;
+}
+
 export type ActionsCreateSelfHostedRunnerGroupForOrgData = RunnerGroupsOrg;
+
+export interface ActionsCreateSelfHostedRunnerGroupForOrgParams {
+  org: string;
+}
 
 export interface ActionsCreateSelfHostedRunnerGroupForOrgPayload {
   /** Name of the runner group. */
@@ -11323,6 +11900,13 @@ export enum ActionsCreateSelfHostedRunnerGroupForOrgVisibilityEnum {
 
 export type ActionsCreateWorkflowDispatchData = any;
 
+export interface ActionsCreateWorkflowDispatchParams {
+  owner: string;
+  repo: string;
+  /** The ID of the workflow. You can also pass the workflow file name as a string. */
+  workflowId: number | string;
+}
+
 export interface ActionsCreateWorkflowDispatchPayload {
   /** Input keys and values configured in the workflow file. The maximum number of properties is 10. Any default properties configured in the workflow file will be used when \`inputs\` are omitted. */
   inputs?: Record<string, string>;
@@ -11332,27 +11916,123 @@ export interface ActionsCreateWorkflowDispatchPayload {
 
 export type ActionsDeleteArtifactData = any;
 
+export interface ActionsDeleteArtifactParams {
+  /** artifact_id parameter */
+  artifactId: number;
+  owner: string;
+  repo: string;
+}
+
 export type ActionsDeleteOrgSecretData = any;
+
+export interface ActionsDeleteOrgSecretParams {
+  org: string;
+  /** secret_name parameter */
+  secretName: string;
+}
 
 export type ActionsDeleteRepoSecretData = any;
 
+export interface ActionsDeleteRepoSecretParams {
+  owner: string;
+  repo: string;
+  /** secret_name parameter */
+  secretName: string;
+}
+
 export type ActionsDeleteSelfHostedRunnerFromOrgData = any;
+
+export interface ActionsDeleteSelfHostedRunnerFromOrgParams {
+  org: string;
+  /** Unique identifier of the self-hosted runner. */
+  runnerId: number;
+}
 
 export type ActionsDeleteSelfHostedRunnerFromRepoData = any;
 
+export interface ActionsDeleteSelfHostedRunnerFromRepoParams {
+  owner: string;
+  repo: string;
+  /** Unique identifier of the self-hosted runner. */
+  runnerId: number;
+}
+
 export type ActionsDeleteSelfHostedRunnerGroupFromOrgData = any;
+
+export interface ActionsDeleteSelfHostedRunnerGroupFromOrgParams {
+  org: string;
+  /** Unique identifier of the self-hosted runner group. */
+  runnerGroupId: number;
+}
 
 export type ActionsDeleteWorkflowRunData = any;
 
 export type ActionsDeleteWorkflowRunLogsData = any;
 
+export interface ActionsDeleteWorkflowRunLogsParams {
+  owner: string;
+  repo: string;
+  runId: number;
+}
+
+export interface ActionsDeleteWorkflowRunParams {
+  owner: string;
+  repo: string;
+  runId: number;
+}
+
 export type ActionsDisableSelectedRepositoryGithubActionsOrganizationData = any;
+
+export interface ActionsDisableSelectedRepositoryGithubActionsOrganizationParams {
+  org: string;
+  repositoryId: number;
+}
 
 export type ActionsDisableWorkflowData = any;
 
+export interface ActionsDisableWorkflowParams {
+  owner: string;
+  repo: string;
+  /** The ID of the workflow. You can also pass the workflow file name as a string. */
+  workflowId: number | string;
+}
+
+export interface ActionsDownloadArtifactParams {
+  archiveFormat: string;
+  /** artifact_id parameter */
+  artifactId: number;
+  owner: string;
+  repo: string;
+}
+
+export interface ActionsDownloadJobLogsForWorkflowRunParams {
+  /** job_id parameter */
+  jobId: number;
+  owner: string;
+  repo: string;
+}
+
+export interface ActionsDownloadWorkflowRunLogsParams {
+  owner: string;
+  repo: string;
+  runId: number;
+}
+
 export type ActionsEnableSelectedRepositoryGithubActionsOrganizationData = any;
 
+export interface ActionsEnableSelectedRepositoryGithubActionsOrganizationParams {
+  org: string;
+  repositoryId: number;
+}
+
 export type ActionsEnableWorkflowData = any;
+
+export interface ActionsEnableWorkflowParams {
+  owner: string;
+  repo: string;
+  /** The ID of the workflow. You can also pass the workflow file name as a string. */
+  workflowId: number | string;
+}
 
 /** Whether GitHub Actions is enabled on the repository. */
 export type ActionsEnabled = boolean;
@@ -11370,39 +12050,138 @@ export interface ActionsEnterprisePermissions {
 
 export type ActionsGetAllowedActionsOrganizationData = SelectedActions;
 
+export interface ActionsGetAllowedActionsOrganizationParams {
+  org: string;
+}
+
 export type ActionsGetAllowedActionsRepositoryData = SelectedActions;
 
+export interface ActionsGetAllowedActionsRepositoryParams {
+  owner: string;
+  repo: string;
+}
+
 export type ActionsGetArtifactData = Artifact;
+
+export interface ActionsGetArtifactParams {
+  /** artifact_id parameter */
+  artifactId: number;
+  owner: string;
+  repo: string;
+}
 
 export type ActionsGetGithubActionsPermissionsOrganizationData =
   ActionsOrganizationPermissions;
 
+export interface ActionsGetGithubActionsPermissionsOrganizationParams {
+  org: string;
+}
+
 export type ActionsGetGithubActionsPermissionsRepositoryData =
   ActionsRepositoryPermissions;
 
+export interface ActionsGetGithubActionsPermissionsRepositoryParams {
+  owner: string;
+  repo: string;
+}
+
 export type ActionsGetJobForWorkflowRunData = Job;
+
+export interface ActionsGetJobForWorkflowRunParams {
+  /** job_id parameter */
+  jobId: number;
+  owner: string;
+  repo: string;
+}
 
 export type ActionsGetOrgPublicKeyData = ActionsPublicKey;
 
+export interface ActionsGetOrgPublicKeyParams {
+  org: string;
+}
+
 export type ActionsGetOrgSecretData = OrganizationActionsSecret;
+
+export interface ActionsGetOrgSecretParams {
+  org: string;
+  /** secret_name parameter */
+  secretName: string;
+}
 
 export type ActionsGetRepoPublicKeyData = ActionsPublicKey;
 
+export interface ActionsGetRepoPublicKeyParams {
+  owner: string;
+  repo: string;
+}
+
 export type ActionsGetRepoSecretData = ActionsSecret;
+
+export interface ActionsGetRepoSecretParams {
+  owner: string;
+  repo: string;
+  /** secret_name parameter */
+  secretName: string;
+}
 
 export type ActionsGetSelfHostedRunnerForOrgData = Runner;
 
+export interface ActionsGetSelfHostedRunnerForOrgParams {
+  org: string;
+  /** Unique identifier of the self-hosted runner. */
+  runnerId: number;
+}
+
 export type ActionsGetSelfHostedRunnerForRepoData = Runner;
+
+export interface ActionsGetSelfHostedRunnerForRepoParams {
+  owner: string;
+  repo: string;
+  /** Unique identifier of the self-hosted runner. */
+  runnerId: number;
+}
 
 export type ActionsGetSelfHostedRunnerGroupForOrgData = RunnerGroupsOrg;
 
+export interface ActionsGetSelfHostedRunnerGroupForOrgParams {
+  org: string;
+  /** Unique identifier of the self-hosted runner group. */
+  runnerGroupId: number;
+}
+
 export type ActionsGetWorkflowData = Workflow;
+
+export interface ActionsGetWorkflowParams {
+  owner: string;
+  repo: string;
+  /** The ID of the workflow. You can also pass the workflow file name as a string. */
+  workflowId: number | string;
+}
 
 export type ActionsGetWorkflowRunData = WorkflowRun;
 
+export interface ActionsGetWorkflowRunParams {
+  owner: string;
+  repo: string;
+  runId: number;
+}
+
 export type ActionsGetWorkflowRunUsageData = WorkflowRunUsage;
 
+export interface ActionsGetWorkflowRunUsageParams {
+  owner: string;
+  repo: string;
+  runId: number;
+}
+
 export type ActionsGetWorkflowUsageData = WorkflowUsage;
+
+export interface ActionsGetWorkflowUsageParams {
+  owner: string;
+  repo: string;
+  /** The ID of the workflow. You can also pass the workflow file name as a string. */
+  workflowId: number | string;
+}
 
 export interface ActionsListArtifactsForRepoData {
   artifacts: Artifact[];
@@ -11487,6 +12266,12 @@ export interface ActionsListRepoAccessToSelfHostedRunnerGroupInOrgData {
   total_count: number;
 }
 
+export interface ActionsListRepoAccessToSelfHostedRunnerGroupInOrgParams {
+  org: string;
+  /** Unique identifier of the self-hosted runner group. */
+  runnerGroupId: number;
+}
+
 export interface ActionsListRepoSecretsData {
   secrets: ActionsSecret[];
   total_count: number;
@@ -11529,11 +12314,26 @@ export interface ActionsListRepoWorkflowsParams {
 
 export type ActionsListRunnerApplicationsForOrgData = RunnerApplication[];
 
+export interface ActionsListRunnerApplicationsForOrgParams {
+  org: string;
+}
+
 export type ActionsListRunnerApplicationsForRepoData = RunnerApplication[];
+
+export interface ActionsListRunnerApplicationsForRepoParams {
+  owner: string;
+  repo: string;
+}
 
 export interface ActionsListSelectedReposForOrgSecretData {
   repositories: MinimalRepository[];
   total_count: number;
+}
+
+export interface ActionsListSelectedReposForOrgSecretParams {
+  org: string;
+  /** secret_name parameter */
+  secretName: string;
 }
 
 export interface ActionsListSelectedRepositoriesEnabledGithubActionsOrganizationData {
@@ -11765,11 +12565,39 @@ export interface ActionsPublicKey {
 
 export type ActionsReRunWorkflowData = any;
 
+export interface ActionsReRunWorkflowParams {
+  owner: string;
+  repo: string;
+  runId: number;
+}
+
 export type ActionsRemoveRepoAccessToSelfHostedRunnerGroupInOrgData = any;
+
+export interface ActionsRemoveRepoAccessToSelfHostedRunnerGroupInOrgParams {
+  org: string;
+  repositoryId: number;
+  /** Unique identifier of the self-hosted runner group. */
+  runnerGroupId: number;
+}
 
 export type ActionsRemoveSelectedRepoFromOrgSecretData = any;
 
+export interface ActionsRemoveSelectedRepoFromOrgSecretParams {
+  org: string;
+  repositoryId: number;
+  /** secret_name parameter */
+  secretName: string;
+}
+
 export type ActionsRemoveSelfHostedRunnerFromGroupForOrgData = any;
+
+export interface ActionsRemoveSelfHostedRunnerFromGroupForOrgParams {
+  org: string;
+  /** Unique identifier of the self-hosted runner group. */
+  runnerGroupId: number;
+  /** Unique identifier of the self-hosted runner. */
+  runnerId: number;
+}
 
 export interface ActionsRepositoryPermissions {
   /** The permissions policy that controls the actions that are allowed to run. Can be one of: \`all\`, \`local_only\`, or \`selected\`. */
@@ -11798,9 +12626,22 @@ export interface ActionsSecret {
 
 export type ActionsSetAllowedActionsOrganizationData = any;
 
+export interface ActionsSetAllowedActionsOrganizationParams {
+  org: string;
+}
+
 export type ActionsSetAllowedActionsRepositoryData = any;
 
+export interface ActionsSetAllowedActionsRepositoryParams {
+  owner: string;
+  repo: string;
+}
+
 export type ActionsSetGithubActionsPermissionsOrganizationData = any;
+
+export interface ActionsSetGithubActionsPermissionsOrganizationParams {
+  org: string;
+}
 
 export interface ActionsSetGithubActionsPermissionsOrganizationPayload {
   /** The permissions policy that controls the actions that are allowed to run. Can be one of: \`all\`, \`local_only\`, or \`selected\`. */
@@ -11811,6 +12652,11 @@ export interface ActionsSetGithubActionsPermissionsOrganizationPayload {
 
 export type ActionsSetGithubActionsPermissionsRepositoryData = any;
 
+export interface ActionsSetGithubActionsPermissionsRepositoryParams {
+  owner: string;
+  repo: string;
+}
+
 export interface ActionsSetGithubActionsPermissionsRepositoryPayload {
   /** The permissions policy that controls the actions that are allowed to run. Can be one of: \`all\`, \`local_only\`, or \`selected\`. */
   allowed_actions?: AllowedActions;
@@ -11820,12 +12666,24 @@ export interface ActionsSetGithubActionsPermissionsRepositoryPayload {
 
 export type ActionsSetRepoAccessToSelfHostedRunnerGroupInOrgData = any;
 
+export interface ActionsSetRepoAccessToSelfHostedRunnerGroupInOrgParams {
+  org: string;
+  /** Unique identifier of the self-hosted runner group. */
+  runnerGroupId: number;
+}
+
 export interface ActionsSetRepoAccessToSelfHostedRunnerGroupInOrgPayload {
   /** List of repository IDs that can access the runner group. */
   selected_repository_ids: number[];
 }
 
 export type ActionsSetSelectedReposForOrgSecretData = any;
+
+export interface ActionsSetSelectedReposForOrgSecretParams {
+  org: string;
+  /** secret_name parameter */
+  secretName: string;
+}
 
 export interface ActionsSetSelectedReposForOrgSecretPayload {
   /** An array of repository ids that can access the organization secret. You can only provide a list of repository ids when the \`visibility\` is set to \`selected\`. You can add and remove individual repositories using the [Set selected repositories for an organization secret](https://docs.github.com/rest/reference/actions#set-selected-repositories-for-an-organization-secret) and [Remove selected repository from an organization secret](https://docs.github.com/rest/reference/actions#remove-selected-repository-from-an-organization-secret) endpoints. */
@@ -11835,6 +12693,10 @@ export interface ActionsSetSelectedReposForOrgSecretPayload {
 export type ActionsSetSelectedRepositoriesEnabledGithubActionsOrganizationData =
   any;
 
+export interface ActionsSetSelectedRepositoriesEnabledGithubActionsOrganizationParams {
+  org: string;
+}
+
 export interface ActionsSetSelectedRepositoriesEnabledGithubActionsOrganizationPayload {
   /** List of repository IDs to enable for GitHub Actions. */
   selected_repository_ids: number[];
@@ -11842,12 +12704,24 @@ export interface ActionsSetSelectedRepositoriesEnabledGithubActionsOrganizationP
 
 export type ActionsSetSelfHostedRunnersInGroupForOrgData = any;
 
+export interface ActionsSetSelfHostedRunnersInGroupForOrgParams {
+  org: string;
+  /** Unique identifier of the self-hosted runner group. */
+  runnerGroupId: number;
+}
+
 export interface ActionsSetSelfHostedRunnersInGroupForOrgPayload {
   /** List of runner IDs to add to the runner group. */
   runners: number[];
 }
 
 export type ActionsUpdateSelfHostedRunnerGroupForOrgData = RunnerGroupsOrg;
+
+export interface ActionsUpdateSelfHostedRunnerGroupForOrgParams {
+  org: string;
+  /** Unique identifier of the self-hosted runner group. */
+  runnerGroupId: number;
+}
 
 export interface ActionsUpdateSelfHostedRunnerGroupForOrgPayload {
   /** Name of the runner group. */
@@ -11867,18 +12741,48 @@ export type ActivityCheckRepoIsStarredByAuthenticatedUserData = any;
 
 export type ActivityCheckRepoIsStarredByAuthenticatedUserError = BasicError;
 
+export interface ActivityCheckRepoIsStarredByAuthenticatedUserParams {
+  owner: string;
+  repo: string;
+}
+
 export type ActivityDeleteRepoSubscriptionData = any;
 
+export interface ActivityDeleteRepoSubscriptionParams {
+  owner: string;
+  repo: string;
+}
+
 export type ActivityDeleteThreadSubscriptionData = any;
+
+export interface ActivityDeleteThreadSubscriptionParams {
+  /** thread_id parameter */
+  threadId: number;
+}
 
 export type ActivityGetFeedsData = Feed;
 
 export type ActivityGetRepoSubscriptionData = RepositorySubscription;
 
+export interface ActivityGetRepoSubscriptionParams {
+  owner: string;
+  repo: string;
+}
+
 export type ActivityGetThreadData = Thread;
+
+export interface ActivityGetThreadParams {
+  /** thread_id parameter */
+  threadId: number;
+}
 
 export type ActivityGetThreadSubscriptionForAuthenticatedUserData =
   ThreadSubscription;
+
+export interface ActivityGetThreadSubscriptionForAuthenticatedUserParams {
+  /** thread_id parameter */
+  threadId: number;
+}
 
 export type ActivityListEventsForAuthenticatedUserData = Event[];
 
@@ -12255,6 +13159,11 @@ export interface ActivityMarkNotificationsAsReadPayload {
 
 export type ActivityMarkRepoNotificationsAsReadData = any;
 
+export interface ActivityMarkRepoNotificationsAsReadParams {
+  owner: string;
+  repo: string;
+}
+
 export interface ActivityMarkRepoNotificationsAsReadPayload {
   /** Describes the last point that notifications were checked. Anything updated since this time will not be marked as read. If you omit this parameter, all notifications are marked as read. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: \`YYYY-MM-DDTHH:MM:SSZ\`. Default: The current timestamp. */
   last_read_at?: string;
@@ -12262,7 +13171,17 @@ export interface ActivityMarkRepoNotificationsAsReadPayload {
 
 export type ActivityMarkThreadAsReadData = any;
 
+export interface ActivityMarkThreadAsReadParams {
+  /** thread_id parameter */
+  threadId: number;
+}
+
 export type ActivitySetRepoSubscriptionData = RepositorySubscription;
+
+export interface ActivitySetRepoSubscriptionParams {
+  owner: string;
+  repo: string;
+}
 
 export interface ActivitySetRepoSubscriptionPayload {
   /** Determines if all notifications should be blocked from this repository. */
@@ -12272,6 +13191,11 @@ export interface ActivitySetRepoSubscriptionPayload {
 }
 
 export type ActivitySetThreadSubscriptionData = ThreadSubscription;
+
+export interface ActivitySetThreadSubscriptionParams {
+  /** thread_id parameter */
+  threadId: number;
+}
 
 export interface ActivitySetThreadSubscriptionPayload {
   /**
@@ -12283,7 +13207,17 @@ export interface ActivitySetThreadSubscriptionPayload {
 
 export type ActivityStarRepoForAuthenticatedUserData = any;
 
+export interface ActivityStarRepoForAuthenticatedUserParams {
+  owner: string;
+  repo: string;
+}
+
 export type ActivityUnstarRepoForAuthenticatedUserData = any;
+
+export interface ActivityUnstarRepoForAuthenticatedUserParams {
+  owner: string;
+  repo: string;
+}
 
 /**
  * Actor
@@ -12663,9 +13597,26 @@ export interface ApplicationGrant {
 
 export type AppsAddRepoToInstallationData = any;
 
+export interface AppsAddRepoToInstallationParams {
+  /** installation_id parameter */
+  installationId: number;
+  repositoryId: number;
+}
+
 export type AppsCheckAuthorizationData = Authorization | null;
 
+export interface AppsCheckAuthorizationParams {
+  accessToken: string;
+  /** The client ID of your GitHub app. */
+  clientId: string;
+}
+
 export type AppsCheckTokenData = Authorization;
+
+export interface AppsCheckTokenParams {
+  /** The client ID of your GitHub app. */
+  clientId: string;
+}
 
 export interface AppsCheckTokenPayload {
   /** The access_token of the OAuth application. */
@@ -12673,6 +13624,10 @@ export interface AppsCheckTokenPayload {
 }
 
 export type AppsCreateContentAttachmentData = ContentReferenceAttachment;
+
+export interface AppsCreateContentAttachmentParams {
+  contentReferenceId: number;
+}
 
 export interface AppsCreateContentAttachmentPayload {
   /**
@@ -12697,7 +13652,16 @@ export type AppsCreateFromManifestData = Integration & {
   [key: string]: any;
 };
 
+export interface AppsCreateFromManifestParams {
+  code: string;
+}
+
 export type AppsCreateInstallationAccessTokenData = InstallationToken;
+
+export interface AppsCreateInstallationAccessTokenParams {
+  /** installation_id parameter */
+  installationId: number;
+}
 
 export interface AppsCreateInstallationAccessTokenPayload {
   /** The permissions granted to the user-to-server access token. */
@@ -12713,6 +13677,11 @@ export interface AppsCreateInstallationAccessTokenPayload {
 
 export type AppsDeleteAuthorizationData = any;
 
+export interface AppsDeleteAuthorizationParams {
+  /** The client ID of your GitHub app. */
+  clientId: string;
+}
+
 export interface AppsDeleteAuthorizationPayload {
   /** The OAuth access token used to authenticate to the GitHub API. */
   access_token?: string;
@@ -12720,7 +13689,17 @@ export interface AppsDeleteAuthorizationPayload {
 
 export type AppsDeleteInstallationData = any;
 
+export interface AppsDeleteInstallationParams {
+  /** installation_id parameter */
+  installationId: number;
+}
+
 export type AppsDeleteTokenData = any;
+
+export interface AppsDeleteTokenParams {
+  /** The client ID of your GitHub app. */
+  clientId: string;
+}
 
 export interface AppsDeleteTokenPayload {
   /** The OAuth access token used to authenticate to the GitHub API. */
@@ -12731,19 +13710,51 @@ export type AppsGetAuthenticatedData = Integration;
 
 export type AppsGetBySlugData = Integration;
 
+export interface AppsGetBySlugParams {
+  appSlug: string;
+}
+
 export type AppsGetInstallationData = Installation;
+
+export interface AppsGetInstallationParams {
+  /** installation_id parameter */
+  installationId: number;
+}
 
 export type AppsGetOrgInstallationData = Installation;
 
+export interface AppsGetOrgInstallationParams {
+  org: string;
+}
+
 export type AppsGetRepoInstallationData = Installation;
+
+export interface AppsGetRepoInstallationParams {
+  owner: string;
+  repo: string;
+}
 
 export type AppsGetSubscriptionPlanForAccountData = MarketplacePurchase;
 
 export type AppsGetSubscriptionPlanForAccountError = BasicError;
 
+export interface AppsGetSubscriptionPlanForAccountParams {
+  /** account_id parameter */
+  accountId: number;
+}
+
 export type AppsGetSubscriptionPlanForAccountStubbedData = MarketplacePurchase;
 
+export interface AppsGetSubscriptionPlanForAccountStubbedParams {
+  /** account_id parameter */
+  accountId: number;
+}
+
 export type AppsGetUserInstallationData = Installation;
+
+export interface AppsGetUserInstallationParams {
+  username: string;
+}
 
 export type AppsGetWebhookConfigForAppData = WebhookConfig;
 
@@ -12966,9 +13977,26 @@ export interface AppsListSubscriptionsForAuthenticatedUserStubbedParams {
 
 export type AppsRemoveRepoFromInstallationData = any;
 
+export interface AppsRemoveRepoFromInstallationParams {
+  /** installation_id parameter */
+  installationId: number;
+  repositoryId: number;
+}
+
 export type AppsResetAuthorizationData = Authorization;
 
+export interface AppsResetAuthorizationParams {
+  accessToken: string;
+  /** The client ID of your GitHub app. */
+  clientId: string;
+}
+
 export type AppsResetTokenData = Authorization;
+
+export interface AppsResetTokenParams {
+  /** The client ID of your GitHub app. */
+  clientId: string;
+}
 
 export interface AppsResetTokenPayload {
   /** The access_token of the OAuth application. */
@@ -12977,11 +14005,28 @@ export interface AppsResetTokenPayload {
 
 export type AppsRevokeAuthorizationForApplicationData = any;
 
+export interface AppsRevokeAuthorizationForApplicationParams {
+  accessToken: string;
+  /** The client ID of your GitHub app. */
+  clientId: string;
+}
+
 export type AppsRevokeGrantForApplicationData = any;
+
+export interface AppsRevokeGrantForApplicationParams {
+  accessToken: string;
+  /** The client ID of your GitHub app. */
+  clientId: string;
+}
 
 export type AppsRevokeInstallationAccessTokenData = any;
 
 export type AppsScopeTokenData = Authorization;
+
+export interface AppsScopeTokenParams {
+  /** The client ID of your GitHub app. */
+  clientId: string;
+}
 
 export interface AppsScopeTokenPayload {
   /**
@@ -13012,7 +14057,17 @@ export interface AppsScopeTokenPayload {
 
 export type AppsSuspendInstallationData = any;
 
+export interface AppsSuspendInstallationParams {
+  /** installation_id parameter */
+  installationId: number;
+}
+
 export type AppsUnsuspendInstallationData = any;
+
+export interface AppsUnsuspendInstallationParams {
+  /** installation_id parameter */
+  installationId: number;
+}
 
 export type AppsUpdateWebhookConfigForAppData = WebhookConfig;
 
@@ -13339,21 +14394,60 @@ export interface BasicError {
 
 export type BillingGetGithubActionsBillingGheData = ActionsBillingUsage;
 
+export interface BillingGetGithubActionsBillingGheParams {
+  /** The slug version of the enterprise name. You can also substitute this value with the enterprise id. */
+  enterprise: string;
+}
+
 export type BillingGetGithubActionsBillingOrgData = ActionsBillingUsage;
+
+export interface BillingGetGithubActionsBillingOrgParams {
+  org: string;
+}
 
 export type BillingGetGithubActionsBillingUserData = ActionsBillingUsage;
 
+export interface BillingGetGithubActionsBillingUserParams {
+  username: string;
+}
+
 export type BillingGetGithubPackagesBillingGheData = PackagesBillingUsage;
+
+export interface BillingGetGithubPackagesBillingGheParams {
+  /** The slug version of the enterprise name. You can also substitute this value with the enterprise id. */
+  enterprise: string;
+}
 
 export type BillingGetGithubPackagesBillingOrgData = PackagesBillingUsage;
 
+export interface BillingGetGithubPackagesBillingOrgParams {
+  org: string;
+}
+
 export type BillingGetGithubPackagesBillingUserData = PackagesBillingUsage;
+
+export interface BillingGetGithubPackagesBillingUserParams {
+  username: string;
+}
 
 export type BillingGetSharedStorageBillingGheData = CombinedBillingUsage;
 
+export interface BillingGetSharedStorageBillingGheParams {
+  /** The slug version of the enterprise name. You can also substitute this value with the enterprise id. */
+  enterprise: string;
+}
+
 export type BillingGetSharedStorageBillingOrgData = CombinedBillingUsage;
 
+export interface BillingGetSharedStorageBillingOrgParams {
+  org: string;
+}
+
 export type BillingGetSharedStorageBillingUserData = CombinedBillingUsage;
+
+export interface BillingGetSharedStorageBillingUserParams {
+  username: string;
+}
 
 /**
  * Blob
@@ -13747,6 +14841,11 @@ export enum ChecksCreateConclusionEnum {
 
 export type ChecksCreateData = CheckRun;
 
+export interface ChecksCreateParams {
+  owner: string;
+  repo: string;
+}
+
 export type ChecksCreatePayload = (
   | {
       status?: ChecksCreateStatusEnum;
@@ -13871,6 +14970,11 @@ export enum ChecksCreateStatusEnum2 {
 
 export type ChecksCreateSuiteData = CheckSuite;
 
+export interface ChecksCreateSuiteParams {
+  owner: string;
+  repo: string;
+}
+
 export interface ChecksCreateSuitePayload {
   /** The sha of the head commit. */
   head_sha: string;
@@ -13878,7 +14982,21 @@ export interface ChecksCreateSuitePayload {
 
 export type ChecksGetData = CheckRun;
 
+export interface ChecksGetParams {
+  /** check_run_id parameter */
+  checkRunId: number;
+  owner: string;
+  repo: string;
+}
+
 export type ChecksGetSuiteData = CheckSuite;
+
+export interface ChecksGetSuiteParams {
+  /** check_suite_id parameter */
+  checkSuiteId: number;
+  owner: string;
+  repo: string;
+}
 
 export type ChecksListAnnotationsData = CheckAnnotation[];
 
@@ -14024,7 +15142,19 @@ export interface ChecksListSuitesForRefParams {
 
 export type ChecksRerequestSuiteData = any;
 
+export interface ChecksRerequestSuiteParams {
+  /** check_suite_id parameter */
+  checkSuiteId: number;
+  owner: string;
+  repo: string;
+}
+
 export type ChecksSetSuitesPreferencesData = CheckSuitePreference;
+
+export interface ChecksSetSuitesPreferencesParams {
+  owner: string;
+  repo: string;
+}
 
 export interface ChecksSetSuitesPreferencesPayload {
   /** Enables or disables automatic creation of CheckSuite events upon pushes to the repository. Enabled by default. See the [\`auto_trigger_checks\` object](https://docs.github.com/rest/reference/checks#auto_trigger_checks-object) description for details. */
@@ -14061,6 +15191,13 @@ export enum ChecksUpdateConclusionEnum {
 }
 
 export type ChecksUpdateData = CheckRun;
+
+export interface ChecksUpdateParams {
+  /** check_run_id parameter */
+  checkRunId: number;
+  owner: string;
+  repo: string;
+}
 
 export type ChecksUpdatePayload = (
   | {
@@ -14444,6 +15581,12 @@ export type CodeScanningAnalysisToolName = string;
 
 export type CodeScanningGetAlertData = CodeScanningAlertCodeScanningAlert;
 
+export interface CodeScanningGetAlertParams {
+  alertNumber: number;
+  owner: string;
+  repo: string;
+}
+
 export type CodeScanningListAlertsForRepoData =
   CodeScanningAlertCodeScanningAlertItems[];
 
@@ -14470,6 +15613,13 @@ export interface CodeScanningListRecentAnalysesParams {
 
 export type CodeScanningUpdateAlertData = CodeScanningAlertCodeScanningAlert;
 
+export interface CodeScanningUpdateAlertParams {
+  /** The security alert number, found at the end of the security alert's URL. */
+  alertNumber: AlertNumber;
+  owner: string;
+  repo: string;
+}
+
 export interface CodeScanningUpdateAlertPayload {
   /** **Required when the state is dismissed.** The reason for dismissing or closing the alert. Can be one of: \`false positive\`, \`won't fix\`, and \`used in tests\`. */
   dismissed_reason?: CodeScanningAlertDismissedReason;
@@ -14478,6 +15628,11 @@ export interface CodeScanningUpdateAlertPayload {
 }
 
 export type CodeScanningUploadSarifData = any;
+
+export interface CodeScanningUploadSarifParams {
+  owner: string;
+  repo: string;
+}
 
 export interface CodeScanningUploadSarifPayload {
   /**
@@ -14532,7 +15687,16 @@ export type CodesOfConductGetAllCodesOfConductData = CodeOfConduct[];
 
 export type CodesOfConductGetConductCodeData = CodeOfConduct;
 
+export interface CodesOfConductGetConductCodeParams {
+  key: string;
+}
+
 export type CodesOfConductGetForRepoData = CodeOfConduct;
+
+export interface CodesOfConductGetForRepoParams {
+  owner: string;
+  repo: string;
+}
 
 /**
  * Collaborator
@@ -15776,16 +16940,49 @@ export interface Enterprise {
 export type EnterpriseAdminAddOrgAccessToSelfHostedRunnerGroupInEnterpriseData =
   any;
 
+export interface EnterpriseAdminAddOrgAccessToSelfHostedRunnerGroupInEnterpriseParams {
+  /** The slug version of the enterprise name. You can also substitute this value with the enterprise id. */
+  enterprise: string;
+  /** Unique identifier of an organization. */
+  orgId: number;
+  /** Unique identifier of the self-hosted runner group. */
+  runnerGroupId: number;
+}
+
 export type EnterpriseAdminAddSelfHostedRunnerToGroupForEnterpriseData = any;
+
+export interface EnterpriseAdminAddSelfHostedRunnerToGroupForEnterpriseParams {
+  /** The slug version of the enterprise name. You can also substitute this value with the enterprise id. */
+  enterprise: string;
+  /** Unique identifier of the self-hosted runner group. */
+  runnerGroupId: number;
+  /** Unique identifier of the self-hosted runner. */
+  runnerId: number;
+}
 
 export type EnterpriseAdminCreateRegistrationTokenForEnterpriseData =
   AuthenticationToken;
 
+export interface EnterpriseAdminCreateRegistrationTokenForEnterpriseParams {
+  /** The slug version of the enterprise name. You can also substitute this value with the enterprise id. */
+  enterprise: string;
+}
+
 export type EnterpriseAdminCreateRemoveTokenForEnterpriseData =
   AuthenticationToken;
 
+export interface EnterpriseAdminCreateRemoveTokenForEnterpriseParams {
+  /** The slug version of the enterprise name. You can also substitute this value with the enterprise id. */
+  enterprise: string;
+}
+
 export type EnterpriseAdminCreateSelfHostedRunnerGroupForEnterpriseData =
   RunnerGroupsEnterprise;
+
+export interface EnterpriseAdminCreateSelfHostedRunnerGroupForEnterpriseParams {
+  /** The slug version of the enterprise name. You can also substitute this value with the enterprise id. */
+  enterprise: string;
+}
 
 export interface EnterpriseAdminCreateSelfHostedRunnerGroupForEnterprisePayload {
   /** Name of the runner group. */
@@ -15806,33 +17003,113 @@ export enum EnterpriseAdminCreateSelfHostedRunnerGroupForEnterpriseVisibilityEnu
 
 export type EnterpriseAdminDeleteScimGroupFromEnterpriseData = any;
 
+export interface EnterpriseAdminDeleteScimGroupFromEnterpriseParams {
+  /** The slug version of the enterprise name. You can also substitute this value with the enterprise id. */
+  enterprise: string;
+  /** Identifier generated by the GitHub SCIM endpoint. */
+  scimGroupId: string;
+}
+
 export type EnterpriseAdminDeleteSelfHostedRunnerFromEnterpriseData = any;
+
+export interface EnterpriseAdminDeleteSelfHostedRunnerFromEnterpriseParams {
+  /** The slug version of the enterprise name. You can also substitute this value with the enterprise id. */
+  enterprise: string;
+  /** Unique identifier of the self-hosted runner. */
+  runnerId: number;
+}
 
 export type EnterpriseAdminDeleteSelfHostedRunnerGroupFromEnterpriseData = any;
 
+export interface EnterpriseAdminDeleteSelfHostedRunnerGroupFromEnterpriseParams {
+  /** The slug version of the enterprise name. You can also substitute this value with the enterprise id. */
+  enterprise: string;
+  /** Unique identifier of the self-hosted runner group. */
+  runnerGroupId: number;
+}
+
 export type EnterpriseAdminDeleteUserFromEnterpriseData = any;
+
+export interface EnterpriseAdminDeleteUserFromEnterpriseParams {
+  /** The slug version of the enterprise name. You can also substitute this value with the enterprise id. */
+  enterprise: string;
+  /** scim_user_id parameter */
+  scimUserId: string;
+}
 
 export type EnterpriseAdminDisableSelectedOrganizationGithubActionsEnterpriseData =
   any;
 
+export interface EnterpriseAdminDisableSelectedOrganizationGithubActionsEnterpriseParams {
+  /** The slug version of the enterprise name. You can also substitute this value with the enterprise id. */
+  enterprise: string;
+  /** Unique identifier of an organization. */
+  orgId: number;
+}
+
 export type EnterpriseAdminEnableSelectedOrganizationGithubActionsEnterpriseData =
   any;
 
+export interface EnterpriseAdminEnableSelectedOrganizationGithubActionsEnterpriseParams {
+  /** The slug version of the enterprise name. You can also substitute this value with the enterprise id. */
+  enterprise: string;
+  /** Unique identifier of an organization. */
+  orgId: number;
+}
+
 export type EnterpriseAdminGetAllowedActionsEnterpriseData = SelectedActions;
+
+export interface EnterpriseAdminGetAllowedActionsEnterpriseParams {
+  /** The slug version of the enterprise name. You can also substitute this value with the enterprise id. */
+  enterprise: string;
+}
 
 export type EnterpriseAdminGetGithubActionsPermissionsEnterpriseData =
   ActionsEnterprisePermissions;
 
+export interface EnterpriseAdminGetGithubActionsPermissionsEnterpriseParams {
+  /** The slug version of the enterprise name. You can also substitute this value with the enterprise id. */
+  enterprise: string;
+}
+
 export type EnterpriseAdminGetProvisioningInformationForEnterpriseGroupData =
   ScimEnterpriseGroup;
+
+export interface EnterpriseAdminGetProvisioningInformationForEnterpriseGroupParams {
+  /** The slug version of the enterprise name. You can also substitute this value with the enterprise id. */
+  enterprise: string;
+  /** Identifier generated by the GitHub SCIM endpoint. */
+  scimGroupId: string;
+}
 
 export type EnterpriseAdminGetProvisioningInformationForEnterpriseUserData =
   ScimEnterpriseUser;
 
+export interface EnterpriseAdminGetProvisioningInformationForEnterpriseUserParams {
+  /** The slug version of the enterprise name. You can also substitute this value with the enterprise id. */
+  enterprise: string;
+  /** scim_user_id parameter */
+  scimUserId: string;
+}
+
 export type EnterpriseAdminGetSelfHostedRunnerForEnterpriseData = Runner;
+
+export interface EnterpriseAdminGetSelfHostedRunnerForEnterpriseParams {
+  /** The slug version of the enterprise name. You can also substitute this value with the enterprise id. */
+  enterprise: string;
+  /** Unique identifier of the self-hosted runner. */
+  runnerId: number;
+}
 
 export type EnterpriseAdminGetSelfHostedRunnerGroupForEnterpriseData =
   RunnerGroupsEnterprise;
+
+export interface EnterpriseAdminGetSelfHostedRunnerGroupForEnterpriseParams {
+  /** The slug version of the enterprise name. You can also substitute this value with the enterprise id. */
+  enterprise: string;
+  /** Unique identifier of the self-hosted runner group. */
+  runnerGroupId: number;
+}
 
 export interface EnterpriseAdminListOrgAccessToSelfHostedRunnerGroupInEnterpriseData {
   organizations: OrganizationSimple[];
@@ -15882,6 +17159,11 @@ export interface EnterpriseAdminListProvisionedIdentitiesEnterpriseParams {
 
 export type EnterpriseAdminListRunnerApplicationsForEnterpriseData =
   RunnerApplication[];
+
+export interface EnterpriseAdminListRunnerApplicationsForEnterpriseParams {
+  /** The slug version of the enterprise name. You can also substitute this value with the enterprise id. */
+  enterprise: string;
+}
 
 export interface EnterpriseAdminListSelectedOrganizationsEnabledGithubActionsEnterpriseData {
   organizations: OrganizationSimple[];
@@ -15968,6 +17250,11 @@ export interface EnterpriseAdminListSelfHostedRunnersInGroupForEnterpriseParams 
 export type EnterpriseAdminProvisionAndInviteEnterpriseGroupData =
   ScimEnterpriseGroup;
 
+export interface EnterpriseAdminProvisionAndInviteEnterpriseGroupParams {
+  /** The slug version of the enterprise name. You can also substitute this value with the enterprise id. */
+  enterprise: string;
+}
+
 export interface EnterpriseAdminProvisionAndInviteEnterpriseGroupPayload {
   /** The name of the SCIM group. This must match the GitHub organization that the group maps to. */
   displayName: string;
@@ -15981,6 +17268,11 @@ export interface EnterpriseAdminProvisionAndInviteEnterpriseGroupPayload {
 
 export type EnterpriseAdminProvisionAndInviteEnterpriseUserData =
   ScimEnterpriseUser;
+
+export interface EnterpriseAdminProvisionAndInviteEnterpriseUserParams {
+  /** The slug version of the enterprise name. You can also substitute this value with the enterprise id. */
+  enterprise: string;
+}
 
 export interface EnterpriseAdminProvisionAndInviteEnterpriseUserPayload {
   /** List of user emails. */
@@ -16011,12 +17303,40 @@ export interface EnterpriseAdminProvisionAndInviteEnterpriseUserPayload {
 export type EnterpriseAdminRemoveOrgAccessToSelfHostedRunnerGroupInEnterpriseData =
   any;
 
+export interface EnterpriseAdminRemoveOrgAccessToSelfHostedRunnerGroupInEnterpriseParams {
+  /** The slug version of the enterprise name. You can also substitute this value with the enterprise id. */
+  enterprise: string;
+  /** Unique identifier of an organization. */
+  orgId: number;
+  /** Unique identifier of the self-hosted runner group. */
+  runnerGroupId: number;
+}
+
 export type EnterpriseAdminRemoveSelfHostedRunnerFromGroupForEnterpriseData =
   any;
 
+export interface EnterpriseAdminRemoveSelfHostedRunnerFromGroupForEnterpriseParams {
+  /** The slug version of the enterprise name. You can also substitute this value with the enterprise id. */
+  enterprise: string;
+  /** Unique identifier of the self-hosted runner group. */
+  runnerGroupId: number;
+  /** Unique identifier of the self-hosted runner. */
+  runnerId: number;
+}
+
 export type EnterpriseAdminSetAllowedActionsEnterpriseData = any;
 
+export interface EnterpriseAdminSetAllowedActionsEnterpriseParams {
+  /** The slug version of the enterprise name. You can also substitute this value with the enterprise id. */
+  enterprise: string;
+}
+
 export type EnterpriseAdminSetGithubActionsPermissionsEnterpriseData = any;
+
+export interface EnterpriseAdminSetGithubActionsPermissionsEnterpriseParams {
+  /** The slug version of the enterprise name. You can also substitute this value with the enterprise id. */
+  enterprise: string;
+}
 
 export interface EnterpriseAdminSetGithubActionsPermissionsEnterprisePayload {
   /** The permissions policy that controls the actions that are allowed to run. Can be one of: \`all\`, \`local_only\`, or \`selected\`. */
@@ -16027,6 +17347,13 @@ export interface EnterpriseAdminSetGithubActionsPermissionsEnterprisePayload {
 
 export type EnterpriseAdminSetInformationForProvisionedEnterpriseGroupData =
   ScimEnterpriseGroup;
+
+export interface EnterpriseAdminSetInformationForProvisionedEnterpriseGroupParams {
+  /** The slug version of the enterprise name. You can also substitute this value with the enterprise id. */
+  enterprise: string;
+  /** Identifier generated by the GitHub SCIM endpoint. */
+  scimGroupId: string;
+}
 
 export interface EnterpriseAdminSetInformationForProvisionedEnterpriseGroupPayload {
   /** The name of the SCIM group. This must match the GitHub organization that the group maps to. */
@@ -16041,6 +17368,13 @@ export interface EnterpriseAdminSetInformationForProvisionedEnterpriseGroupPaylo
 
 export type EnterpriseAdminSetInformationForProvisionedEnterpriseUserData =
   ScimEnterpriseUser;
+
+export interface EnterpriseAdminSetInformationForProvisionedEnterpriseUserParams {
+  /** The slug version of the enterprise name. You can also substitute this value with the enterprise id. */
+  enterprise: string;
+  /** scim_user_id parameter */
+  scimUserId: string;
+}
 
 export interface EnterpriseAdminSetInformationForProvisionedEnterpriseUserPayload {
   /** List of user emails. */
@@ -16071,6 +17405,13 @@ export interface EnterpriseAdminSetInformationForProvisionedEnterpriseUserPayloa
 export type EnterpriseAdminSetOrgAccessToSelfHostedRunnerGroupInEnterpriseData =
   any;
 
+export interface EnterpriseAdminSetOrgAccessToSelfHostedRunnerGroupInEnterpriseParams {
+  /** The slug version of the enterprise name. You can also substitute this value with the enterprise id. */
+  enterprise: string;
+  /** Unique identifier of the self-hosted runner group. */
+  runnerGroupId: number;
+}
+
 export interface EnterpriseAdminSetOrgAccessToSelfHostedRunnerGroupInEnterprisePayload {
   /** List of organization IDs that can access the runner group. */
   selected_organization_ids: number[];
@@ -16079,12 +17420,24 @@ export interface EnterpriseAdminSetOrgAccessToSelfHostedRunnerGroupInEnterpriseP
 export type EnterpriseAdminSetSelectedOrganizationsEnabledGithubActionsEnterpriseData =
   any;
 
+export interface EnterpriseAdminSetSelectedOrganizationsEnabledGithubActionsEnterpriseParams {
+  /** The slug version of the enterprise name. You can also substitute this value with the enterprise id. */
+  enterprise: string;
+}
+
 export interface EnterpriseAdminSetSelectedOrganizationsEnabledGithubActionsEnterprisePayload {
   /** List of organization IDs to enable for GitHub Actions. */
   selected_organization_ids: number[];
 }
 
 export type EnterpriseAdminSetSelfHostedRunnersInGroupForEnterpriseData = any;
+
+export interface EnterpriseAdminSetSelfHostedRunnersInGroupForEnterpriseParams {
+  /** The slug version of the enterprise name. You can also substitute this value with the enterprise id. */
+  enterprise: string;
+  /** Unique identifier of the self-hosted runner group. */
+  runnerGroupId: number;
+}
 
 export interface EnterpriseAdminSetSelfHostedRunnersInGroupForEnterprisePayload {
   /** List of runner IDs to add to the runner group. */
@@ -16093,6 +17446,13 @@ export interface EnterpriseAdminSetSelfHostedRunnersInGroupForEnterprisePayload 
 
 export type EnterpriseAdminUpdateAttributeForEnterpriseGroupData =
   ScimEnterpriseGroup;
+
+export interface EnterpriseAdminUpdateAttributeForEnterpriseGroupParams {
+  /** The slug version of the enterprise name. You can also substitute this value with the enterprise id. */
+  enterprise: string;
+  /** Identifier generated by the GitHub SCIM endpoint. */
+  scimGroupId: string;
+}
 
 export interface EnterpriseAdminUpdateAttributeForEnterpriseGroupPayload {
   /** Array of [SCIM operations](https://tools.ietf.org/html/rfc7644#section-3.5.2). */
@@ -16104,6 +17464,13 @@ export interface EnterpriseAdminUpdateAttributeForEnterpriseGroupPayload {
 export type EnterpriseAdminUpdateAttributeForEnterpriseUserData =
   ScimEnterpriseUser;
 
+export interface EnterpriseAdminUpdateAttributeForEnterpriseUserParams {
+  /** The slug version of the enterprise name. You can also substitute this value with the enterprise id. */
+  enterprise: string;
+  /** scim_user_id parameter */
+  scimUserId: string;
+}
+
 export interface EnterpriseAdminUpdateAttributeForEnterpriseUserPayload {
   /** Array of [SCIM operations](https://tools.ietf.org/html/rfc7644#section-3.5.2). */
   Operations: object[];
@@ -16113,6 +17480,13 @@ export interface EnterpriseAdminUpdateAttributeForEnterpriseUserPayload {
 
 export type EnterpriseAdminUpdateSelfHostedRunnerGroupForEnterpriseData =
   RunnerGroupsEnterprise;
+
+export interface EnterpriseAdminUpdateSelfHostedRunnerGroupForEnterpriseParams {
+  /** The slug version of the enterprise name. You can also substitute this value with the enterprise id. */
+  enterprise: string;
+  /** Unique identifier of the self-hosted runner group. */
+  runnerGroupId: number;
+}
 
 export interface EnterpriseAdminUpdateSelfHostedRunnerGroupForEnterprisePayload {
   /** Name of the runner group. */
@@ -16730,7 +18104,17 @@ export type GistsCheckIsStarredData = any;
 
 export type GistsCheckIsStarredError = object;
 
+export interface GistsCheckIsStarredParams {
+  /** gist_id parameter */
+  gistId: string;
+}
+
 export type GistsCreateCommentData = GistComment;
+
+export interface GistsCreateCommentParams {
+  /** gist_id parameter */
+  gistId: string;
+}
 
 export interface GistsCreateCommentPayload {
   /**
@@ -16775,15 +18159,50 @@ export enum GistsCreatePublicEnum {
 
 export type GistsDeleteCommentData = any;
 
+export interface GistsDeleteCommentParams {
+  /** comment_id parameter */
+  commentId: number;
+  /** gist_id parameter */
+  gistId: string;
+}
+
 export type GistsDeleteData = any;
+
+export interface GistsDeleteParams {
+  /** gist_id parameter */
+  gistId: string;
+}
 
 export type GistsForkData = BaseGist;
 
+export interface GistsForkParams {
+  /** gist_id parameter */
+  gistId: string;
+}
+
 export type GistsGetCommentData = GistComment;
+
+export interface GistsGetCommentParams {
+  /** comment_id parameter */
+  commentId: number;
+  /** gist_id parameter */
+  gistId: string;
+}
 
 export type GistsGetData = GistSimple;
 
+export interface GistsGetParams {
+  /** gist_id parameter */
+  gistId: string;
+}
+
 export type GistsGetRevisionData = GistSimple;
+
+export interface GistsGetRevisionParams {
+  /** gist_id parameter */
+  gistId: string;
+  sha: string;
+}
 
 export type GistsListCommentsData = GistComment[];
 
@@ -16907,9 +18326,26 @@ export interface GistsListStarredParams {
 
 export type GistsStarData = any;
 
+export interface GistsStarParams {
+  /** gist_id parameter */
+  gistId: string;
+}
+
 export type GistsUnstarData = any;
 
+export interface GistsUnstarParams {
+  /** gist_id parameter */
+  gistId: string;
+}
+
 export type GistsUpdateCommentData = GistComment;
+
+export interface GistsUpdateCommentParams {
+  /** comment_id parameter */
+  commentId: number;
+  /** gist_id parameter */
+  gistId: string;
+}
 
 export interface GistsUpdateCommentPayload {
   /**
@@ -16921,6 +18357,11 @@ export interface GistsUpdateCommentPayload {
 }
 
 export type GistsUpdateData = GistSimple;
+
+export interface GistsUpdateParams {
+  /** gist_id parameter */
+  gistId: string;
+}
 
 export type GistsUpdatePayload = null & {
   /**
@@ -17031,6 +18472,11 @@ export interface GitCommit {
 
 export type GitCreateBlobData = ShortBlob;
 
+export interface GitCreateBlobParams {
+  owner: string;
+  repo: string;
+}
+
 export interface GitCreateBlobPayload {
   /** The new blob's content. */
   content: string;
@@ -17042,6 +18488,11 @@ export interface GitCreateBlobPayload {
 }
 
 export type GitCreateCommitData = GitCommit;
+
+export interface GitCreateCommitParams {
+  owner: string;
+  repo: string;
+}
 
 export interface GitCreateCommitPayload {
   /** Information about the author of the commit. By default, the \`author\` will be the authenticated user and the current date. See the \`author\` and \`committer\` object below for details. */
@@ -17074,6 +18525,11 @@ export interface GitCreateCommitPayload {
 
 export type GitCreateRefData = GitRef;
 
+export interface GitCreateRefParams {
+  owner: string;
+  repo: string;
+}
+
 export interface GitCreateRefPayload {
   /** @example ""refs/heads/newbranch"" */
   key?: string;
@@ -17084,6 +18540,11 @@ export interface GitCreateRefPayload {
 }
 
 export type GitCreateTagData = GitTag;
+
+export interface GitCreateTagParams {
+  owner: string;
+  repo: string;
+}
 
 export interface GitCreateTagPayload {
   /** The tag message. */
@@ -17121,6 +18582,11 @@ export enum GitCreateTreeModeEnum {
   Value040000 = "040000",
   Value160000 = "160000",
   Value120000 = "120000",
+}
+
+export interface GitCreateTreeParams {
+  owner: string;
+  repo: string;
 }
 
 export interface GitCreateTreePayload {
@@ -17161,13 +18627,46 @@ export enum GitCreateTreeTypeEnum {
 
 export type GitDeleteRefData = any;
 
+export interface GitDeleteRefParams {
+  owner: string;
+  /** ref+ parameter */
+  ref: string;
+  repo: string;
+}
+
 export type GitGetBlobData = Blob;
+
+export interface GitGetBlobParams {
+  fileSha: string;
+  owner: string;
+  repo: string;
+}
 
 export type GitGetCommitData = GitCommit;
 
+export interface GitGetCommitParams {
+  /** commit_sha parameter */
+  commitSha: string;
+  owner: string;
+  repo: string;
+}
+
 export type GitGetRefData = GitRef;
 
+export interface GitGetRefParams {
+  owner: string;
+  /** ref+ parameter */
+  ref: string;
+  repo: string;
+}
+
 export type GitGetTagData = GitTag;
+
+export interface GitGetTagParams {
+  owner: string;
+  repo: string;
+  tagSha: string;
+}
 
 export type GitGetTreeData = GitTree;
 
@@ -17291,6 +18790,13 @@ export interface GitTree {
 
 export type GitUpdateRefData = GitRef;
 
+export interface GitUpdateRefParams {
+  owner: string;
+  /** ref+ parameter */
+  ref: string;
+  repo: string;
+}
+
 export interface GitUpdateRefPayload {
   /**
    * Indicates whether to force the update or to make sure the update is a fast-forward update. Leaving this out or setting it to \`false\` will make sure you're not overwriting work.
@@ -17317,6 +18823,10 @@ export interface GitUser {
 export type GitignoreGetAllTemplatesData = string[];
 
 export type GitignoreGetTemplateData = GitignoreTemplate;
+
+export interface GitignoreGetTemplateParams {
+  name: string;
+}
 
 /**
  * Gitignore Template
@@ -17870,20 +19380,47 @@ export type InteractionsGetRestrictionsForAuthenticatedUserData =
 
 export type InteractionsGetRestrictionsForOrgData = InteractionLimitResponse;
 
+export interface InteractionsGetRestrictionsForOrgParams {
+  org: string;
+}
+
 export type InteractionsGetRestrictionsForRepoData = InteractionLimitResponse;
+
+export interface InteractionsGetRestrictionsForRepoParams {
+  owner: string;
+  repo: string;
+}
 
 export type InteractionsRemoveRestrictionsForAuthenticatedUserData = any;
 
 export type InteractionsRemoveRestrictionsForOrgData = any;
 
+export interface InteractionsRemoveRestrictionsForOrgParams {
+  org: string;
+}
+
 export type InteractionsRemoveRestrictionsForRepoData = any;
+
+export interface InteractionsRemoveRestrictionsForRepoParams {
+  owner: string;
+  repo: string;
+}
 
 export type InteractionsSetRestrictionsForAuthenticatedUserData =
   InteractionLimitResponse;
 
 export type InteractionsSetRestrictionsForOrgData = InteractionLimitResponse;
 
+export interface InteractionsSetRestrictionsForOrgParams {
+  org: string;
+}
+
 export type InteractionsSetRestrictionsForRepoData = InteractionLimitResponse;
+
+export interface InteractionsSetRestrictionsForRepoParams {
+  owner: string;
+  repo: string;
+}
 
 /** Internal Error */
 export type InternalError = BasicError;
@@ -18331,12 +19868,26 @@ export interface IssueSimple {
 
 export type IssuesAddAssigneesData = IssueSimple;
 
+export interface IssuesAddAssigneesParams {
+  /** issue_number parameter */
+  issueNumber: number;
+  owner: string;
+  repo: string;
+}
+
 export interface IssuesAddAssigneesPayload {
   /** Usernames of people to assign this issue to. _NOTE: Only users with push access can add assignees to an issue. Assignees are silently ignored otherwise._ */
   assignees?: string[];
 }
 
 export type IssuesAddLabelsData = Label[];
+
+export interface IssuesAddLabelsParams {
+  /** issue_number parameter */
+  issueNumber: number;
+  owner: string;
+  repo: string;
+}
 
 export interface IssuesAddLabelsPayload {
   /** The name of the label to add to the issue. Must contain at least one label. **Note:** Alternatively, you can pass a single label as a \`string\` or an \`array\` of labels directly, but GitHub recommends passing an object with the \`labels\` key. */
@@ -18347,7 +19898,20 @@ export type IssuesCheckUserCanBeAssignedData = any;
 
 export type IssuesCheckUserCanBeAssignedError = BasicError;
 
+export interface IssuesCheckUserCanBeAssignedParams {
+  assignee: string;
+  owner: string;
+  repo: string;
+}
+
 export type IssuesCreateCommentData = IssueComment;
+
+export interface IssuesCreateCommentParams {
+  /** issue_number parameter */
+  issueNumber: number;
+  owner: string;
+  repo: string;
+}
 
 export interface IssuesCreateCommentPayload {
   /** The contents of the comment. */
@@ -18357,6 +19921,11 @@ export interface IssuesCreateCommentPayload {
 export type IssuesCreateData = Issue;
 
 export type IssuesCreateLabelData = Label;
+
+export interface IssuesCreateLabelParams {
+  owner: string;
+  repo: string;
+}
 
 export interface IssuesCreateLabelPayload {
   /** The [hexadecimal color code](http://www.color-hex.com/) for the label, without the leading \`#\`. */
@@ -18368,6 +19937,11 @@ export interface IssuesCreateLabelPayload {
 }
 
 export type IssuesCreateMilestoneData = Milestone;
+
+export interface IssuesCreateMilestoneParams {
+  owner: string;
+  repo: string;
+}
 
 export interface IssuesCreateMilestonePayload {
   /** A description of the milestone. */
@@ -18390,6 +19964,11 @@ export interface IssuesCreateMilestonePayload {
 export enum IssuesCreateMilestoneStateEnum {
   Open = "open",
   Closed = "closed",
+}
+
+export interface IssuesCreateParams {
+  owner: string;
+  repo: string;
 }
 
 export interface IssuesCreatePayload {
@@ -18417,19 +19996,72 @@ export interface IssuesCreatePayload {
 
 export type IssuesDeleteCommentData = any;
 
+export interface IssuesDeleteCommentParams {
+  /** comment_id parameter */
+  commentId: number;
+  owner: string;
+  repo: string;
+}
+
 export type IssuesDeleteLabelData = any;
+
+export interface IssuesDeleteLabelParams {
+  name: string;
+  owner: string;
+  repo: string;
+}
 
 export type IssuesDeleteMilestoneData = any;
 
+export interface IssuesDeleteMilestoneParams {
+  /** milestone_number parameter */
+  milestoneNumber: number;
+  owner: string;
+  repo: string;
+}
+
 export type IssuesGetCommentData = IssueComment;
+
+export interface IssuesGetCommentParams {
+  /** comment_id parameter */
+  commentId: number;
+  owner: string;
+  repo: string;
+}
 
 export type IssuesGetData = Issue;
 
 export type IssuesGetEventData = IssueEvent;
 
+export interface IssuesGetEventParams {
+  eventId: number;
+  owner: string;
+  repo: string;
+}
+
 export type IssuesGetLabelData = Label;
 
+export interface IssuesGetLabelParams {
+  name: string;
+  owner: string;
+  repo: string;
+}
+
 export type IssuesGetMilestoneData = Milestone;
+
+export interface IssuesGetMilestoneParams {
+  /** milestone_number parameter */
+  milestoneNumber: number;
+  owner: string;
+  repo: string;
+}
+
+export interface IssuesGetParams {
+  /** issue_number parameter */
+  issueNumber: number;
+  owner: string;
+  repo: string;
+}
 
 export type IssuesListAssigneesData = SimpleUser[];
 
@@ -19044,6 +20676,13 @@ export enum IssuesLockLockReasonEnum {
   Spam = "spam",
 }
 
+export interface IssuesLockParams {
+  /** issue_number parameter */
+  issueNumber: number;
+  owner: string;
+  repo: string;
+}
+
 export type IssuesLockPayload = {
   /**
    * The reason for locking the issue or pull request conversation. Lock will fail if you don't use one of these reasons:
@@ -19057,7 +20696,21 @@ export type IssuesLockPayload = {
 
 export type IssuesRemoveAllLabelsData = any;
 
+export interface IssuesRemoveAllLabelsParams {
+  /** issue_number parameter */
+  issueNumber: number;
+  owner: string;
+  repo: string;
+}
+
 export type IssuesRemoveAssigneesData = IssueSimple;
+
+export interface IssuesRemoveAssigneesParams {
+  /** issue_number parameter */
+  issueNumber: number;
+  owner: string;
+  repo: string;
+}
 
 export interface IssuesRemoveAssigneesPayload {
   /** Usernames of assignees to remove from an issue. _NOTE: Only users with push access can remove assignees from an issue. Assignees are silently ignored otherwise._ */
@@ -19066,7 +20719,22 @@ export interface IssuesRemoveAssigneesPayload {
 
 export type IssuesRemoveLabelData = Label[];
 
+export interface IssuesRemoveLabelParams {
+  /** issue_number parameter */
+  issueNumber: number;
+  name: string;
+  owner: string;
+  repo: string;
+}
+
 export type IssuesSetLabelsData = Label[];
+
+export interface IssuesSetLabelsParams {
+  /** issue_number parameter */
+  issueNumber: number;
+  owner: string;
+  repo: string;
+}
 
 export interface IssuesSetLabelsPayload {
   /** The names of the labels to add to the issue. You can pass an empty array to remove all labels. **Note:** Alternatively, you can pass a single label as a \`string\` or an \`array\` of labels directly, but GitHub recommends passing an object with the \`labels\` key. */
@@ -19075,7 +20743,21 @@ export interface IssuesSetLabelsPayload {
 
 export type IssuesUnlockData = any;
 
+export interface IssuesUnlockParams {
+  /** issue_number parameter */
+  issueNumber: number;
+  owner: string;
+  repo: string;
+}
+
 export type IssuesUpdateCommentData = IssueComment;
+
+export interface IssuesUpdateCommentParams {
+  /** comment_id parameter */
+  commentId: number;
+  owner: string;
+  repo: string;
+}
 
 export interface IssuesUpdateCommentPayload {
   /** The contents of the comment. */
@@ -19085,6 +20767,12 @@ export interface IssuesUpdateCommentPayload {
 export type IssuesUpdateData = Issue;
 
 export type IssuesUpdateLabelData = Label;
+
+export interface IssuesUpdateLabelParams {
+  name: string;
+  owner: string;
+  repo: string;
+}
 
 export interface IssuesUpdateLabelPayload {
   /** The [hexadecimal color code](http://www.color-hex.com/) for the label, without the leading \`#\`. */
@@ -19096,6 +20784,13 @@ export interface IssuesUpdateLabelPayload {
 }
 
 export type IssuesUpdateMilestoneData = Milestone;
+
+export interface IssuesUpdateMilestoneParams {
+  /** milestone_number parameter */
+  milestoneNumber: number;
+  owner: string;
+  repo: string;
+}
 
 export interface IssuesUpdateMilestonePayload {
   /** A description of the milestone. */
@@ -19118,6 +20813,13 @@ export interface IssuesUpdateMilestonePayload {
 export enum IssuesUpdateMilestoneStateEnum {
   Open = "open",
   Closed = "closed",
+}
+
+export interface IssuesUpdateParams {
+  /** issue_number parameter */
+  issueNumber: number;
+  owner: string;
+  repo: string;
 }
 
 export interface IssuesUpdatePayload {
@@ -19473,6 +21175,15 @@ export type LicensesGetData = License;
 
 export type LicensesGetForRepoData = LicenseContent;
 
+export interface LicensesGetForRepoParams {
+  owner: string;
+  repo: string;
+}
+
+export interface LicensesGetParams {
+  license: string;
+}
+
 /**
  * Link
  * Hypermedia Link
@@ -19721,9 +21432,36 @@ export interface Migration {
 
 export type MigrationsCancelImportData = any;
 
+export interface MigrationsCancelImportParams {
+  owner: string;
+  repo: string;
+}
+
 export type MigrationsDeleteArchiveForAuthenticatedUserData = any;
 
+export interface MigrationsDeleteArchiveForAuthenticatedUserParams {
+  /** migration_id parameter */
+  migrationId: number;
+}
+
 export type MigrationsDeleteArchiveForOrgData = any;
+
+export interface MigrationsDeleteArchiveForOrgParams {
+  /** migration_id parameter */
+  migrationId: number;
+  org: string;
+}
+
+export interface MigrationsDownloadArchiveForOrgParams {
+  /** migration_id parameter */
+  migrationId: number;
+  org: string;
+}
+
+export interface MigrationsGetArchiveForAuthenticatedUserParams {
+  /** migration_id parameter */
+  migrationId: number;
+}
 
 export type MigrationsGetCommitAuthorsData = PorterAuthor[];
 
@@ -19736,7 +21474,17 @@ export interface MigrationsGetCommitAuthorsParams {
 
 export type MigrationsGetImportStatusData = Import;
 
+export interface MigrationsGetImportStatusParams {
+  owner: string;
+  repo: string;
+}
+
 export type MigrationsGetLargeFilesData = PorterLargeFile[];
+
+export interface MigrationsGetLargeFilesParams {
+  owner: string;
+  repo: string;
+}
 
 export type MigrationsGetStatusForAuthenticatedUserData = Migration;
 
@@ -19747,6 +21495,12 @@ export interface MigrationsGetStatusForAuthenticatedUserParams {
 }
 
 export type MigrationsGetStatusForOrgData = Migration;
+
+export interface MigrationsGetStatusForOrgParams {
+  /** migration_id parameter */
+  migrationId: number;
+  org: string;
+}
 
 export type MigrationsListForAuthenticatedUserData = Migration[];
 
@@ -19816,6 +21570,12 @@ export interface MigrationsListReposForUserParams {
 
 export type MigrationsMapCommitAuthorData = PorterAuthor;
 
+export interface MigrationsMapCommitAuthorParams {
+  authorId: number;
+  owner: string;
+  repo: string;
+}
+
 export interface MigrationsMapCommitAuthorPayload {
   /** The new Git author email. */
   email?: string;
@@ -19826,6 +21586,11 @@ export interface MigrationsMapCommitAuthorPayload {
 }
 
 export type MigrationsSetLfsPreferenceData = Import;
+
+export interface MigrationsSetLfsPreferenceParams {
+  owner: string;
+  repo: string;
+}
 
 export interface MigrationsSetLfsPreferencePayload {
   /** Can be one of \`opt_in\` (large files will be stored using Git LFS) or \`opt_out\` (large files will be removed during the import). */
@@ -19869,6 +21634,10 @@ export interface MigrationsStartForAuthenticatedUserPayload {
 
 export type MigrationsStartForOrgData = Migration;
 
+export interface MigrationsStartForOrgParams {
+  org: string;
+}
+
 export interface MigrationsStartForOrgPayload {
   exclude?: string[];
   /**
@@ -19886,6 +21655,11 @@ export interface MigrationsStartForOrgPayload {
 }
 
 export type MigrationsStartImportData = Import;
+
+export interface MigrationsStartImportParams {
+  owner: string;
+  repo: string;
+}
 
 export interface MigrationsStartImportPayload {
   /** For a tfvc import, the name of the project that is being imported. */
@@ -19910,9 +21684,29 @@ export enum MigrationsStartImportVcsEnum {
 
 export type MigrationsUnlockRepoForAuthenticatedUserData = any;
 
+export interface MigrationsUnlockRepoForAuthenticatedUserParams {
+  /** migration_id parameter */
+  migrationId: number;
+  /** repo_name parameter */
+  repoName: string;
+}
+
 export type MigrationsUnlockRepoForOrgData = any;
 
+export interface MigrationsUnlockRepoForOrgParams {
+  /** migration_id parameter */
+  migrationId: number;
+  org: string;
+  /** repo_name parameter */
+  repoName: string;
+}
+
 export type MigrationsUpdateImportData = Import;
+
+export interface MigrationsUpdateImportParams {
+  owner: string;
+  repo: string;
+}
 
 export interface MigrationsUpdateImportPayload {
   /** @example ""project1"" */
@@ -20246,14 +22040,40 @@ export interface OauthAuthorizationsCreateAuthorizationPayload {
 
 export type OauthAuthorizationsDeleteAuthorizationData = any;
 
+export interface OauthAuthorizationsDeleteAuthorizationParams {
+  /** authorization_id parameter */
+  authorizationId: number;
+}
+
 export type OauthAuthorizationsDeleteGrantData = any;
+
+export interface OauthAuthorizationsDeleteGrantParams {
+  /** grant_id parameter */
+  grantId: number;
+}
 
 export type OauthAuthorizationsGetAuthorizationData = Authorization;
 
+export interface OauthAuthorizationsGetAuthorizationParams {
+  /** authorization_id parameter */
+  authorizationId: number;
+}
+
 export type OauthAuthorizationsGetGrantData = ApplicationGrant;
+
+export interface OauthAuthorizationsGetGrantParams {
+  /** grant_id parameter */
+  grantId: number;
+}
 
 export type OauthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprintData =
   Authorization;
+
+export interface OauthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprintParams {
+  /** The client ID of your GitHub app. */
+  clientId: string;
+  fingerprint: string;
+}
 
 export interface OauthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprintPayload {
   /**
@@ -20277,6 +22097,11 @@ export interface OauthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprint
 
 export type OauthAuthorizationsGetOrCreateAuthorizationForAppData =
   Authorization;
+
+export interface OauthAuthorizationsGetOrCreateAuthorizationForAppParams {
+  /** The client ID of your GitHub app. */
+  clientId: string;
+}
 
 export interface OauthAuthorizationsGetOrCreateAuthorizationForAppPayload {
   /**
@@ -20331,6 +22156,11 @@ export interface OauthAuthorizationsListGrantsParams {
 }
 
 export type OauthAuthorizationsUpdateAuthorizationData = Authorization;
+
+export interface OauthAuthorizationsUpdateAuthorizationParams {
+  /** authorization_id parameter */
+  authorizationId: number;
+}
 
 export interface OauthAuthorizationsUpdateAuthorizationPayload {
   /** A list of scopes to add to this authorization. */
@@ -20717,15 +22547,41 @@ export interface OrganizationSimple {
 
 export type OrgsBlockUserData = any;
 
+export interface OrgsBlockUserParams {
+  org: string;
+  username: string;
+}
+
 export type OrgsCancelInvitationData = any;
+
+export interface OrgsCancelInvitationParams {
+  /** invitation_id parameter */
+  invitationId: number;
+  org: string;
+}
 
 export type OrgsCheckBlockedUserData = any;
 
 export type OrgsCheckBlockedUserError = BasicError;
 
+export interface OrgsCheckBlockedUserParams {
+  org: string;
+  username: string;
+}
+
 export type OrgsCheckMembershipForUserData = any;
 
+export interface OrgsCheckMembershipForUserParams {
+  org: string;
+  username: string;
+}
+
 export type OrgsCheckPublicMembershipForUserData = any;
+
+export interface OrgsCheckPublicMembershipForUserParams {
+  org: string;
+  username: string;
+}
 
 export type OrgsConvertMemberToOutsideCollaboratorData = any;
 
@@ -20734,7 +22590,16 @@ export type OrgsConvertMemberToOutsideCollaboratorError = {
   message?: string;
 };
 
+export interface OrgsConvertMemberToOutsideCollaboratorParams {
+  org: string;
+  username: string;
+}
+
 export type OrgsCreateInvitationData = OrganizationInvitation;
+
+export interface OrgsCreateInvitationParams {
+  org: string;
+}
 
 export interface OrgsCreateInvitationPayload {
   /** **Required unless you provide \`invitee_id\`**. Email address of the person you are inviting, which can be an existing GitHub user. */
@@ -20768,6 +22633,10 @@ export enum OrgsCreateInvitationRoleEnum {
 
 export type OrgsCreateWebhookData = OrgHook;
 
+export interface OrgsCreateWebhookParams {
+  org: string;
+}
+
 export interface OrgsCreateWebhookPayload {
   /**
    * Determines if notifications are sent when the webhook is triggered. Set to \`true\` to send notifications.
@@ -20799,6 +22668,11 @@ export interface OrgsCreateWebhookPayload {
 }
 
 export type OrgsDeleteWebhookData = any;
+
+export interface OrgsDeleteWebhookParams {
+  hookId: number;
+  org: string;
+}
 
 export type OrgsGetAuditLogData = AuditLogEvent[];
 
@@ -20862,11 +22736,34 @@ export type OrgsGetData = OrganizationFull;
 
 export type OrgsGetMembershipForAuthenticatedUserData = OrgMembership;
 
+export interface OrgsGetMembershipForAuthenticatedUserParams {
+  org: string;
+}
+
 export type OrgsGetMembershipForUserData = OrgMembership;
+
+export interface OrgsGetMembershipForUserParams {
+  org: string;
+  username: string;
+}
+
+export interface OrgsGetParams {
+  org: string;
+}
 
 export type OrgsGetWebhookConfigForOrgData = WebhookConfig;
 
+export interface OrgsGetWebhookConfigForOrgParams {
+  hookId: number;
+  org: string;
+}
+
 export type OrgsGetWebhookData = OrgHook;
+
+export interface OrgsGetWebhookParams {
+  hookId: number;
+  org: string;
+}
 
 export interface OrgsListAppInstallationsData {
   installations: Installation[];
@@ -20888,6 +22785,10 @@ export interface OrgsListAppInstallationsParams {
 }
 
 export type OrgsListBlockedUsersData = SimpleUser[];
+
+export interface OrgsListBlockedUsersParams {
+  org: string;
+}
 
 export type OrgsListData = OrganizationSimple[];
 
@@ -21112,6 +23013,10 @@ export interface OrgsListPublicMembersParams {
 
 export type OrgsListSamlSsoAuthorizationsData = CredentialAuthorization[];
 
+export interface OrgsListSamlSsoAuthorizationsParams {
+  org: string;
+}
+
 export type OrgsListWebhooksData = OrgHook[];
 
 export interface OrgsListWebhooksParams {
@@ -21130,9 +23035,24 @@ export interface OrgsListWebhooksParams {
 
 export type OrgsPingWebhookData = any;
 
+export interface OrgsPingWebhookParams {
+  hookId: number;
+  org: string;
+}
+
 export type OrgsRemoveMemberData = any;
 
+export interface OrgsRemoveMemberParams {
+  org: string;
+  username: string;
+}
+
 export type OrgsRemoveMembershipForUserData = any;
+
+export interface OrgsRemoveMembershipForUserParams {
+  org: string;
+  username: string;
+}
 
 export type OrgsRemoveOutsideCollaboratorData = any;
 
@@ -21141,11 +23061,31 @@ export type OrgsRemoveOutsideCollaboratorError = {
   message?: string;
 };
 
+export interface OrgsRemoveOutsideCollaboratorParams {
+  org: string;
+  username: string;
+}
+
 export type OrgsRemovePublicMembershipForAuthenticatedUserData = any;
+
+export interface OrgsRemovePublicMembershipForAuthenticatedUserParams {
+  org: string;
+  username: string;
+}
 
 export type OrgsRemoveSamlSsoAuthorizationData = any;
 
+export interface OrgsRemoveSamlSsoAuthorizationParams {
+  credentialId: number;
+  org: string;
+}
+
 export type OrgsSetMembershipForUserData = OrgMembership;
+
+export interface OrgsSetMembershipForUserParams {
+  org: string;
+  username: string;
+}
 
 export interface OrgsSetMembershipForUserPayload {
   /**
@@ -21170,7 +23110,17 @@ export enum OrgsSetMembershipForUserRoleEnum {
 
 export type OrgsSetPublicMembershipForAuthenticatedUserData = any;
 
+export interface OrgsSetPublicMembershipForAuthenticatedUserParams {
+  org: string;
+  username: string;
+}
+
 export type OrgsUnblockUserData = any;
+
+export interface OrgsUnblockUserParams {
+  org: string;
+  username: string;
+}
 
 export type OrgsUpdateData = OrganizationFull;
 
@@ -21206,6 +23156,10 @@ export enum OrgsUpdateMembersAllowedRepositoryCreationTypeEnum {
 
 export type OrgsUpdateMembershipForAuthenticatedUserData = OrgMembership;
 
+export interface OrgsUpdateMembershipForAuthenticatedUserParams {
+  org: string;
+}
+
 export interface OrgsUpdateMembershipForAuthenticatedUserPayload {
   /** The state that the membership should be in. Only \`"active"\` will be accepted. */
   state: OrgsUpdateMembershipForAuthenticatedUserStateEnum;
@@ -21214,6 +23168,10 @@ export interface OrgsUpdateMembershipForAuthenticatedUserPayload {
 /** The state that the membership should be in. Only \`"active"\` will be accepted. */
 export enum OrgsUpdateMembershipForAuthenticatedUserStateEnum {
   Active = "active",
+}
+
+export interface OrgsUpdateParams {
+  org: string;
 }
 
 export interface OrgsUpdatePayload {
@@ -21309,6 +23267,11 @@ export interface OrgsUpdatePayload {
 
 export type OrgsUpdateWebhookConfigForOrgData = WebhookConfig;
 
+export interface OrgsUpdateWebhookConfigForOrgParams {
+  hookId: number;
+  org: string;
+}
+
 /** @example {"content_type":"json","insecure_ssl":"0","secret":"********","url":"https://example.com/webhook"} */
 export interface OrgsUpdateWebhookConfigForOrgPayload {
   /** The media type used to serialize the payloads. Supported values include \`json\` and \`form\`. The default is \`form\`. */
@@ -21322,6 +23285,11 @@ export interface OrgsUpdateWebhookConfigForOrgPayload {
 }
 
 export type OrgsUpdateWebhookData = OrgHook;
+
+export interface OrgsUpdateWebhookParams {
+  hookId: number;
+  org: string;
+}
 
 export interface OrgsUpdateWebhookPayload {
   /**
@@ -21799,6 +23767,11 @@ export enum ProjectOrganizationPermissionEnum {
 
 export type ProjectsAddCollaboratorData = any;
 
+export interface ProjectsAddCollaboratorParams {
+  projectId: number;
+  username: string;
+}
+
 export interface ProjectsAddCollaboratorPayload {
   /**
    * The permission to grant the collaborator.
@@ -21833,6 +23806,11 @@ export type ProjectsCreateCardError =
       message?: string;
     };
 
+export interface ProjectsCreateCardParams {
+  /** column_id parameter */
+  columnId: number;
+}
+
 export type ProjectsCreateCardPayload =
   | {
       /**
@@ -21855,6 +23833,10 @@ export type ProjectsCreateCardPayload =
     };
 
 export type ProjectsCreateColumnData = ProjectColumn;
+
+export interface ProjectsCreateColumnParams {
+  projectId: number;
+}
 
 export interface ProjectsCreateColumnPayload {
   /**
@@ -21881,6 +23863,10 @@ export interface ProjectsCreateForAuthenticatedUserPayload {
 
 export type ProjectsCreateForOrgData = Project;
 
+export interface ProjectsCreateForOrgParams {
+  org: string;
+}
+
 export interface ProjectsCreateForOrgPayload {
   /** The description of the project. */
   body?: string;
@@ -21889,6 +23875,11 @@ export interface ProjectsCreateForOrgPayload {
 }
 
 export type ProjectsCreateForRepoData = Project;
+
+export interface ProjectsCreateForRepoParams {
+  owner: string;
+  repo: string;
+}
 
 export interface ProjectsCreateForRepoPayload {
   /** The description of the project. */
@@ -21905,7 +23896,17 @@ export type ProjectsDeleteCardError = {
   message?: string;
 };
 
+export interface ProjectsDeleteCardParams {
+  /** card_id parameter */
+  cardId: number;
+}
+
 export type ProjectsDeleteColumnData = any;
+
+export interface ProjectsDeleteColumnParams {
+  /** column_id parameter */
+  columnId: number;
+}
 
 export type ProjectsDeleteData = any;
 
@@ -21915,13 +23916,36 @@ export type ProjectsDeleteError = {
   message?: string;
 };
 
+export interface ProjectsDeleteParams {
+  projectId: number;
+}
+
 export type ProjectsGetCardData = ProjectCard;
+
+export interface ProjectsGetCardParams {
+  /** card_id parameter */
+  cardId: number;
+}
 
 export type ProjectsGetColumnData = ProjectColumn;
 
+export interface ProjectsGetColumnParams {
+  /** column_id parameter */
+  columnId: number;
+}
+
 export type ProjectsGetData = Project;
 
+export interface ProjectsGetParams {
+  projectId: number;
+}
+
 export type ProjectsGetPermissionForUserData = RepositoryCollaboratorPermission;
+
+export interface ProjectsGetPermissionForUserParams {
+  projectId: number;
+  username: string;
+}
 
 export type ProjectsListCardsData = ProjectCard[];
 
@@ -22125,6 +24149,11 @@ export type ProjectsMoveCardError =
       message?: string;
     };
 
+export interface ProjectsMoveCardParams {
+  /** card_id parameter */
+  cardId: number;
+}
+
 export interface ProjectsMoveCardPayload {
   /**
    * The unique identifier of the column the card should be moved to
@@ -22141,6 +24170,11 @@ export interface ProjectsMoveCardPayload {
 
 export type ProjectsMoveColumnData = object;
 
+export interface ProjectsMoveColumnParams {
+  /** column_id parameter */
+  columnId: number;
+}
+
 export interface ProjectsMoveColumnPayload {
   /**
    * The position of the column in a project
@@ -22152,7 +24186,17 @@ export interface ProjectsMoveColumnPayload {
 
 export type ProjectsRemoveCollaboratorData = any;
 
+export interface ProjectsRemoveCollaboratorParams {
+  projectId: number;
+  username: string;
+}
+
 export type ProjectsUpdateCardData = ProjectCard;
+
+export interface ProjectsUpdateCardParams {
+  /** card_id parameter */
+  cardId: number;
+}
 
 export interface ProjectsUpdateCardPayload {
   /**
@@ -22168,6 +24212,11 @@ export interface ProjectsUpdateCardPayload {
 }
 
 export type ProjectsUpdateColumnData = ProjectColumn;
+
+export interface ProjectsUpdateColumnParams {
+  /** column_id parameter */
+  columnId: number;
+}
 
 export interface ProjectsUpdateColumnPayload {
   /**
@@ -22191,6 +24240,10 @@ export enum ProjectsUpdateOrganizationPermissionEnum {
   Write = "write",
   Admin = "admin",
   None = "none",
+}
+
+export interface ProjectsUpdateParams {
+  projectId: number;
 }
 
 export interface ProjectsUpdatePayload {
@@ -23318,7 +25371,18 @@ export enum PullRequestStateEnum {
 
 export type PullsCheckIfMergedData = any;
 
+export interface PullsCheckIfMergedParams {
+  owner: string;
+  pullNumber: number;
+  repo: string;
+}
+
 export type PullsCreateData = PullRequest;
+
+export interface PullsCreateParams {
+  owner: string;
+  repo: string;
+}
 
 export interface PullsCreatePayload {
   /** The name of the branch you want the changes pulled into. This should be an existing branch on the current repository. You cannot submit a pull request to one repository that requests a merge to a base of another repository. */
@@ -23339,12 +25403,26 @@ export interface PullsCreatePayload {
 
 export type PullsCreateReplyForReviewCommentData = PullRequestReviewComment;
 
+export interface PullsCreateReplyForReviewCommentParams {
+  /** comment_id parameter */
+  commentId: number;
+  owner: string;
+  pullNumber: number;
+  repo: string;
+}
+
 export interface PullsCreateReplyForReviewCommentPayload {
   /** The text of the review comment. */
   body: string;
 }
 
 export type PullsCreateReviewCommentData = PullRequestReviewComment;
+
+export interface PullsCreateReviewCommentParams {
+  owner: string;
+  pullNumber: number;
+  repo: string;
+}
 
 export interface PullsCreateReviewCommentPayload {
   /** The text of the review comment. */
@@ -23389,6 +25467,12 @@ export enum PullsCreateReviewEventEnum {
   COMMENT = "COMMENT",
 }
 
+export interface PullsCreateReviewParams {
+  owner: string;
+  pullNumber: number;
+  repo: string;
+}
+
 export interface PullsCreateReviewPayload {
   /** **Required** when using \`REQUEST_CHANGES\` or \`COMMENT\` for the \`event\` parameter. The body text of the pull request review. */
   body?: string;
@@ -23417,9 +25501,32 @@ export interface PullsCreateReviewPayload {
 
 export type PullsDeletePendingReviewData = PullRequestReview;
 
+export interface PullsDeletePendingReviewParams {
+  owner: string;
+  pullNumber: number;
+  repo: string;
+  /** review_id parameter */
+  reviewId: number;
+}
+
 export type PullsDeleteReviewCommentData = any;
 
+export interface PullsDeleteReviewCommentParams {
+  /** comment_id parameter */
+  commentId: number;
+  owner: string;
+  repo: string;
+}
+
 export type PullsDismissReviewData = PullRequestReview;
+
+export interface PullsDismissReviewParams {
+  owner: string;
+  pullNumber: number;
+  repo: string;
+  /** review_id parameter */
+  reviewId: number;
+}
 
 export interface PullsDismissReviewPayload {
   /** @example ""APPROVE"" */
@@ -23430,9 +25537,30 @@ export interface PullsDismissReviewPayload {
 
 export type PullsGetData = PullRequest;
 
+export interface PullsGetParams {
+  owner: string;
+  pullNumber: number;
+  repo: string;
+}
+
 export type PullsGetReviewCommentData = PullRequestReviewComment;
 
+export interface PullsGetReviewCommentParams {
+  /** comment_id parameter */
+  commentId: number;
+  owner: string;
+  repo: string;
+}
+
 export type PullsGetReviewData = PullRequestReview;
+
+export interface PullsGetReviewParams {
+  owner: string;
+  pullNumber: number;
+  repo: string;
+  /** review_id parameter */
+  reviewId: number;
+}
 
 export type PullsListCommentsForReviewData = ReviewComment[];
 
@@ -23683,6 +25811,12 @@ export enum PullsMergeMergeMethodEnum {
   Rebase = "rebase",
 }
 
+export interface PullsMergeParams {
+  owner: string;
+  pullNumber: number;
+  repo: string;
+}
+
 export type PullsMergePayload = {
   /** Extra detail to append to automatic commit message. */
   commit_message?: string;
@@ -23696,6 +25830,12 @@ export type PullsMergePayload = {
 
 export type PullsRemoveRequestedReviewersData = any;
 
+export interface PullsRemoveRequestedReviewersParams {
+  owner: string;
+  pullNumber: number;
+  repo: string;
+}
+
 export interface PullsRemoveRequestedReviewersPayload {
   /** An array of user \`login\`s that will be removed. */
   reviewers?: string[];
@@ -23704,6 +25844,12 @@ export interface PullsRemoveRequestedReviewersPayload {
 }
 
 export type PullsRequestReviewersData = PullRequestSimple;
+
+export interface PullsRequestReviewersParams {
+  owner: string;
+  pullNumber: number;
+  repo: string;
+}
 
 export interface PullsRequestReviewersPayload {
   /** An array of user \`login\`s that will be requested. */
@@ -23721,6 +25867,14 @@ export enum PullsSubmitReviewEventEnum {
   COMMENT = "COMMENT",
 }
 
+export interface PullsSubmitReviewParams {
+  owner: string;
+  pullNumber: number;
+  repo: string;
+  /** review_id parameter */
+  reviewId: number;
+}
+
 export interface PullsSubmitReviewPayload {
   /** The body text of the pull request review */
   body?: string;
@@ -23733,12 +25887,24 @@ export interface PullsUpdateBranchData {
   url?: string;
 }
 
+export interface PullsUpdateBranchParams {
+  owner: string;
+  pullNumber: number;
+  repo: string;
+}
+
 export type PullsUpdateBranchPayload = {
   /** The expected SHA of the pull request's HEAD ref. This is the most recent commit on the pull request's branch. If the expected SHA does not match the pull request's HEAD, you will receive a \`422 Unprocessable Entity\` status. You can use the "[List commits](https://docs.github.com/rest/reference/repos#list-commits)" endpoint to find the most recent commit SHA. Default: SHA of the pull request's current HEAD ref. */
   expected_head_sha?: string;
 } | null;
 
 export type PullsUpdateData = PullRequest;
+
+export interface PullsUpdateParams {
+  owner: string;
+  pullNumber: number;
+  repo: string;
+}
 
 export interface PullsUpdatePayload {
   /** The name of the branch you want your changes pulled into. This should be an existing branch on the current repository. You cannot update the base branch on a pull request to point to another repository. */
@@ -23755,12 +25921,27 @@ export interface PullsUpdatePayload {
 
 export type PullsUpdateReviewCommentData = PullRequestReviewComment;
 
+export interface PullsUpdateReviewCommentParams {
+  /** comment_id parameter */
+  commentId: number;
+  owner: string;
+  repo: string;
+}
+
 export interface PullsUpdateReviewCommentPayload {
   /** The text of the reply to the review comment. */
   body: string;
 }
 
 export type PullsUpdateReviewData = PullRequestReview;
+
+export interface PullsUpdateReviewParams {
+  owner: string;
+  pullNumber: number;
+  repo: string;
+  /** review_id parameter */
+  reviewId: number;
+}
 
 export interface PullsUpdateReviewPayload {
   /** The body text of the pull request review. */
@@ -23864,6 +26045,13 @@ export enum ReactionsCreateForCommitCommentContentEnum {
 
 export type ReactionsCreateForCommitCommentData = Reaction;
 
+export interface ReactionsCreateForCommitCommentParams {
+  /** comment_id parameter */
+  commentId: number;
+  owner: string;
+  repo: string;
+}
+
 export interface ReactionsCreateForCommitCommentPayload {
   /** The [reaction type](https://docs.github.com/rest/reference/reactions#reaction-types) to add to the commit comment. */
   content: ReactionsCreateForCommitCommentContentEnum;
@@ -23882,6 +26070,13 @@ export enum ReactionsCreateForIssueCommentContentEnum {
 }
 
 export type ReactionsCreateForIssueCommentData = Reaction;
+
+export interface ReactionsCreateForIssueCommentParams {
+  /** comment_id parameter */
+  commentId: number;
+  owner: string;
+  repo: string;
+}
 
 export interface ReactionsCreateForIssueCommentPayload {
   /** The [reaction type](https://docs.github.com/rest/reference/reactions#reaction-types) to add to the issue comment. */
@@ -23902,6 +26097,13 @@ export enum ReactionsCreateForIssueContentEnum {
 
 export type ReactionsCreateForIssueData = Reaction;
 
+export interface ReactionsCreateForIssueParams {
+  /** issue_number parameter */
+  issueNumber: number;
+  owner: string;
+  repo: string;
+}
+
 export interface ReactionsCreateForIssuePayload {
   /** The [reaction type](https://docs.github.com/rest/reference/reactions#reaction-types) to add to the issue. */
   content: ReactionsCreateForIssueContentEnum;
@@ -23920,6 +26122,13 @@ export enum ReactionsCreateForPullRequestReviewCommentContentEnum {
 }
 
 export type ReactionsCreateForPullRequestReviewCommentData = Reaction;
+
+export interface ReactionsCreateForPullRequestReviewCommentParams {
+  /** comment_id parameter */
+  commentId: number;
+  owner: string;
+  repo: string;
+}
 
 export interface ReactionsCreateForPullRequestReviewCommentPayload {
   /** The [reaction type](https://docs.github.com/rest/reference/reactions#reaction-types) to add to the pull request review comment. */
@@ -23940,6 +26149,14 @@ export enum ReactionsCreateForTeamDiscussionCommentInOrgContentEnum {
 
 export type ReactionsCreateForTeamDiscussionCommentInOrgData = Reaction;
 
+export interface ReactionsCreateForTeamDiscussionCommentInOrgParams {
+  commentNumber: number;
+  discussionNumber: number;
+  org: string;
+  /** team_slug parameter */
+  teamSlug: string;
+}
+
 export interface ReactionsCreateForTeamDiscussionCommentInOrgPayload {
   /** The [reaction type](https://docs.github.com/rest/reference/reactions#reaction-types) to add to the team discussion comment. */
   content: ReactionsCreateForTeamDiscussionCommentInOrgContentEnum;
@@ -23958,6 +26175,12 @@ export enum ReactionsCreateForTeamDiscussionCommentLegacyContentEnum {
 }
 
 export type ReactionsCreateForTeamDiscussionCommentLegacyData = Reaction;
+
+export interface ReactionsCreateForTeamDiscussionCommentLegacyParams {
+  commentNumber: number;
+  discussionNumber: number;
+  teamId: number;
+}
 
 export interface ReactionsCreateForTeamDiscussionCommentLegacyPayload {
   /** The [reaction type](https://docs.github.com/rest/reference/reactions#reaction-types) to add to the team discussion comment. */
@@ -23978,6 +26201,13 @@ export enum ReactionsCreateForTeamDiscussionInOrgContentEnum {
 
 export type ReactionsCreateForTeamDiscussionInOrgData = Reaction;
 
+export interface ReactionsCreateForTeamDiscussionInOrgParams {
+  discussionNumber: number;
+  org: string;
+  /** team_slug parameter */
+  teamSlug: string;
+}
+
 export interface ReactionsCreateForTeamDiscussionInOrgPayload {
   /** The [reaction type](https://docs.github.com/rest/reference/reactions#reaction-types) to add to the team discussion. */
   content: ReactionsCreateForTeamDiscussionInOrgContentEnum;
@@ -23997,6 +26227,11 @@ export enum ReactionsCreateForTeamDiscussionLegacyContentEnum {
 
 export type ReactionsCreateForTeamDiscussionLegacyData = Reaction;
 
+export interface ReactionsCreateForTeamDiscussionLegacyParams {
+  discussionNumber: number;
+  teamId: number;
+}
+
 export interface ReactionsCreateForTeamDiscussionLegacyPayload {
   /** The [reaction type](https://docs.github.com/rest/reference/reactions#reaction-types) to add to the team discussion. */
   content: ReactionsCreateForTeamDiscussionLegacyContentEnum;
@@ -24004,17 +26239,70 @@ export interface ReactionsCreateForTeamDiscussionLegacyPayload {
 
 export type ReactionsDeleteForCommitCommentData = any;
 
+export interface ReactionsDeleteForCommitCommentParams {
+  /** comment_id parameter */
+  commentId: number;
+  owner: string;
+  reactionId: number;
+  repo: string;
+}
+
 export type ReactionsDeleteForIssueCommentData = any;
+
+export interface ReactionsDeleteForIssueCommentParams {
+  /** comment_id parameter */
+  commentId: number;
+  owner: string;
+  reactionId: number;
+  repo: string;
+}
 
 export type ReactionsDeleteForIssueData = any;
 
+export interface ReactionsDeleteForIssueParams {
+  /** issue_number parameter */
+  issueNumber: number;
+  owner: string;
+  reactionId: number;
+  repo: string;
+}
+
 export type ReactionsDeleteForPullRequestCommentData = any;
+
+export interface ReactionsDeleteForPullRequestCommentParams {
+  /** comment_id parameter */
+  commentId: number;
+  owner: string;
+  reactionId: number;
+  repo: string;
+}
 
 export type ReactionsDeleteForTeamDiscussionCommentData = any;
 
+export interface ReactionsDeleteForTeamDiscussionCommentParams {
+  commentNumber: number;
+  discussionNumber: number;
+  org: string;
+  reactionId: number;
+  /** team_slug parameter */
+  teamSlug: string;
+}
+
 export type ReactionsDeleteForTeamDiscussionData = any;
 
+export interface ReactionsDeleteForTeamDiscussionParams {
+  discussionNumber: number;
+  org: string;
+  reactionId: number;
+  /** team_slug parameter */
+  teamSlug: string;
+}
+
 export type ReactionsDeleteLegacyData = any;
+
+export interface ReactionsDeleteLegacyParams {
+  reactionId: number;
+}
 
 export type ReactionsListForCommitCommentData = Reaction[];
 
@@ -24495,7 +26783,19 @@ export interface RepoSearchResultItem {
 
 export type ReposAcceptInvitationData = any;
 
+export interface ReposAcceptInvitationParams {
+  /** invitation_id parameter */
+  invitationId: number;
+}
+
 export type ReposAddAppAccessRestrictionsData = Integration[];
+
+export interface ReposAddAppAccessRestrictionsParams {
+  /** The name of the branch. */
+  branch: string;
+  owner: string;
+  repo: string;
+}
 
 /** @example {"apps":["my-app"]} */
 export interface ReposAddAppAccessRestrictionsPayload {
@@ -24504,6 +26804,12 @@ export interface ReposAddAppAccessRestrictionsPayload {
 }
 
 export type ReposAddCollaboratorData = RepositoryInvitation;
+
+export interface ReposAddCollaboratorParams {
+  owner: string;
+  repo: string;
+  username: string;
+}
 
 export interface ReposAddCollaboratorPayload {
   /**
@@ -24539,6 +26845,13 @@ export enum ReposAddCollaboratorPermissionEnum {
 
 export type ReposAddStatusCheckContextsData = string[];
 
+export interface ReposAddStatusCheckContextsParams {
+  /** The name of the branch. */
+  branch: string;
+  owner: string;
+  repo: string;
+}
+
 /** @example {"contexts":["contexts"]} */
 export interface ReposAddStatusCheckContextsPayload {
   /** contexts parameter */
@@ -24546,6 +26859,13 @@ export interface ReposAddStatusCheckContextsPayload {
 }
 
 export type ReposAddTeamAccessRestrictionsData = Team[];
+
+export interface ReposAddTeamAccessRestrictionsParams {
+  /** The name of the branch. */
+  branch: string;
+  owner: string;
+  repo: string;
+}
 
 /** @example {"teams":["my-team"]} */
 export interface ReposAddTeamAccessRestrictionsPayload {
@@ -24555,6 +26875,13 @@ export interface ReposAddTeamAccessRestrictionsPayload {
 
 export type ReposAddUserAccessRestrictionsData = SimpleUser[];
 
+export interface ReposAddUserAccessRestrictionsParams {
+  /** The name of the branch. */
+  branch: string;
+  owner: string;
+  repo: string;
+}
+
 /** @example {"users":["mona"]} */
 export interface ReposAddUserAccessRestrictionsPayload {
   /** users parameter */
@@ -24563,11 +26890,36 @@ export interface ReposAddUserAccessRestrictionsPayload {
 
 export type ReposCheckCollaboratorData = any;
 
+export interface ReposCheckCollaboratorParams {
+  owner: string;
+  repo: string;
+  username: string;
+}
+
 export type ReposCheckVulnerabilityAlertsData = any;
+
+export interface ReposCheckVulnerabilityAlertsParams {
+  owner: string;
+  repo: string;
+}
 
 export type ReposCompareCommitsData = CommitComparison;
 
+export interface ReposCompareCommitsParams {
+  base: string;
+  head: string;
+  owner: string;
+  repo: string;
+}
+
 export type ReposCreateCommitCommentData = CommitComment;
+
+export interface ReposCreateCommitCommentParams {
+  /** commit_sha parameter */
+  commitSha: string;
+  owner: string;
+  repo: string;
+}
 
 export interface ReposCreateCommitCommentPayload {
   /** The contents of the comment. */
@@ -24583,7 +26935,20 @@ export interface ReposCreateCommitCommentPayload {
 export type ReposCreateCommitSignatureProtectionData =
   ProtectedBranchAdminEnforced;
 
+export interface ReposCreateCommitSignatureProtectionParams {
+  /** The name of the branch. */
+  branch: string;
+  owner: string;
+  repo: string;
+}
+
 export type ReposCreateCommitStatusData = Status;
+
+export interface ReposCreateCommitStatusParams {
+  owner: string;
+  repo: string;
+  sha: string;
+}
 
 export interface ReposCreateCommitStatusPayload {
   /**
@@ -24613,6 +26978,11 @@ export enum ReposCreateCommitStatusStateEnum {
 
 export type ReposCreateDeployKeyData = DeployKey;
 
+export interface ReposCreateDeployKeyParams {
+  owner: string;
+  repo: string;
+}
+
 export interface ReposCreateDeployKeyPayload {
   /** The contents of the key. */
   key: string;
@@ -24633,6 +27003,11 @@ export type ReposCreateDeploymentError = {
   documentation_url?: string;
   message?: string;
 };
+
+export interface ReposCreateDeploymentParams {
+  owner: string;
+  repo: string;
+}
 
 export interface ReposCreateDeploymentPayload {
   /**
@@ -24685,6 +27060,13 @@ export enum ReposCreateDeploymentStatusEnvironmentEnum {
   Qa = "qa",
 }
 
+export interface ReposCreateDeploymentStatusParams {
+  /** deployment_id parameter */
+  deploymentId: number;
+  owner: string;
+  repo: string;
+}
+
 export interface ReposCreateDeploymentStatusPayload {
   /**
    * Adds a new \`inactive\` status to all prior non-transient, non-production environment deployments with the same repository and \`environment\` name as the created status's deployment. An \`inactive\` status is only added to deployments that had a \`success\` state. Default: \`true\`
@@ -24732,6 +27114,11 @@ export enum ReposCreateDeploymentStatusStateEnum {
 }
 
 export type ReposCreateDispatchEventData = any;
+
+export interface ReposCreateDispatchEventParams {
+  owner: string;
+  repo: string;
+}
 
 export interface ReposCreateDispatchEventPayload {
   /** JSON payload with extra information about the webhook event that your action or worklow may use. */
@@ -24832,12 +27219,21 @@ export interface ReposCreateForAuthenticatedUserPayload {
 
 export type ReposCreateForkData = Repository;
 
+export interface ReposCreateForkParams {
+  owner: string;
+  repo: string;
+}
+
 export interface ReposCreateForkPayload {
   /** Optional parameter to specify the organization name if forking into an organization. */
   organization?: string;
 }
 
 export type ReposCreateInOrgData = Repository;
+
+export interface ReposCreateInOrgParams {
+  org: string;
+}
 
 export interface ReposCreateInOrgPayload {
   /**
@@ -24922,6 +27318,13 @@ export enum ReposCreateInOrgVisibilityEnum {
 
 export type ReposCreateOrUpdateFileContentsData = FileCommit;
 
+export interface ReposCreateOrUpdateFileContentsParams {
+  owner: string;
+  /** path+ parameter */
+  path: string;
+  repo: string;
+}
+
 export interface ReposCreateOrUpdateFileContentsPayload {
   /** The author of the file. Default: The \`committer\` or the authenticated user if you omit \`committer\`. */
   author?: {
@@ -24953,6 +27356,11 @@ export interface ReposCreateOrUpdateFileContentsPayload {
 
 export type ReposCreatePagesSiteData = Page;
 
+export interface ReposCreatePagesSiteParams {
+  owner: string;
+  repo: string;
+}
+
 /**
  * The repository directory that includes the source files for the Pages site. Allowed paths are \`/\` or \`/docs\`. Default: \`/\`
  * @default "/"
@@ -24978,6 +27386,11 @@ export interface ReposCreatePagesSitePayload {
 
 export type ReposCreateReleaseData = Release;
 
+export interface ReposCreateReleaseParams {
+  owner: string;
+  repo: string;
+}
+
 export interface ReposCreateReleasePayload {
   /** Text describing the contents of the tag. */
   body?: string;
@@ -25001,6 +27414,11 @@ export interface ReposCreateReleasePayload {
 
 export type ReposCreateUsingTemplateData = Repository;
 
+export interface ReposCreateUsingTemplateParams {
+  templateOwner: string;
+  templateRepo: string;
+}
+
 export interface ReposCreateUsingTemplatePayload {
   /** A short description of the new repository. */
   description?: string;
@@ -25021,6 +27439,11 @@ export interface ReposCreateUsingTemplatePayload {
 }
 
 export type ReposCreateWebhookData = Hook;
+
+export interface ReposCreateWebhookParams {
+  owner: string;
+  repo: string;
+}
 
 export interface ReposCreateWebhookPayload {
   /**
@@ -25054,21 +27477,75 @@ export interface ReposCreateWebhookPayload {
 
 export type ReposDeclineInvitationData = any;
 
+export interface ReposDeclineInvitationParams {
+  /** invitation_id parameter */
+  invitationId: number;
+}
+
 export type ReposDeleteAccessRestrictionsData = any;
+
+export interface ReposDeleteAccessRestrictionsParams {
+  /** The name of the branch. */
+  branch: string;
+  owner: string;
+  repo: string;
+}
 
 export type ReposDeleteAdminBranchProtectionData = any;
 
+export interface ReposDeleteAdminBranchProtectionParams {
+  /** The name of the branch. */
+  branch: string;
+  owner: string;
+  repo: string;
+}
+
 export type ReposDeleteBranchProtectionData = any;
+
+export interface ReposDeleteBranchProtectionParams {
+  /** The name of the branch. */
+  branch: string;
+  owner: string;
+  repo: string;
+}
 
 export type ReposDeleteCommitCommentData = any;
 
+export interface ReposDeleteCommitCommentParams {
+  /** comment_id parameter */
+  commentId: number;
+  owner: string;
+  repo: string;
+}
+
 export type ReposDeleteCommitSignatureProtectionData = any;
+
+export interface ReposDeleteCommitSignatureProtectionParams {
+  /** The name of the branch. */
+  branch: string;
+  owner: string;
+  repo: string;
+}
 
 export type ReposDeleteData = any;
 
 export type ReposDeleteDeployKeyData = any;
 
+export interface ReposDeleteDeployKeyParams {
+  /** key_id parameter */
+  keyId: number;
+  owner: string;
+  repo: string;
+}
+
 export type ReposDeleteDeploymentData = any;
+
+export interface ReposDeleteDeploymentParams {
+  /** deployment_id parameter */
+  deploymentId: number;
+  owner: string;
+  repo: string;
+}
 
 export type ReposDeleteError = {
   documentation_url?: string;
@@ -25076,6 +27553,13 @@ export type ReposDeleteError = {
 };
 
 export type ReposDeleteFileData = FileCommit;
+
+export interface ReposDeleteFileParams {
+  owner: string;
+  /** path+ parameter */
+  path: string;
+  repo: string;
+}
 
 export interface ReposDeleteFilePayload {
   /** object containing information about the author. */
@@ -25102,37 +27586,160 @@ export interface ReposDeleteFilePayload {
 
 export type ReposDeleteInvitationData = any;
 
+export interface ReposDeleteInvitationParams {
+  /** invitation_id parameter */
+  invitationId: number;
+  owner: string;
+  repo: string;
+}
+
 export type ReposDeletePagesSiteData = any;
+
+export interface ReposDeletePagesSiteParams {
+  owner: string;
+  repo: string;
+}
+
+export interface ReposDeleteParams {
+  owner: string;
+  repo: string;
+}
 
 export type ReposDeletePullRequestReviewProtectionData = any;
 
+export interface ReposDeletePullRequestReviewProtectionParams {
+  /** The name of the branch. */
+  branch: string;
+  owner: string;
+  repo: string;
+}
+
 export type ReposDeleteReleaseAssetData = any;
+
+export interface ReposDeleteReleaseAssetParams {
+  /** asset_id parameter */
+  assetId: number;
+  owner: string;
+  repo: string;
+}
 
 export type ReposDeleteReleaseData = any;
 
+export interface ReposDeleteReleaseParams {
+  owner: string;
+  /** release_id parameter */
+  releaseId: number;
+  repo: string;
+}
+
 export type ReposDeleteWebhookData = any;
+
+export interface ReposDeleteWebhookParams {
+  hookId: number;
+  owner: string;
+  repo: string;
+}
 
 export type ReposDisableAutomatedSecurityFixesData = any;
 
+export interface ReposDisableAutomatedSecurityFixesParams {
+  owner: string;
+  repo: string;
+}
+
 export type ReposDisableVulnerabilityAlertsData = any;
+
+export interface ReposDisableVulnerabilityAlertsParams {
+  owner: string;
+  repo: string;
+}
+
+export interface ReposDownloadTarballArchiveParams {
+  owner: string;
+  ref: string;
+  repo: string;
+}
+
+export interface ReposDownloadZipballArchiveParams {
+  owner: string;
+  ref: string;
+  repo: string;
+}
 
 export type ReposEnableAutomatedSecurityFixesData = any;
 
+export interface ReposEnableAutomatedSecurityFixesParams {
+  owner: string;
+  repo: string;
+}
+
 export type ReposEnableVulnerabilityAlertsData = any;
+
+export interface ReposEnableVulnerabilityAlertsParams {
+  owner: string;
+  repo: string;
+}
 
 export type ReposGetAccessRestrictionsData = BranchRestrictionPolicy;
 
+export interface ReposGetAccessRestrictionsParams {
+  /** The name of the branch. */
+  branch: string;
+  owner: string;
+  repo: string;
+}
+
 export type ReposGetAdminBranchProtectionData = ProtectedBranchAdminEnforced;
+
+export interface ReposGetAdminBranchProtectionParams {
+  /** The name of the branch. */
+  branch: string;
+  owner: string;
+  repo: string;
+}
 
 export type ReposGetAllStatusCheckContextsData = string[];
 
+export interface ReposGetAllStatusCheckContextsParams {
+  /** The name of the branch. */
+  branch: string;
+  owner: string;
+  repo: string;
+}
+
 export type ReposGetAllTopicsData = Topic;
+
+export interface ReposGetAllTopicsParams {
+  owner: string;
+  repo: string;
+}
 
 export type ReposGetAppsWithAccessToProtectedBranchData = Integration[];
 
+export interface ReposGetAppsWithAccessToProtectedBranchParams {
+  /** The name of the branch. */
+  branch: string;
+  owner: string;
+  repo: string;
+}
+
 export type ReposGetBranchData = BranchWithProtection;
 
+export interface ReposGetBranchParams {
+  /** The name of the branch. */
+  branch: string;
+  owner: string;
+  repo: string;
+}
+
 export type ReposGetBranchProtectionData = BranchProtection;
+
+export interface ReposGetBranchProtectionParams {
+  /** The name of the branch. */
+  branch: string;
+  owner: string;
+  repo: string;
+}
 
 export type ReposGetClonesData = CloneTraffic;
 
@@ -25157,21 +27764,70 @@ export enum ReposGetClonesParams1PerEnum {
 
 export type ReposGetCodeFrequencyStatsData = CodeFrequencyStat[];
 
+export interface ReposGetCodeFrequencyStatsParams {
+  owner: string;
+  repo: string;
+}
+
 export type ReposGetCollaboratorPermissionLevelData =
   RepositoryCollaboratorPermission;
 
+export interface ReposGetCollaboratorPermissionLevelParams {
+  owner: string;
+  repo: string;
+  username: string;
+}
+
 export type ReposGetCombinedStatusForRefData = CombinedCommitStatus;
+
+export interface ReposGetCombinedStatusForRefParams {
+  owner: string;
+  /** ref+ parameter */
+  ref: string;
+  repo: string;
+}
 
 export type ReposGetCommitActivityStatsData = CommitActivity[];
 
+export interface ReposGetCommitActivityStatsParams {
+  owner: string;
+  repo: string;
+}
+
 export type ReposGetCommitCommentData = CommitComment;
 
+export interface ReposGetCommitCommentParams {
+  /** comment_id parameter */
+  commentId: number;
+  owner: string;
+  repo: string;
+}
+
 export type ReposGetCommitData = Commit;
+
+export interface ReposGetCommitParams {
+  owner: string;
+  /** ref+ parameter */
+  ref: string;
+  repo: string;
+}
 
 export type ReposGetCommitSignatureProtectionData =
   ProtectedBranchAdminEnforced;
 
+export interface ReposGetCommitSignatureProtectionParams {
+  /** The name of the branch. */
+  branch: string;
+  owner: string;
+  repo: string;
+}
+
 export type ReposGetCommunityProfileMetricsData = CommunityProfile;
+
+export interface ReposGetCommunityProfileMetricsParams {
+  owner: string;
+  repo: string;
+}
 
 export type ReposGetContentData = ContentTree;
 
@@ -25186,28 +27842,98 @@ export interface ReposGetContentParams {
 
 export type ReposGetContributorsStatsData = ContributorActivity[];
 
+export interface ReposGetContributorsStatsParams {
+  owner: string;
+  repo: string;
+}
+
 export type ReposGetData = FullRepository;
 
 export type ReposGetDeployKeyData = DeployKey;
 
+export interface ReposGetDeployKeyParams {
+  /** key_id parameter */
+  keyId: number;
+  owner: string;
+  repo: string;
+}
+
 export type ReposGetDeploymentData = Deployment;
+
+export interface ReposGetDeploymentParams {
+  /** deployment_id parameter */
+  deploymentId: number;
+  owner: string;
+  repo: string;
+}
 
 export type ReposGetDeploymentStatusData = DeploymentStatus;
 
+export interface ReposGetDeploymentStatusParams {
+  /** deployment_id parameter */
+  deploymentId: number;
+  owner: string;
+  repo: string;
+  statusId: number;
+}
+
 export type ReposGetLatestPagesBuildData = PageBuild;
+
+export interface ReposGetLatestPagesBuildParams {
+  owner: string;
+  repo: string;
+}
 
 export type ReposGetLatestReleaseData = Release;
 
+export interface ReposGetLatestReleaseParams {
+  owner: string;
+  repo: string;
+}
+
 export type ReposGetPagesBuildData = PageBuild;
+
+export interface ReposGetPagesBuildParams {
+  buildId: number;
+  owner: string;
+  repo: string;
+}
 
 export type ReposGetPagesData = Page;
 
+export interface ReposGetPagesParams {
+  owner: string;
+  repo: string;
+}
+
+export interface ReposGetParams {
+  owner: string;
+  repo: string;
+}
+
 export type ReposGetParticipationStatsData = ParticipationStats;
+
+export interface ReposGetParticipationStatsParams {
+  owner: string;
+  repo: string;
+}
 
 export type ReposGetPullRequestReviewProtectionData =
   ProtectedBranchPullRequestReview;
 
+export interface ReposGetPullRequestReviewProtectionParams {
+  /** The name of the branch. */
+  branch: string;
+  owner: string;
+  repo: string;
+}
+
 export type ReposGetPunchCardStatsData = CodeFrequencyStat[];
+
+export interface ReposGetPunchCardStatsParams {
+  owner: string;
+  repo: string;
+}
 
 export type ReposGetReadmeData = ContentFile;
 
@@ -25220,19 +27946,71 @@ export interface ReposGetReadmeParams {
 
 export type ReposGetReleaseAssetData = ReleaseAsset;
 
+export interface ReposGetReleaseAssetParams {
+  /** asset_id parameter */
+  assetId: number;
+  owner: string;
+  repo: string;
+}
+
 export type ReposGetReleaseByTagData = Release;
+
+export interface ReposGetReleaseByTagParams {
+  owner: string;
+  repo: string;
+  /** tag+ parameter */
+  tag: string;
+}
 
 export type ReposGetReleaseData = Release;
 
+export interface ReposGetReleaseParams {
+  owner: string;
+  /** release_id parameter */
+  releaseId: number;
+  repo: string;
+}
+
 export type ReposGetStatusChecksProtectionData = StatusCheckPolicy;
+
+export interface ReposGetStatusChecksProtectionParams {
+  /** The name of the branch. */
+  branch: string;
+  owner: string;
+  repo: string;
+}
 
 export type ReposGetTeamsWithAccessToProtectedBranchData = Team[];
 
+export interface ReposGetTeamsWithAccessToProtectedBranchParams {
+  /** The name of the branch. */
+  branch: string;
+  owner: string;
+  repo: string;
+}
+
 export type ReposGetTopPathsData = ContentTraffic[];
+
+export interface ReposGetTopPathsParams {
+  owner: string;
+  repo: string;
+}
 
 export type ReposGetTopReferrersData = ReferrerTraffic[];
 
+export interface ReposGetTopReferrersParams {
+  owner: string;
+  repo: string;
+}
+
 export type ReposGetUsersWithAccessToProtectedBranchData = SimpleUser[];
+
+export interface ReposGetUsersWithAccessToProtectedBranchParams {
+  /** The name of the branch. */
+  branch: string;
+  owner: string;
+  repo: string;
+}
 
 export type ReposGetViewsData = ViewTraffic;
 
@@ -25257,11 +28035,30 @@ export enum ReposGetViewsParams1PerEnum {
 
 export type ReposGetWebhookConfigForRepoData = WebhookConfig;
 
+export interface ReposGetWebhookConfigForRepoParams {
+  hookId: number;
+  owner: string;
+  repo: string;
+}
+
 export type ReposGetWebhookData = Hook;
+
+export interface ReposGetWebhookParams {
+  hookId: number;
+  owner: string;
+  repo: string;
+}
 
 export type ReposListBranchesData = ShortBranch[];
 
 export type ReposListBranchesForHeadCommitData = BranchShort[];
+
+export interface ReposListBranchesForHeadCommitParams {
+  /** commit_sha parameter */
+  commitSha: string;
+  owner: string;
+  repo: string;
+}
 
 export interface ReposListBranchesParams {
   owner: string;
@@ -25754,6 +28551,11 @@ export interface ReposListInvitationsParams {
 
 export type ReposListLanguagesData = Language;
 
+export interface ReposListLanguagesParams {
+  owner: string;
+  repo: string;
+}
+
 export type ReposListPagesBuildsData = PageBuild[];
 
 export interface ReposListPagesBuildsParams {
@@ -25892,6 +28694,11 @@ export type ReposMergeError = {
   message?: string;
 };
 
+export interface ReposMergeParams {
+  owner: string;
+  repo: string;
+}
+
 export interface ReposMergePayload {
   /** The name of the base branch that the head will be merged into. */
   base: string;
@@ -25903,7 +28710,20 @@ export interface ReposMergePayload {
 
 export type ReposPingWebhookData = any;
 
+export interface ReposPingWebhookParams {
+  hookId: number;
+  owner: string;
+  repo: string;
+}
+
 export type ReposRemoveAppAccessRestrictionsData = Integration[];
+
+export interface ReposRemoveAppAccessRestrictionsParams {
+  /** The name of the branch. */
+  branch: string;
+  owner: string;
+  repo: string;
+}
 
 /** @example {"apps":["my-app"]} */
 export interface ReposRemoveAppAccessRestrictionsPayload {
@@ -25913,7 +28733,20 @@ export interface ReposRemoveAppAccessRestrictionsPayload {
 
 export type ReposRemoveCollaboratorData = any;
 
+export interface ReposRemoveCollaboratorParams {
+  owner: string;
+  repo: string;
+  username: string;
+}
+
 export type ReposRemoveStatusCheckContextsData = string[];
+
+export interface ReposRemoveStatusCheckContextsParams {
+  /** The name of the branch. */
+  branch: string;
+  owner: string;
+  repo: string;
+}
 
 /** @example {"contexts":["contexts"]} */
 export interface ReposRemoveStatusCheckContextsPayload {
@@ -25923,7 +28756,21 @@ export interface ReposRemoveStatusCheckContextsPayload {
 
 export type ReposRemoveStatusCheckProtectionData = any;
 
+export interface ReposRemoveStatusCheckProtectionParams {
+  /** The name of the branch. */
+  branch: string;
+  owner: string;
+  repo: string;
+}
+
 export type ReposRemoveTeamAccessRestrictionsData = Team[];
+
+export interface ReposRemoveTeamAccessRestrictionsParams {
+  /** The name of the branch. */
+  branch: string;
+  owner: string;
+  repo: string;
+}
 
 /** @example {"teams":["my-team"]} */
 export interface ReposRemoveTeamAccessRestrictionsPayload {
@@ -25933,6 +28780,13 @@ export interface ReposRemoveTeamAccessRestrictionsPayload {
 
 export type ReposRemoveUserAccessRestrictionsData = SimpleUser[];
 
+export interface ReposRemoveUserAccessRestrictionsParams {
+  /** The name of the branch. */
+  branch: string;
+  owner: string;
+  repo: string;
+}
+
 /** @example {"users":["mona"]} */
 export interface ReposRemoveUserAccessRestrictionsPayload {
   /** users parameter */
@@ -25941,12 +28795,24 @@ export interface ReposRemoveUserAccessRestrictionsPayload {
 
 export type ReposRenameBranchData = BranchWithProtection;
 
+export interface ReposRenameBranchParams {
+  /** The name of the branch. */
+  branch: string;
+  owner: string;
+  repo: string;
+}
+
 export interface ReposRenameBranchPayload {
   /** The new name of the branch. */
   new_name: string;
 }
 
 export type ReposReplaceAllTopicsData = Topic;
+
+export interface ReposReplaceAllTopicsParams {
+  owner: string;
+  repo: string;
+}
 
 export interface ReposReplaceAllTopicsPayload {
   /** An array of topics to add to the repository. Pass one or more topics to _replace_ the set of existing topics. Send an empty array (\`[]\`) to clear all topics from the repository. **Note:** Topic \`names\` cannot contain uppercase letters. */
@@ -25955,9 +28821,28 @@ export interface ReposReplaceAllTopicsPayload {
 
 export type ReposRequestPagesBuildData = PageBuildStatus;
 
+export interface ReposRequestPagesBuildParams {
+  owner: string;
+  repo: string;
+}
+
 export type ReposSetAdminBranchProtectionData = ProtectedBranchAdminEnforced;
 
+export interface ReposSetAdminBranchProtectionParams {
+  /** The name of the branch. */
+  branch: string;
+  owner: string;
+  repo: string;
+}
+
 export type ReposSetAppAccessRestrictionsData = Integration[];
+
+export interface ReposSetAppAccessRestrictionsParams {
+  /** The name of the branch. */
+  branch: string;
+  owner: string;
+  repo: string;
+}
 
 /** @example {"apps":["my-app"]} */
 export interface ReposSetAppAccessRestrictionsPayload {
@@ -25967,6 +28852,13 @@ export interface ReposSetAppAccessRestrictionsPayload {
 
 export type ReposSetStatusCheckContextsData = string[];
 
+export interface ReposSetStatusCheckContextsParams {
+  /** The name of the branch. */
+  branch: string;
+  owner: string;
+  repo: string;
+}
+
 /** @example {"contexts":["contexts"]} */
 export interface ReposSetStatusCheckContextsPayload {
   /** contexts parameter */
@@ -25974,6 +28866,13 @@ export interface ReposSetStatusCheckContextsPayload {
 }
 
 export type ReposSetTeamAccessRestrictionsData = Team[];
+
+export interface ReposSetTeamAccessRestrictionsParams {
+  /** The name of the branch. */
+  branch: string;
+  owner: string;
+  repo: string;
+}
 
 /** @example {"teams":["my-team"]} */
 export interface ReposSetTeamAccessRestrictionsPayload {
@@ -25983,6 +28882,13 @@ export interface ReposSetTeamAccessRestrictionsPayload {
 
 export type ReposSetUserAccessRestrictionsData = SimpleUser[];
 
+export interface ReposSetUserAccessRestrictionsParams {
+  /** The name of the branch. */
+  branch: string;
+  owner: string;
+  repo: string;
+}
+
 /** @example {"users":["mona"]} */
 export interface ReposSetUserAccessRestrictionsPayload {
   /** users parameter */
@@ -25991,7 +28897,18 @@ export interface ReposSetUserAccessRestrictionsPayload {
 
 export type ReposTestPushWebhookData = any;
 
+export interface ReposTestPushWebhookParams {
+  hookId: number;
+  owner: string;
+  repo: string;
+}
+
 export type ReposTransferData = Repository;
+
+export interface ReposTransferParams {
+  owner: string;
+  repo: string;
+}
 
 export interface ReposTransferPayload {
   /** The username or organization name the repository will be transferred to. */
@@ -26001,6 +28918,13 @@ export interface ReposTransferPayload {
 }
 
 export type ReposUpdateBranchProtectionData = ProtectedBranch;
+
+export interface ReposUpdateBranchProtectionParams {
+  /** The name of the branch. */
+  branch: string;
+  owner: string;
+  repo: string;
+}
 
 export interface ReposUpdateBranchProtectionPayload {
   /** Allows deletion of the protected branch by anyone with write access to the repository. Set to \`false\` to prevent deletion of the protected branch. Default: \`false\`. For more information, see "[Enabling force pushes to a protected branch](https://help.github.com/en/github/administering-a-repository/enabling-force-pushes-to-a-protected-branch)" in the GitHub Help documentation. */
@@ -26047,6 +28971,13 @@ export interface ReposUpdateBranchProtectionPayload {
 
 export type ReposUpdateCommitCommentData = CommitComment;
 
+export interface ReposUpdateCommitCommentParams {
+  /** comment_id parameter */
+  commentId: number;
+  owner: string;
+  repo: string;
+}
+
 export interface ReposUpdateCommitCommentPayload {
   /** The contents of the comment */
   body: string;
@@ -26055,6 +28986,11 @@ export interface ReposUpdateCommitCommentPayload {
 export type ReposUpdateData = FullRepository;
 
 export type ReposUpdateInformationAboutPagesSiteData = any;
+
+export interface ReposUpdateInformationAboutPagesSiteParams {
+  owner: string;
+  repo: string;
+}
 
 /** The repository directory that includes the source files for the Pages site. Allowed paths are \`/\` or \`/docs\`. */
 export enum ReposUpdateInformationAboutPagesSitePathEnum {
@@ -26087,6 +29023,13 @@ export enum ReposUpdateInformationAboutPagesSiteSourceEnum {
 
 export type ReposUpdateInvitationData = RepositoryInvitation;
 
+export interface ReposUpdateInvitationParams {
+  /** invitation_id parameter */
+  invitationId: number;
+  owner: string;
+  repo: string;
+}
+
 export interface ReposUpdateInvitationPayload {
   /** The permissions that the associated user will have on the repository. Valid values are \`read\`, \`write\`, \`maintain\`, \`triage\`, and \`admin\`. */
   permissions?: ReposUpdateInvitationPermissionsEnum;
@@ -26099,6 +29042,11 @@ export enum ReposUpdateInvitationPermissionsEnum {
   Maintain = "maintain",
   Triage = "triage",
   Admin = "admin",
+}
+
+export interface ReposUpdateParams {
+  owner: string;
+  repo: string;
 }
 
 export interface ReposUpdatePayload {
@@ -26168,6 +29116,13 @@ export interface ReposUpdatePayload {
 export type ReposUpdatePullRequestReviewProtectionData =
   ProtectedBranchPullRequestReview;
 
+export interface ReposUpdatePullRequestReviewProtectionParams {
+  /** The name of the branch. */
+  branch: string;
+  owner: string;
+  repo: string;
+}
+
 export interface ReposUpdatePullRequestReviewProtectionPayload {
   /** Set to \`true\` if you want to automatically dismiss approving reviews when someone pushes a new commit. */
   dismiss_stale_reviews?: boolean;
@@ -26186,6 +29141,13 @@ export interface ReposUpdatePullRequestReviewProtectionPayload {
 
 export type ReposUpdateReleaseAssetData = ReleaseAsset;
 
+export interface ReposUpdateReleaseAssetParams {
+  /** asset_id parameter */
+  assetId: number;
+  owner: string;
+  repo: string;
+}
+
 export interface ReposUpdateReleaseAssetPayload {
   /** An alternate short description of the asset. Used in place of the filename. */
   label?: string;
@@ -26196,6 +29158,13 @@ export interface ReposUpdateReleaseAssetPayload {
 }
 
 export type ReposUpdateReleaseData = Release;
+
+export interface ReposUpdateReleaseParams {
+  owner: string;
+  /** release_id parameter */
+  releaseId: number;
+  repo: string;
+}
 
 export interface ReposUpdateReleasePayload {
   /** Text describing the contents of the tag. */
@@ -26214,6 +29183,13 @@ export interface ReposUpdateReleasePayload {
 
 export type ReposUpdateStatusCheckProtectionData = StatusCheckPolicy;
 
+export interface ReposUpdateStatusCheckProtectionParams {
+  /** The name of the branch. */
+  branch: string;
+  owner: string;
+  repo: string;
+}
+
 export interface ReposUpdateStatusCheckProtectionPayload {
   /** The list of status checks to require in order to merge into this branch */
   contexts?: string[];
@@ -26231,6 +29207,12 @@ export enum ReposUpdateVisibilityEnum {
 
 export type ReposUpdateWebhookConfigForRepoData = WebhookConfig;
 
+export interface ReposUpdateWebhookConfigForRepoParams {
+  hookId: number;
+  owner: string;
+  repo: string;
+}
+
 /** @example {"content_type":"json","insecure_ssl":"0","secret":"********","url":"https://example.com/webhook"} */
 export interface ReposUpdateWebhookConfigForRepoPayload {
   /** The media type used to serialize the payloads. Supported values include \`json\` and \`form\`. The default is \`form\`. */
@@ -26244,6 +29226,12 @@ export interface ReposUpdateWebhookConfigForRepoPayload {
 }
 
 export type ReposUpdateWebhookData = Hook;
+
+export interface ReposUpdateWebhookParams {
+  hookId: number;
+  owner: string;
+  repo: string;
+}
 
 export interface ReposUpdateWebhookPayload {
   /**
@@ -27010,6 +29998,12 @@ export type ScimConflict = ScimError;
 
 export type ScimDeleteUserFromOrgData = any;
 
+export interface ScimDeleteUserFromOrgParams {
+  org: string;
+  /** scim_user_id parameter */
+  scimUserId: string;
+}
+
 export interface ScimEnterpriseGroup {
   displayName?: string;
   externalId?: string | null;
@@ -27072,6 +30066,12 @@ export type ScimForbidden = ScimError;
 
 export type ScimGetProvisioningInformationForUserData = ScimUser;
 
+export interface ScimGetProvisioningInformationForUserParams {
+  org: string;
+  /** scim_user_id parameter */
+  scimUserId: string;
+}
+
 export interface ScimGroupListEnterprise {
   Resources: {
     displayName?: string;
@@ -27124,6 +30124,10 @@ export type ScimNotFound = ScimError;
 
 export type ScimProvisionAndInviteUserData = ScimUser;
 
+export interface ScimProvisionAndInviteUserParams {
+  org: string;
+}
+
 export interface ScimProvisionAndInviteUserPayload {
   active?: boolean;
   /**
@@ -27158,6 +30162,12 @@ export interface ScimProvisionAndInviteUserPayload {
 }
 
 export type ScimSetInformationForProvisionedUserData = ScimUser;
+
+export interface ScimSetInformationForProvisionedUserParams {
+  org: string;
+  /** scim_user_id parameter */
+  scimUserId: string;
+}
 
 export interface ScimSetInformationForProvisionedUserPayload {
   active?: boolean;
@@ -27200,6 +30210,12 @@ export enum ScimUpdateAttributeForUserOpEnum {
   Add = "add",
   Remove = "remove",
   Replace = "replace",
+}
+
+export interface ScimUpdateAttributeForUserParams {
+  org: string;
+  /** scim_user_id parameter */
+  scimUserId: string;
 }
 
 export interface ScimUpdateAttributeForUserPayload {
@@ -27729,6 +30745,13 @@ export enum SecretScanningAlertState {
 
 export type SecretScanningGetAlertData = SecretScanningAlert;
 
+export interface SecretScanningGetAlertParams {
+  /** The security alert number, found at the end of the security alert's URL. */
+  alertNumber: AlertNumber;
+  owner: string;
+  repo: string;
+}
+
 export type SecretScanningListAlertsForRepoData = SecretScanningAlert[];
 
 export interface SecretScanningListAlertsForRepoParams {
@@ -27755,6 +30778,13 @@ export enum SecretScanningListAlertsForRepoParams1StateEnum {
 }
 
 export type SecretScanningUpdateAlertData = SecretScanningAlert;
+
+export interface SecretScanningUpdateAlertParams {
+  /** The security alert number, found at the end of the security alert's URL. */
+  alertNumber: AlertNumber;
+  owner: string;
+  repo: string;
+}
 
 export interface SecretScanningUpdateAlertPayload {
   /** **Required when the \`state\` is \`resolved\`.** The reason for resolving the alert. Can be one of \`false_positive\`, \`wont_fix\`, \`revoked\`, or \`used_in_tests\`. */
@@ -29008,6 +32038,11 @@ export type TeamsAddMemberLegacyError = {
   message?: string;
 };
 
+export interface TeamsAddMemberLegacyParams {
+  teamId: number;
+  username: string;
+}
+
 export type TeamsAddOrUpdateMembershipForUserInOrgData = TeamMembership;
 
 export type TeamsAddOrUpdateMembershipForUserInOrgError = {
@@ -29018,6 +32053,13 @@ export type TeamsAddOrUpdateMembershipForUserInOrgError = {
   }[];
   message?: string;
 };
+
+export interface TeamsAddOrUpdateMembershipForUserInOrgParams {
+  org: string;
+  /** team_slug parameter */
+  teamSlug: string;
+  username: string;
+}
 
 export interface TeamsAddOrUpdateMembershipForUserInOrgPayload {
   /**
@@ -29053,6 +32095,11 @@ export type TeamsAddOrUpdateMembershipForUserLegacyError = {
   message?: string;
 };
 
+export interface TeamsAddOrUpdateMembershipForUserLegacyParams {
+  teamId: number;
+  username: string;
+}
+
 export interface TeamsAddOrUpdateMembershipForUserLegacyPayload {
   /**
    * The role that this user should have in the team. Can be one of:
@@ -29080,6 +32127,13 @@ export type TeamsAddOrUpdateProjectPermissionsInOrgError = {
   documentation_url?: string;
   message?: string;
 };
+
+export interface TeamsAddOrUpdateProjectPermissionsInOrgParams {
+  org: string;
+  projectId: number;
+  /** team_slug parameter */
+  teamSlug: string;
+}
 
 export interface TeamsAddOrUpdateProjectPermissionsInOrgPayload {
   /**
@@ -29112,6 +32166,11 @@ export type TeamsAddOrUpdateProjectPermissionsLegacyError = {
   message?: string;
 };
 
+export interface TeamsAddOrUpdateProjectPermissionsLegacyParams {
+  projectId: number;
+  teamId: number;
+}
+
 export interface TeamsAddOrUpdateProjectPermissionsLegacyPayload {
   /**
    * The permission to grant to the team for this project. Can be one of:
@@ -29137,6 +32196,14 @@ export enum TeamsAddOrUpdateProjectPermissionsLegacyPermissionEnum {
 }
 
 export type TeamsAddOrUpdateRepoPermissionsInOrgData = any;
+
+export interface TeamsAddOrUpdateRepoPermissionsInOrgParams {
+  org: string;
+  owner: string;
+  repo: string;
+  /** team_slug parameter */
+  teamSlug: string;
+}
 
 export interface TeamsAddOrUpdateRepoPermissionsInOrgPayload {
   /**
@@ -29172,6 +32239,12 @@ export enum TeamsAddOrUpdateRepoPermissionsInOrgPermissionEnum {
 
 export type TeamsAddOrUpdateRepoPermissionsLegacyData = any;
 
+export interface TeamsAddOrUpdateRepoPermissionsLegacyParams {
+  owner: string;
+  repo: string;
+  teamId: number;
+}
+
 export interface TeamsAddOrUpdateRepoPermissionsLegacyPayload {
   /**
    * The permission to grant the team on this repository. Can be one of:
@@ -29200,15 +32273,48 @@ export enum TeamsAddOrUpdateRepoPermissionsLegacyPermissionEnum {
 
 export type TeamsCheckPermissionsForProjectInOrgData = TeamProject;
 
+export interface TeamsCheckPermissionsForProjectInOrgParams {
+  org: string;
+  projectId: number;
+  /** team_slug parameter */
+  teamSlug: string;
+}
+
 export type TeamsCheckPermissionsForProjectLegacyData = TeamProject;
+
+export interface TeamsCheckPermissionsForProjectLegacyParams {
+  projectId: number;
+  teamId: number;
+}
 
 export type TeamsCheckPermissionsForRepoInOrgData = TeamRepository;
 
+export interface TeamsCheckPermissionsForRepoInOrgParams {
+  org: string;
+  owner: string;
+  repo: string;
+  /** team_slug parameter */
+  teamSlug: string;
+}
+
 export type TeamsCheckPermissionsForRepoLegacyData = TeamRepository;
+
+export interface TeamsCheckPermissionsForRepoLegacyParams {
+  owner: string;
+  repo: string;
+  teamId: number;
+}
 
 export type TeamsCreateData = TeamFull;
 
 export type TeamsCreateDiscussionCommentInOrgData = TeamDiscussionComment;
+
+export interface TeamsCreateDiscussionCommentInOrgParams {
+  discussionNumber: number;
+  org: string;
+  /** team_slug parameter */
+  teamSlug: string;
+}
 
 export interface TeamsCreateDiscussionCommentInOrgPayload {
   /** The discussion comment's body text. */
@@ -29217,12 +32323,23 @@ export interface TeamsCreateDiscussionCommentInOrgPayload {
 
 export type TeamsCreateDiscussionCommentLegacyData = TeamDiscussionComment;
 
+export interface TeamsCreateDiscussionCommentLegacyParams {
+  discussionNumber: number;
+  teamId: number;
+}
+
 export interface TeamsCreateDiscussionCommentLegacyPayload {
   /** The discussion comment's body text. */
   body: string;
 }
 
 export type TeamsCreateDiscussionInOrgData = TeamDiscussion;
+
+export interface TeamsCreateDiscussionInOrgParams {
+  org: string;
+  /** team_slug parameter */
+  teamSlug: string;
+}
 
 export interface TeamsCreateDiscussionInOrgPayload {
   /** The discussion post's body text. */
@@ -29238,6 +32355,10 @@ export interface TeamsCreateDiscussionInOrgPayload {
 
 export type TeamsCreateDiscussionLegacyData = TeamDiscussion;
 
+export interface TeamsCreateDiscussionLegacyParams {
+  teamId: number;
+}
+
 export interface TeamsCreateDiscussionLegacyPayload {
   /** The discussion post's body text. */
   body: string;
@@ -29252,6 +32373,12 @@ export interface TeamsCreateDiscussionLegacyPayload {
 
 export type TeamsCreateOrUpdateIdpGroupConnectionsInOrgData = GroupMapping;
 
+export interface TeamsCreateOrUpdateIdpGroupConnectionsInOrgParams {
+  org: string;
+  /** team_slug parameter */
+  teamSlug: string;
+}
+
 export interface TeamsCreateOrUpdateIdpGroupConnectionsInOrgPayload {
   /** The IdP groups you want to connect to a GitHub team. When updating, the new \`groups\` object will replace the original one. You must include any existing groups that you don't want to remove. */
   groups: {
@@ -29265,6 +32392,10 @@ export interface TeamsCreateOrUpdateIdpGroupConnectionsInOrgPayload {
 }
 
 export type TeamsCreateOrUpdateIdpGroupConnectionsLegacyData = GroupMapping;
+
+export interface TeamsCreateOrUpdateIdpGroupConnectionsLegacyParams {
+  teamId: number;
+}
 
 export interface TeamsCreateOrUpdateIdpGroupConnectionsLegacyPayload {
   /** The IdP groups you want to connect to a GitHub team. When updating, the new \`groups\` object will replace the original one. You must include any existing groups that you don't want to remove. */
@@ -29284,6 +32415,10 @@ export interface TeamsCreateOrUpdateIdpGroupConnectionsLegacyPayload {
   }[];
   /** @example ""I am not a timestamp"" */
   synced_at?: string;
+}
+
+export interface TeamsCreateParams {
+  org: string;
 }
 
 export interface TeamsCreatePayload {
@@ -29348,33 +32483,122 @@ export enum TeamsCreatePrivacyEnum {
 
 export type TeamsDeleteDiscussionCommentInOrgData = any;
 
+export interface TeamsDeleteDiscussionCommentInOrgParams {
+  commentNumber: number;
+  discussionNumber: number;
+  org: string;
+  /** team_slug parameter */
+  teamSlug: string;
+}
+
 export type TeamsDeleteDiscussionCommentLegacyData = any;
+
+export interface TeamsDeleteDiscussionCommentLegacyParams {
+  commentNumber: number;
+  discussionNumber: number;
+  teamId: number;
+}
 
 export type TeamsDeleteDiscussionInOrgData = any;
 
+export interface TeamsDeleteDiscussionInOrgParams {
+  discussionNumber: number;
+  org: string;
+  /** team_slug parameter */
+  teamSlug: string;
+}
+
 export type TeamsDeleteDiscussionLegacyData = any;
+
+export interface TeamsDeleteDiscussionLegacyParams {
+  discussionNumber: number;
+  teamId: number;
+}
 
 export type TeamsDeleteInOrgData = any;
 
+export interface TeamsDeleteInOrgParams {
+  org: string;
+  /** team_slug parameter */
+  teamSlug: string;
+}
+
 export type TeamsDeleteLegacyData = any;
+
+export interface TeamsDeleteLegacyParams {
+  teamId: number;
+}
 
 export type TeamsGetByNameData = TeamFull;
 
+export interface TeamsGetByNameParams {
+  org: string;
+  /** team_slug parameter */
+  teamSlug: string;
+}
+
 export type TeamsGetDiscussionCommentInOrgData = TeamDiscussionComment;
+
+export interface TeamsGetDiscussionCommentInOrgParams {
+  commentNumber: number;
+  discussionNumber: number;
+  org: string;
+  /** team_slug parameter */
+  teamSlug: string;
+}
 
 export type TeamsGetDiscussionCommentLegacyData = TeamDiscussionComment;
 
+export interface TeamsGetDiscussionCommentLegacyParams {
+  commentNumber: number;
+  discussionNumber: number;
+  teamId: number;
+}
+
 export type TeamsGetDiscussionInOrgData = TeamDiscussion;
+
+export interface TeamsGetDiscussionInOrgParams {
+  discussionNumber: number;
+  org: string;
+  /** team_slug parameter */
+  teamSlug: string;
+}
 
 export type TeamsGetDiscussionLegacyData = TeamDiscussion;
 
+export interface TeamsGetDiscussionLegacyParams {
+  discussionNumber: number;
+  teamId: number;
+}
+
 export type TeamsGetLegacyData = TeamFull;
+
+export interface TeamsGetLegacyParams {
+  teamId: number;
+}
 
 export type TeamsGetMemberLegacyData = any;
 
+export interface TeamsGetMemberLegacyParams {
+  teamId: number;
+  username: string;
+}
+
 export type TeamsGetMembershipForUserInOrgData = TeamMembership;
 
+export interface TeamsGetMembershipForUserInOrgParams {
+  org: string;
+  /** team_slug parameter */
+  teamSlug: string;
+  username: string;
+}
+
 export type TeamsGetMembershipForUserLegacyData = TeamMembership;
+
+export interface TeamsGetMembershipForUserLegacyParams {
+  teamId: number;
+  username: string;
+}
 
 export type TeamsListChildInOrgData = Team[];
 
@@ -29555,6 +32779,10 @@ export interface TeamsListForAuthenticatedUserParams {
 
 export type TeamsListIdpGroupsForLegacyData = GroupMapping;
 
+export interface TeamsListIdpGroupsForLegacyParams {
+  teamId: number;
+}
+
 export type TeamsListIdpGroupsForOrgData = GroupMapping;
 
 export interface TeamsListIdpGroupsForOrgParams {
@@ -29572,6 +32800,12 @@ export interface TeamsListIdpGroupsForOrgParams {
 }
 
 export type TeamsListIdpGroupsInOrgData = GroupMapping;
+
+export interface TeamsListIdpGroupsInOrgParams {
+  org: string;
+  /** team_slug parameter */
+  teamSlug: string;
+}
 
 export type TeamsListMembersInOrgData = SimpleUser[];
 
@@ -29767,19 +33001,70 @@ export interface TeamsListReposLegacyParams {
 
 export type TeamsRemoveMemberLegacyData = any;
 
+export interface TeamsRemoveMemberLegacyParams {
+  teamId: number;
+  username: string;
+}
+
 export type TeamsRemoveMembershipForUserInOrgData = any;
+
+export interface TeamsRemoveMembershipForUserInOrgParams {
+  org: string;
+  /** team_slug parameter */
+  teamSlug: string;
+  username: string;
+}
 
 export type TeamsRemoveMembershipForUserLegacyData = any;
 
+export interface TeamsRemoveMembershipForUserLegacyParams {
+  teamId: number;
+  username: string;
+}
+
 export type TeamsRemoveProjectInOrgData = any;
+
+export interface TeamsRemoveProjectInOrgParams {
+  org: string;
+  projectId: number;
+  /** team_slug parameter */
+  teamSlug: string;
+}
 
 export type TeamsRemoveProjectLegacyData = any;
 
+export interface TeamsRemoveProjectLegacyParams {
+  projectId: number;
+  teamId: number;
+}
+
 export type TeamsRemoveRepoInOrgData = any;
+
+export interface TeamsRemoveRepoInOrgParams {
+  org: string;
+  owner: string;
+  repo: string;
+  /** team_slug parameter */
+  teamSlug: string;
+}
 
 export type TeamsRemoveRepoLegacyData = any;
 
+export interface TeamsRemoveRepoLegacyParams {
+  owner: string;
+  repo: string;
+  teamId: number;
+}
+
 export type TeamsUpdateDiscussionCommentInOrgData = TeamDiscussionComment;
+
+export interface TeamsUpdateDiscussionCommentInOrgParams {
+  commentNumber: number;
+  discussionNumber: number;
+  org: string;
+  /** team_slug parameter */
+  teamSlug: string;
+}
 
 export interface TeamsUpdateDiscussionCommentInOrgPayload {
   /** The discussion comment's body text. */
@@ -29788,12 +33073,25 @@ export interface TeamsUpdateDiscussionCommentInOrgPayload {
 
 export type TeamsUpdateDiscussionCommentLegacyData = TeamDiscussionComment;
 
+export interface TeamsUpdateDiscussionCommentLegacyParams {
+  commentNumber: number;
+  discussionNumber: number;
+  teamId: number;
+}
+
 export interface TeamsUpdateDiscussionCommentLegacyPayload {
   /** The discussion comment's body text. */
   body: string;
 }
 
 export type TeamsUpdateDiscussionInOrgData = TeamDiscussion;
+
+export interface TeamsUpdateDiscussionInOrgParams {
+  discussionNumber: number;
+  org: string;
+  /** team_slug parameter */
+  teamSlug: string;
+}
 
 export interface TeamsUpdateDiscussionInOrgPayload {
   /** The discussion post's body text. */
@@ -29804,6 +33102,11 @@ export interface TeamsUpdateDiscussionInOrgPayload {
 
 export type TeamsUpdateDiscussionLegacyData = TeamDiscussion;
 
+export interface TeamsUpdateDiscussionLegacyParams {
+  discussionNumber: number;
+  teamId: number;
+}
+
 export interface TeamsUpdateDiscussionLegacyPayload {
   /** The discussion post's body text. */
   body?: string;
@@ -29812,6 +33115,12 @@ export interface TeamsUpdateDiscussionLegacyPayload {
 }
 
 export type TeamsUpdateInOrgData = TeamFull;
+
+export interface TeamsUpdateInOrgParams {
+  org: string;
+  /** team_slug parameter */
+  teamSlug: string;
+}
 
 export interface TeamsUpdateInOrgPayload {
   /** The description of the team. */
@@ -29866,6 +33175,10 @@ export enum TeamsUpdateInOrgPrivacyEnum {
 }
 
 export type TeamsUpdateLegacyData = TeamFull;
+
+export interface TeamsUpdateLegacyParams {
+  teamId: number;
+}
 
 export interface TeamsUpdateLegacyPayload {
   /** The description of the team. */
@@ -30166,15 +33479,32 @@ export type UsersAddEmailForAuthenticatedPayload =
 
 export type UsersBlockData = any;
 
+export interface UsersBlockParams {
+  username: string;
+}
+
 export type UsersCheckBlockedData = any;
 
 export type UsersCheckBlockedError = BasicError;
 
+export interface UsersCheckBlockedParams {
+  username: string;
+}
+
 export type UsersCheckFollowingForUserData = any;
+
+export interface UsersCheckFollowingForUserParams {
+  targetUser: string;
+  username: string;
+}
 
 export type UsersCheckPersonIsFollowedByAuthenticatedData = any;
 
 export type UsersCheckPersonIsFollowedByAuthenticatedError = BasicError;
+
+export interface UsersCheckPersonIsFollowedByAuthenticatedParams {
+  username: string;
+}
 
 export type UsersCreateGpgKeyForAuthenticatedData = GpgKey;
 
@@ -30211,13 +33541,31 @@ export type UsersDeleteEmailForAuthenticatedPayload =
 
 export type UsersDeleteGpgKeyForAuthenticatedData = any;
 
+export interface UsersDeleteGpgKeyForAuthenticatedParams {
+  /** gpg_key_id parameter */
+  gpgKeyId: number;
+}
+
 export type UsersDeletePublicSshKeyForAuthenticatedData = any;
 
+export interface UsersDeletePublicSshKeyForAuthenticatedParams {
+  /** key_id parameter */
+  keyId: number;
+}
+
 export type UsersFollowData = any;
+
+export interface UsersFollowParams {
+  username: string;
+}
 
 export type UsersGetAuthenticatedData = PrivateUser | PublicUser;
 
 export type UsersGetByUsernameData = PrivateUser | PublicUser;
+
+export interface UsersGetByUsernameParams {
+  username: string;
+}
 
 export type UsersGetContextForUserData = Hovercard;
 
@@ -30239,7 +33587,17 @@ export enum UsersGetContextForUserParams1SubjectTypeEnum {
 
 export type UsersGetGpgKeyForAuthenticatedData = GpgKey;
 
+export interface UsersGetGpgKeyForAuthenticatedParams {
+  /** gpg_key_id parameter */
+  gpgKeyId: number;
+}
+
 export type UsersGetPublicSshKeyForAuthenticatedData = Key;
+
+export interface UsersGetPublicSshKeyForAuthenticatedParams {
+  /** key_id parameter */
+  keyId: number;
+}
 
 export type UsersListBlockedByAuthenticatedData = SimpleUser[];
 
@@ -30429,7 +33787,15 @@ export enum UsersSetPrimaryEmailVisibilityForAuthenticatedVisibilityEnum {
 
 export type UsersUnblockData = any;
 
+export interface UsersUnblockParams {
+  username: string;
+}
+
 export type UsersUnfollowData = any;
+
+export interface UsersUnfollowParams {
+  username: string;
+}
 
 export type UsersUpdateAuthenticatedData = PrivateUser;
 
@@ -46776,7 +50142,7 @@ export class Api<
      * @request POST:/app/installations/{installation_id}/access_tokens
      */
     appsCreateInstallationAccessToken: (
-      installationId: number,
+      { installationId, ...query }: AppsCreateInstallationAccessTokenParams,
       data: AppsCreateInstallationAccessTokenPayload,
       params: RequestParams = {},
     ) =>
@@ -46806,7 +50172,7 @@ export class Api<
      * @request DELETE:/app/installations/{installation_id}
      */
     appsDeleteInstallation: (
-      installationId: number,
+      { installationId, ...query }: AppsDeleteInstallationParams,
       params: RequestParams = {},
     ) =>
       this.request<AppsDeleteInstallationData, BasicError>({
@@ -46839,7 +50205,10 @@ export class Api<
      * @summary Get an installation for the authenticated app
      * @request GET:/app/installations/{installation_id}
      */
-    appsGetInstallation: (installationId: number, params: RequestParams = {}) =>
+    appsGetInstallation: (
+      { installationId, ...query }: AppsGetInstallationParams,
+      params: RequestParams = {},
+    ) =>
       this.request<
         AppsGetInstallationData,
         | BasicError
@@ -46899,7 +50268,7 @@ export class Api<
      * @request PUT:/app/installations/{installation_id}/suspended
      */
     appsSuspendInstallation: (
-      installationId: number,
+      { installationId, ...query }: AppsSuspendInstallationParams,
       params: RequestParams = {},
     ) =>
       this.request<AppsSuspendInstallationData, BasicError>({
@@ -46917,7 +50286,7 @@ export class Api<
      * @request DELETE:/app/installations/{installation_id}/suspended
      */
     appsUnsuspendInstallation: (
-      installationId: number,
+      { installationId, ...query }: AppsUnsuspendInstallationParams,
       params: RequestParams = {},
     ) =>
       this.request<AppsUnsuspendInstallationData, BasicError>({
@@ -46956,7 +50325,10 @@ export class Api<
      * @summary Create a GitHub App from a manifest
      * @request POST:/app-manifests/{code}/conversions
      */
-    appsCreateFromManifest: (code: string, params: RequestParams = {}) =>
+    appsCreateFromManifest: (
+      { code, ...query }: AppsCreateFromManifestParams,
+      params: RequestParams = {},
+    ) =>
       this.request<
         AppsCreateFromManifestData,
         BasicError | ValidationErrorSimple
@@ -46978,8 +50350,7 @@ export class Api<
      * @deprecated
      */
     appsCheckAuthorization: (
-      clientId: string,
-      accessToken: string,
+      { clientId, accessToken, ...query }: AppsCheckAuthorizationParams,
       params: RequestParams = {},
     ) =>
       this.request<AppsCheckAuthorizationData, BasicError>({
@@ -46998,7 +50369,7 @@ export class Api<
      * @request POST:/applications/{client_id}/token
      */
     appsCheckToken: (
-      clientId: string,
+      { clientId, ...query }: AppsCheckTokenParams,
       data: AppsCheckTokenPayload,
       params: RequestParams = {},
     ) =>
@@ -47020,7 +50391,7 @@ export class Api<
      * @request DELETE:/applications/{client_id}/grant
      */
     appsDeleteAuthorization: (
-      clientId: string,
+      { clientId, ...query }: AppsDeleteAuthorizationParams,
       data: AppsDeleteAuthorizationPayload,
       params: RequestParams = {},
     ) =>
@@ -47041,7 +50412,7 @@ export class Api<
      * @request DELETE:/applications/{client_id}/token
      */
     appsDeleteToken: (
-      clientId: string,
+      { clientId, ...query }: AppsDeleteTokenParams,
       data: AppsDeleteTokenPayload,
       params: RequestParams = {},
     ) =>
@@ -47063,8 +50434,7 @@ export class Api<
      * @deprecated
      */
     appsResetAuthorization: (
-      clientId: string,
-      accessToken: string,
+      { clientId, accessToken, ...query }: AppsResetAuthorizationParams,
       params: RequestParams = {},
     ) =>
       this.request<AppsResetAuthorizationData, any>({
@@ -47083,7 +50453,7 @@ export class Api<
      * @request PATCH:/applications/{client_id}/token
      */
     appsResetToken: (
-      clientId: string,
+      { clientId, ...query }: AppsResetTokenParams,
       data: AppsResetTokenPayload,
       params: RequestParams = {},
     ) =>
@@ -47106,8 +50476,11 @@ export class Api<
      * @deprecated
      */
     appsRevokeAuthorizationForApplication: (
-      clientId: string,
-      accessToken: string,
+      {
+        clientId,
+        accessToken,
+        ...query
+      }: AppsRevokeAuthorizationForApplicationParams,
       params: RequestParams = {},
     ) =>
       this.request<AppsRevokeAuthorizationForApplicationData, any>({
@@ -47126,8 +50499,7 @@ export class Api<
      * @deprecated
      */
     appsRevokeGrantForApplication: (
-      clientId: string,
-      accessToken: string,
+      { clientId, accessToken, ...query }: AppsRevokeGrantForApplicationParams,
       params: RequestParams = {},
     ) =>
       this.request<AppsRevokeGrantForApplicationData, any>({
@@ -47145,7 +50517,7 @@ export class Api<
      * @request POST:/applications/{client_id}/token/scoped
      */
     appsScopeToken: (
-      clientId: string,
+      { clientId, ...query }: AppsScopeTokenParams,
       data: AppsScopeTokenPayload,
       params: RequestParams = {},
     ) =>
@@ -47168,7 +50540,7 @@ export class Api<
      * @deprecated
      */
     oauthAuthorizationsDeleteGrant: (
-      grantId: number,
+      { grantId, ...query }: OauthAuthorizationsDeleteGrantParams,
       params: RequestParams = {},
     ) =>
       this.request<OauthAuthorizationsDeleteGrantData, BasicError>({
@@ -47187,7 +50559,7 @@ export class Api<
      * @deprecated
      */
     oauthAuthorizationsGetGrant: (
-      grantId: number,
+      { grantId, ...query }: OauthAuthorizationsGetGrantParams,
       params: RequestParams = {},
     ) =>
       this.request<OauthAuthorizationsGetGrantData, BasicError>({
@@ -47227,7 +50599,10 @@ export class Api<
      * @summary Get an app
      * @request GET:/apps/{app_slug}
      */
-    appsGetBySlug: (appSlug: string, params: RequestParams = {}) =>
+    appsGetBySlug: (
+      { appSlug, ...query }: AppsGetBySlugParams,
+      params: RequestParams = {},
+    ) =>
       this.request<
         AppsGetBySlugData,
         | BasicError
@@ -47278,7 +50653,10 @@ export class Api<
      * @deprecated
      */
     oauthAuthorizationsDeleteAuthorization: (
-      authorizationId: number,
+      {
+        authorizationId,
+        ...query
+      }: OauthAuthorizationsDeleteAuthorizationParams,
       params: RequestParams = {},
     ) =>
       this.request<OauthAuthorizationsDeleteAuthorizationData, BasicError>({
@@ -47297,7 +50675,7 @@ export class Api<
      * @deprecated
      */
     oauthAuthorizationsGetAuthorization: (
-      authorizationId: number,
+      { authorizationId, ...query }: OauthAuthorizationsGetAuthorizationParams,
       params: RequestParams = {},
     ) =>
       this.request<OauthAuthorizationsGetAuthorizationData, BasicError>({
@@ -47317,7 +50695,10 @@ export class Api<
      * @deprecated
      */
     oauthAuthorizationsGetOrCreateAuthorizationForApp: (
-      clientId: string,
+      {
+        clientId,
+        ...query
+      }: OauthAuthorizationsGetOrCreateAuthorizationForAppParams,
       data: OauthAuthorizationsGetOrCreateAuthorizationForAppPayload,
       params: RequestParams = {},
     ) =>
@@ -47343,8 +50724,11 @@ export class Api<
      * @deprecated
      */
     oauthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprint: (
-      clientId: string,
-      fingerprint: string,
+      {
+        clientId,
+        fingerprint,
+        ...query
+      }: OauthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprintParams,
       data: OauthAuthorizationsGetOrCreateAuthorizationForAppAndFingerprintPayload,
       params: RequestParams = {},
     ) =>
@@ -47391,7 +50775,10 @@ export class Api<
      * @deprecated
      */
     oauthAuthorizationsUpdateAuthorization: (
-      authorizationId: number,
+      {
+        authorizationId,
+        ...query
+      }: OauthAuthorizationsUpdateAuthorizationParams,
       data: OauthAuthorizationsUpdateAuthorizationPayload,
       params: RequestParams = {},
     ) =>
@@ -47437,7 +50824,10 @@ export class Api<
      * @summary Get a code of conduct
      * @request GET:/codes_of_conduct/{key}
      */
-    codesOfConductGetConductCode: (key: string, params: RequestParams = {}) =>
+    codesOfConductGetConductCode: (
+      { key, ...query }: CodesOfConductGetConductCodeParams,
+      params: RequestParams = {},
+    ) =>
       this.request<
         CodesOfConductGetConductCodeData,
         | BasicError
@@ -47462,7 +50852,7 @@ export class Api<
      * @request POST:/content_references/{content_reference_id}/attachments
      */
     appsCreateContentAttachment: (
-      contentReferenceId: number,
+      { contentReferenceId, ...query }: AppsCreateContentAttachmentParams,
       data: AppsCreateContentAttachmentPayload,
       params: RequestParams = {},
     ) =>
@@ -47530,7 +50920,7 @@ export class Api<
      * @request GET:/enterprises/{enterprise}/settings/billing/actions
      */
     billingGetGithubActionsBillingGhe: (
-      enterprise: string,
+      { enterprise, ...query }: BillingGetGithubActionsBillingGheParams,
       params: RequestParams = {},
     ) =>
       this.request<BillingGetGithubActionsBillingGheData, any>({
@@ -47549,7 +50939,7 @@ export class Api<
      * @request GET:/enterprises/{enterprise}/settings/billing/packages
      */
     billingGetGithubPackagesBillingGhe: (
-      enterprise: string,
+      { enterprise, ...query }: BillingGetGithubPackagesBillingGheParams,
       params: RequestParams = {},
     ) =>
       this.request<BillingGetGithubPackagesBillingGheData, any>({
@@ -47568,7 +50958,7 @@ export class Api<
      * @request GET:/enterprises/{enterprise}/settings/billing/shared-storage
      */
     billingGetSharedStorageBillingGhe: (
-      enterprise: string,
+      { enterprise, ...query }: BillingGetSharedStorageBillingGheParams,
       params: RequestParams = {},
     ) =>
       this.request<BillingGetSharedStorageBillingGheData, any>({
@@ -47587,9 +50977,12 @@ export class Api<
      * @request PUT:/enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/organizations/{org_id}
      */
     enterpriseAdminAddOrgAccessToSelfHostedRunnerGroupInEnterprise: (
-      enterprise: string,
-      runnerGroupId: number,
-      orgId: number,
+      {
+        enterprise,
+        runnerGroupId,
+        orgId,
+        ...query
+      }: EnterpriseAdminAddOrgAccessToSelfHostedRunnerGroupInEnterpriseParams,
       params: RequestParams = {},
     ) =>
       this.request<
@@ -47610,9 +51003,12 @@ export class Api<
      * @request PUT:/enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/runners/{runner_id}
      */
     enterpriseAdminAddSelfHostedRunnerToGroupForEnterprise: (
-      enterprise: string,
-      runnerGroupId: number,
-      runnerId: number,
+      {
+        enterprise,
+        runnerGroupId,
+        runnerId,
+        ...query
+      }: EnterpriseAdminAddSelfHostedRunnerToGroupForEnterpriseParams,
       params: RequestParams = {},
     ) =>
       this.request<
@@ -47633,7 +51029,10 @@ export class Api<
      * @request POST:/enterprises/{enterprise}/actions/runners/registration-token
      */
     enterpriseAdminCreateRegistrationTokenForEnterprise: (
-      enterprise: string,
+      {
+        enterprise,
+        ...query
+      }: EnterpriseAdminCreateRegistrationTokenForEnterpriseParams,
       params: RequestParams = {},
     ) =>
       this.request<
@@ -47655,7 +51054,10 @@ export class Api<
      * @request POST:/enterprises/{enterprise}/actions/runners/remove-token
      */
     enterpriseAdminCreateRemoveTokenForEnterprise: (
-      enterprise: string,
+      {
+        enterprise,
+        ...query
+      }: EnterpriseAdminCreateRemoveTokenForEnterpriseParams,
       params: RequestParams = {},
     ) =>
       this.request<EnterpriseAdminCreateRemoveTokenForEnterpriseData, any>({
@@ -47674,7 +51076,10 @@ export class Api<
      * @request POST:/enterprises/{enterprise}/actions/runner-groups
      */
     enterpriseAdminCreateSelfHostedRunnerGroupForEnterprise: (
-      enterprise: string,
+      {
+        enterprise,
+        ...query
+      }: EnterpriseAdminCreateSelfHostedRunnerGroupForEnterpriseParams,
       data: EnterpriseAdminCreateSelfHostedRunnerGroupForEnterprisePayload,
       params: RequestParams = {},
     ) =>
@@ -47699,8 +51104,11 @@ export class Api<
      * @request DELETE:/enterprises/{enterprise}/actions/runners/{runner_id}
      */
     enterpriseAdminDeleteSelfHostedRunnerFromEnterprise: (
-      enterprise: string,
-      runnerId: number,
+      {
+        enterprise,
+        runnerId,
+        ...query
+      }: EnterpriseAdminDeleteSelfHostedRunnerFromEnterpriseParams,
       params: RequestParams = {},
     ) =>
       this.request<
@@ -47721,8 +51129,11 @@ export class Api<
      * @request DELETE:/enterprises/{enterprise}/actions/runner-groups/{runner_group_id}
      */
     enterpriseAdminDeleteSelfHostedRunnerGroupFromEnterprise: (
-      enterprise: string,
-      runnerGroupId: number,
+      {
+        enterprise,
+        runnerGroupId,
+        ...query
+      }: EnterpriseAdminDeleteSelfHostedRunnerGroupFromEnterpriseParams,
       params: RequestParams = {},
     ) =>
       this.request<
@@ -47743,8 +51154,11 @@ export class Api<
      * @request DELETE:/enterprises/{enterprise}/actions/permissions/organizations/{org_id}
      */
     enterpriseAdminDisableSelectedOrganizationGithubActionsEnterprise: (
-      enterprise: string,
-      orgId: number,
+      {
+        enterprise,
+        orgId,
+        ...query
+      }: EnterpriseAdminDisableSelectedOrganizationGithubActionsEnterpriseParams,
       params: RequestParams = {},
     ) =>
       this.request<
@@ -47765,8 +51179,11 @@ export class Api<
      * @request PUT:/enterprises/{enterprise}/actions/permissions/organizations/{org_id}
      */
     enterpriseAdminEnableSelectedOrganizationGithubActionsEnterprise: (
-      enterprise: string,
-      orgId: number,
+      {
+        enterprise,
+        orgId,
+        ...query
+      }: EnterpriseAdminEnableSelectedOrganizationGithubActionsEnterpriseParams,
       params: RequestParams = {},
     ) =>
       this.request<
@@ -47787,7 +51204,10 @@ export class Api<
      * @request GET:/enterprises/{enterprise}/actions/permissions/selected-actions
      */
     enterpriseAdminGetAllowedActionsEnterprise: (
-      enterprise: string,
+      {
+        enterprise,
+        ...query
+      }: EnterpriseAdminGetAllowedActionsEnterpriseParams,
       params: RequestParams = {},
     ) =>
       this.request<EnterpriseAdminGetAllowedActionsEnterpriseData, any>({
@@ -47806,7 +51226,10 @@ export class Api<
      * @request GET:/enterprises/{enterprise}/actions/permissions
      */
     enterpriseAdminGetGithubActionsPermissionsEnterprise: (
-      enterprise: string,
+      {
+        enterprise,
+        ...query
+      }: EnterpriseAdminGetGithubActionsPermissionsEnterpriseParams,
       params: RequestParams = {},
     ) =>
       this.request<
@@ -47828,8 +51251,11 @@ export class Api<
      * @request GET:/enterprises/{enterprise}/actions/runners/{runner_id}
      */
     enterpriseAdminGetSelfHostedRunnerForEnterprise: (
-      enterprise: string,
-      runnerId: number,
+      {
+        enterprise,
+        runnerId,
+        ...query
+      }: EnterpriseAdminGetSelfHostedRunnerForEnterpriseParams,
       params: RequestParams = {},
     ) =>
       this.request<EnterpriseAdminGetSelfHostedRunnerForEnterpriseData, any>({
@@ -47848,8 +51274,11 @@ export class Api<
      * @request GET:/enterprises/{enterprise}/actions/runner-groups/{runner_group_id}
      */
     enterpriseAdminGetSelfHostedRunnerGroupForEnterprise: (
-      enterprise: string,
-      runnerGroupId: number,
+      {
+        enterprise,
+        runnerGroupId,
+        ...query
+      }: EnterpriseAdminGetSelfHostedRunnerGroupForEnterpriseParams,
       params: RequestParams = {},
     ) =>
       this.request<
@@ -47898,7 +51327,10 @@ export class Api<
      * @request GET:/enterprises/{enterprise}/actions/runners/downloads
      */
     enterpriseAdminListRunnerApplicationsForEnterprise: (
-      enterprise: string,
+      {
+        enterprise,
+        ...query
+      }: EnterpriseAdminListRunnerApplicationsForEnterpriseParams,
       params: RequestParams = {},
     ) =>
       this.request<EnterpriseAdminListRunnerApplicationsForEnterpriseData, any>(
@@ -48021,9 +51453,12 @@ export class Api<
      * @request DELETE:/enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/organizations/{org_id}
      */
     enterpriseAdminRemoveOrgAccessToSelfHostedRunnerGroupInEnterprise: (
-      enterprise: string,
-      runnerGroupId: number,
-      orgId: number,
+      {
+        enterprise,
+        runnerGroupId,
+        orgId,
+        ...query
+      }: EnterpriseAdminRemoveOrgAccessToSelfHostedRunnerGroupInEnterpriseParams,
       params: RequestParams = {},
     ) =>
       this.request<
@@ -48044,9 +51479,12 @@ export class Api<
      * @request DELETE:/enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/runners/{runner_id}
      */
     enterpriseAdminRemoveSelfHostedRunnerFromGroupForEnterprise: (
-      enterprise: string,
-      runnerGroupId: number,
-      runnerId: number,
+      {
+        enterprise,
+        runnerGroupId,
+        runnerId,
+        ...query
+      }: EnterpriseAdminRemoveSelfHostedRunnerFromGroupForEnterpriseParams,
       params: RequestParams = {},
     ) =>
       this.request<
@@ -48067,7 +51505,10 @@ export class Api<
      * @request PUT:/enterprises/{enterprise}/actions/permissions/selected-actions
      */
     enterpriseAdminSetAllowedActionsEnterprise: (
-      enterprise: string,
+      {
+        enterprise,
+        ...query
+      }: EnterpriseAdminSetAllowedActionsEnterpriseParams,
       data: SelectedActions,
       params: RequestParams = {},
     ) =>
@@ -48088,7 +51529,10 @@ export class Api<
      * @request PUT:/enterprises/{enterprise}/actions/permissions
      */
     enterpriseAdminSetGithubActionsPermissionsEnterprise: (
-      enterprise: string,
+      {
+        enterprise,
+        ...query
+      }: EnterpriseAdminSetGithubActionsPermissionsEnterpriseParams,
       data: EnterpriseAdminSetGithubActionsPermissionsEnterprisePayload,
       params: RequestParams = {},
     ) =>
@@ -48112,8 +51556,11 @@ export class Api<
      * @request PUT:/enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/organizations
      */
     enterpriseAdminSetOrgAccessToSelfHostedRunnerGroupInEnterprise: (
-      enterprise: string,
-      runnerGroupId: number,
+      {
+        enterprise,
+        runnerGroupId,
+        ...query
+      }: EnterpriseAdminSetOrgAccessToSelfHostedRunnerGroupInEnterpriseParams,
       data: EnterpriseAdminSetOrgAccessToSelfHostedRunnerGroupInEnterprisePayload,
       params: RequestParams = {},
     ) =>
@@ -48137,7 +51584,10 @@ export class Api<
      * @request PUT:/enterprises/{enterprise}/actions/permissions/organizations
      */
     enterpriseAdminSetSelectedOrganizationsEnabledGithubActionsEnterprise: (
-      enterprise: string,
+      {
+        enterprise,
+        ...query
+      }: EnterpriseAdminSetSelectedOrganizationsEnabledGithubActionsEnterpriseParams,
       data: EnterpriseAdminSetSelectedOrganizationsEnabledGithubActionsEnterprisePayload,
       params: RequestParams = {},
     ) =>
@@ -48161,8 +51611,11 @@ export class Api<
      * @request PUT:/enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/runners
      */
     enterpriseAdminSetSelfHostedRunnersInGroupForEnterprise: (
-      enterprise: string,
-      runnerGroupId: number,
+      {
+        enterprise,
+        runnerGroupId,
+        ...query
+      }: EnterpriseAdminSetSelfHostedRunnersInGroupForEnterpriseParams,
       data: EnterpriseAdminSetSelfHostedRunnersInGroupForEnterprisePayload,
       params: RequestParams = {},
     ) =>
@@ -48186,8 +51639,11 @@ export class Api<
      * @request PATCH:/enterprises/{enterprise}/actions/runner-groups/{runner_group_id}
      */
     enterpriseAdminUpdateSelfHostedRunnerGroupForEnterprise: (
-      enterprise: string,
-      runnerGroupId: number,
+      {
+        enterprise,
+        runnerGroupId,
+        ...query
+      }: EnterpriseAdminUpdateSelfHostedRunnerGroupForEnterpriseParams,
       data: EnterpriseAdminUpdateSelfHostedRunnerGroupForEnterprisePayload,
       params: RequestParams = {},
     ) =>
@@ -48258,7 +51714,10 @@ export class Api<
      * @summary Check if a gist is starred
      * @request GET:/gists/{gist_id}/star
      */
-    gistsCheckIsStarred: (gistId: string, params: RequestParams = {}) =>
+    gistsCheckIsStarred: (
+      { gistId, ...query }: GistsCheckIsStarredParams,
+      params: RequestParams = {},
+    ) =>
       this.request<GistsCheckIsStarredData, GistsCheckIsStarredError>({
         path: \`/gists/\${gistId}/star\`,
         method: "GET",
@@ -48292,7 +51751,7 @@ export class Api<
      * @request POST:/gists/{gist_id}/comments
      */
     gistsCreateComment: (
-      gistId: string,
+      { gistId, ...query }: GistsCreateCommentParams,
       data: GistsCreateCommentPayload,
       params: RequestParams = {},
     ) =>
@@ -48313,7 +51772,10 @@ export class Api<
      * @summary Delete a gist
      * @request DELETE:/gists/{gist_id}
      */
-    gistsDelete: (gistId: string, params: RequestParams = {}) =>
+    gistsDelete: (
+      { gistId, ...query }: GistsDeleteParams,
+      params: RequestParams = {},
+    ) =>
       this.request<GistsDeleteData, BasicError>({
         path: \`/gists/\${gistId}\`,
         method: "DELETE",
@@ -48329,8 +51791,7 @@ export class Api<
      * @request DELETE:/gists/{gist_id}/comments/{comment_id}
      */
     gistsDeleteComment: (
-      gistId: string,
-      commentId: number,
+      { gistId, commentId, ...query }: GistsDeleteCommentParams,
       params: RequestParams = {},
     ) =>
       this.request<GistsDeleteCommentData, BasicError>({
@@ -48347,7 +51808,10 @@ export class Api<
      * @summary Fork a gist
      * @request POST:/gists/{gist_id}/forks
      */
-    gistsFork: (gistId: string, params: RequestParams = {}) =>
+    gistsFork: (
+      { gistId, ...query }: GistsForkParams,
+      params: RequestParams = {},
+    ) =>
       this.request<GistsForkData, BasicError | ValidationError>({
         path: \`/gists/\${gistId}/forks\`,
         method: "POST",
@@ -48363,7 +51827,10 @@ export class Api<
      * @summary Get a gist
      * @request GET:/gists/{gist_id}
      */
-    gistsGet: (gistId: string, params: RequestParams = {}) =>
+    gistsGet: (
+      { gistId, ...query }: GistsGetParams,
+      params: RequestParams = {},
+    ) =>
       this.request<
         GistsGetData,
         | {
@@ -48392,8 +51859,7 @@ export class Api<
      * @request GET:/gists/{gist_id}/comments/{comment_id}
      */
     gistsGetComment: (
-      gistId: string,
-      commentId: number,
+      { gistId, commentId, ...query }: GistsGetCommentParams,
       params: RequestParams = {},
     ) =>
       this.request<
@@ -48424,8 +51890,7 @@ export class Api<
      * @request GET:/gists/{gist_id}/{sha}
      */
     gistsGetRevision: (
-      gistId: string,
-      sha: string,
+      { gistId, sha, ...query }: GistsGetRevisionParams,
       params: RequestParams = {},
     ) =>
       this.request<GistsGetRevisionData, BasicError | ValidationError>({
@@ -48560,7 +52025,10 @@ export class Api<
      * @summary Star a gist
      * @request PUT:/gists/{gist_id}/star
      */
-    gistsStar: (gistId: string, params: RequestParams = {}) =>
+    gistsStar: (
+      { gistId, ...query }: GistsStarParams,
+      params: RequestParams = {},
+    ) =>
       this.request<GistsStarData, BasicError>({
         path: \`/gists/\${gistId}/star\`,
         method: "PUT",
@@ -48575,7 +52043,10 @@ export class Api<
      * @summary Unstar a gist
      * @request DELETE:/gists/{gist_id}/star
      */
-    gistsUnstar: (gistId: string, params: RequestParams = {}) =>
+    gistsUnstar: (
+      { gistId, ...query }: GistsUnstarParams,
+      params: RequestParams = {},
+    ) =>
       this.request<GistsUnstarData, BasicError>({
         path: \`/gists/\${gistId}/star\`,
         method: "DELETE",
@@ -48591,7 +52062,7 @@ export class Api<
      * @request PATCH:/gists/{gist_id}
      */
     gistsUpdate: (
-      gistId: string,
+      { gistId, ...query }: GistsUpdateParams,
       data: GistsUpdatePayload,
       params: RequestParams = {},
     ) =>
@@ -48613,8 +52084,7 @@ export class Api<
      * @request PATCH:/gists/{gist_id}/comments/{comment_id}
      */
     gistsUpdateComment: (
-      gistId: string,
-      commentId: number,
+      { gistId, commentId, ...query }: GistsUpdateCommentParams,
       data: GistsUpdateCommentPayload,
       params: RequestParams = {},
     ) =>
@@ -48652,7 +52122,10 @@ export class Api<
      * @summary Get a gitignore template
      * @request GET:/gitignore/templates/{name}
      */
-    gitignoreGetTemplate: (name: string, params: RequestParams = {}) =>
+    gitignoreGetTemplate: (
+      { name, ...query }: GitignoreGetTemplateParams,
+      params: RequestParams = {},
+    ) =>
       this.request<GitignoreGetTemplateData, any>({
         path: \`/gitignore/templates/\${name}\`,
         method: "GET",
@@ -48723,7 +52196,10 @@ export class Api<
      * @summary Get a license
      * @request GET:/licenses/{license}
      */
-    licensesGet: (license: string, params: RequestParams = {}) =>
+    licensesGet: (
+      { license, ...query }: LicensesGetParams,
+      params: RequestParams = {},
+    ) =>
       this.request<LicensesGetData, BasicError>({
         path: \`/licenses/\${license}\`,
         method: "GET",
@@ -48799,7 +52275,7 @@ export class Api<
      * @request GET:/marketplace_listing/accounts/{account_id}
      */
     appsGetSubscriptionPlanForAccount: (
-      accountId: number,
+      { accountId, ...query }: AppsGetSubscriptionPlanForAccountParams,
       params: RequestParams = {},
     ) =>
       this.request<
@@ -48821,7 +52297,7 @@ export class Api<
      * @request GET:/marketplace_listing/stubbed/accounts/{account_id}
      */
     appsGetSubscriptionPlanForAccountStubbed: (
-      accountId: number,
+      { accountId, ...query }: AppsGetSubscriptionPlanForAccountStubbedParams,
       params: RequestParams = {},
     ) =>
       this.request<
@@ -48959,7 +52435,7 @@ export class Api<
      * @request DELETE:/notifications/threads/{thread_id}/subscription
      */
     activityDeleteThreadSubscription: (
-      threadId: number,
+      { threadId, ...query }: ActivityDeleteThreadSubscriptionParams,
       params: RequestParams = {},
     ) =>
       this.request<ActivityDeleteThreadSubscriptionData, BasicError>({
@@ -48976,7 +52452,10 @@ export class Api<
      * @summary Get a thread
      * @request GET:/notifications/threads/{thread_id}
      */
-    activityGetThread: (threadId: number, params: RequestParams = {}) =>
+    activityGetThread: (
+      { threadId, ...query }: ActivityGetThreadParams,
+      params: RequestParams = {},
+    ) =>
       this.request<ActivityGetThreadData, BasicError>({
         path: \`/notifications/threads/\${threadId}\`,
         method: "GET",
@@ -48993,7 +52472,10 @@ export class Api<
      * @request GET:/notifications/threads/{thread_id}/subscription
      */
     activityGetThreadSubscriptionForAuthenticatedUser: (
-      threadId: number,
+      {
+        threadId,
+        ...query
+      }: ActivityGetThreadSubscriptionForAuthenticatedUserParams,
       params: RequestParams = {},
     ) =>
       this.request<
@@ -49058,7 +52540,10 @@ export class Api<
      * @summary Mark a thread as read
      * @request PATCH:/notifications/threads/{thread_id}
      */
-    activityMarkThreadAsRead: (threadId: number, params: RequestParams = {}) =>
+    activityMarkThreadAsRead: (
+      { threadId, ...query }: ActivityMarkThreadAsReadParams,
+      params: RequestParams = {},
+    ) =>
       this.request<ActivityMarkThreadAsReadData, BasicError>({
         path: \`/notifications/threads/\${threadId}\`,
         method: "PATCH",
@@ -49074,7 +52559,7 @@ export class Api<
      * @request PUT:/notifications/threads/{thread_id}/subscription
      */
     activitySetThreadSubscription: (
-      threadId: number,
+      { threadId, ...query }: ActivitySetThreadSubscriptionParams,
       data: ActivitySetThreadSubscriptionPayload,
       params: RequestParams = {},
     ) =>
@@ -49132,9 +52617,12 @@ export class Api<
      * @request PUT:/orgs/{org}/actions/runner-groups/{runner_group_id}/repositories/{repository_id}
      */
     actionsAddRepoAccessToSelfHostedRunnerGroupInOrg: (
-      org: string,
-      runnerGroupId: number,
-      repositoryId: number,
+      {
+        org,
+        runnerGroupId,
+        repositoryId,
+        ...query
+      }: ActionsAddRepoAccessToSelfHostedRunnerGroupInOrgParams,
       params: RequestParams = {},
     ) =>
       this.request<ActionsAddRepoAccessToSelfHostedRunnerGroupInOrgData, any>({
@@ -49152,9 +52640,12 @@ export class Api<
      * @request PUT:/orgs/{org}/actions/secrets/{secret_name}/repositories/{repository_id}
      */
     actionsAddSelectedRepoToOrgSecret: (
-      org: string,
-      secretName: string,
-      repositoryId: number,
+      {
+        org,
+        secretName,
+        repositoryId,
+        ...query
+      }: ActionsAddSelectedRepoToOrgSecretParams,
       params: RequestParams = {},
     ) =>
       this.request<ActionsAddSelectedRepoToOrgSecretData, void>({
@@ -49172,9 +52663,12 @@ export class Api<
      * @request PUT:/orgs/{org}/actions/runner-groups/{runner_group_id}/runners/{runner_id}
      */
     actionsAddSelfHostedRunnerToGroupForOrg: (
-      org: string,
-      runnerGroupId: number,
-      runnerId: number,
+      {
+        org,
+        runnerGroupId,
+        runnerId,
+        ...query
+      }: ActionsAddSelfHostedRunnerToGroupForOrgParams,
       params: RequestParams = {},
     ) =>
       this.request<ActionsAddSelfHostedRunnerToGroupForOrgData, any>({
@@ -49192,8 +52686,7 @@ export class Api<
      * @request PUT:/orgs/{org}/actions/secrets/{secret_name}
      */
     actionsCreateOrUpdateOrgSecret: (
-      org: string,
-      secretName: string,
+      { org, secretName, ...query }: ActionsCreateOrUpdateOrgSecretParams,
       data: ActionsCreateOrUpdateOrgSecretPayload,
       params: RequestParams = {},
     ) =>
@@ -49214,7 +52707,7 @@ export class Api<
      * @request POST:/orgs/{org}/actions/runners/registration-token
      */
     actionsCreateRegistrationTokenForOrg: (
-      org: string,
+      { org, ...query }: ActionsCreateRegistrationTokenForOrgParams,
       params: RequestParams = {},
     ) =>
       this.request<ActionsCreateRegistrationTokenForOrgData, any>({
@@ -49232,7 +52725,10 @@ export class Api<
      * @summary Create a remove token for an organization
      * @request POST:/orgs/{org}/actions/runners/remove-token
      */
-    actionsCreateRemoveTokenForOrg: (org: string, params: RequestParams = {}) =>
+    actionsCreateRemoveTokenForOrg: (
+      { org, ...query }: ActionsCreateRemoveTokenForOrgParams,
+      params: RequestParams = {},
+    ) =>
       this.request<ActionsCreateRemoveTokenForOrgData, any>({
         path: \`/orgs/\${org}/actions/runners/remove-token\`,
         method: "POST",
@@ -49249,7 +52745,7 @@ export class Api<
      * @request POST:/orgs/{org}/actions/runner-groups
      */
     actionsCreateSelfHostedRunnerGroupForOrg: (
-      org: string,
+      { org, ...query }: ActionsCreateSelfHostedRunnerGroupForOrgParams,
       data: ActionsCreateSelfHostedRunnerGroupForOrgPayload,
       params: RequestParams = {},
     ) =>
@@ -49271,8 +52767,7 @@ export class Api<
      * @request DELETE:/orgs/{org}/actions/secrets/{secret_name}
      */
     actionsDeleteOrgSecret: (
-      org: string,
-      secretName: string,
+      { org, secretName, ...query }: ActionsDeleteOrgSecretParams,
       params: RequestParams = {},
     ) =>
       this.request<ActionsDeleteOrgSecretData, any>({
@@ -49290,8 +52785,7 @@ export class Api<
      * @request DELETE:/orgs/{org}/actions/runners/{runner_id}
      */
     actionsDeleteSelfHostedRunnerFromOrg: (
-      org: string,
-      runnerId: number,
+      { org, runnerId, ...query }: ActionsDeleteSelfHostedRunnerFromOrgParams,
       params: RequestParams = {},
     ) =>
       this.request<ActionsDeleteSelfHostedRunnerFromOrgData, any>({
@@ -49309,8 +52803,11 @@ export class Api<
      * @request DELETE:/orgs/{org}/actions/runner-groups/{runner_group_id}
      */
     actionsDeleteSelfHostedRunnerGroupFromOrg: (
-      org: string,
-      runnerGroupId: number,
+      {
+        org,
+        runnerGroupId,
+        ...query
+      }: ActionsDeleteSelfHostedRunnerGroupFromOrgParams,
       params: RequestParams = {},
     ) =>
       this.request<ActionsDeleteSelfHostedRunnerGroupFromOrgData, any>({
@@ -49328,8 +52825,11 @@ export class Api<
      * @request DELETE:/orgs/{org}/actions/permissions/repositories/{repository_id}
      */
     actionsDisableSelectedRepositoryGithubActionsOrganization: (
-      org: string,
-      repositoryId: number,
+      {
+        org,
+        repositoryId,
+        ...query
+      }: ActionsDisableSelectedRepositoryGithubActionsOrganizationParams,
       params: RequestParams = {},
     ) =>
       this.request<
@@ -49350,8 +52850,11 @@ export class Api<
      * @request PUT:/orgs/{org}/actions/permissions/repositories/{repository_id}
      */
     actionsEnableSelectedRepositoryGithubActionsOrganization: (
-      org: string,
-      repositoryId: number,
+      {
+        org,
+        repositoryId,
+        ...query
+      }: ActionsEnableSelectedRepositoryGithubActionsOrganizationParams,
       params: RequestParams = {},
     ) =>
       this.request<
@@ -49372,7 +52875,7 @@ export class Api<
      * @request GET:/orgs/{org}/actions/permissions/selected-actions
      */
     actionsGetAllowedActionsOrganization: (
-      org: string,
+      { org, ...query }: ActionsGetAllowedActionsOrganizationParams,
       params: RequestParams = {},
     ) =>
       this.request<ActionsGetAllowedActionsOrganizationData, any>({
@@ -49391,7 +52894,7 @@ export class Api<
      * @request GET:/orgs/{org}/actions/permissions
      */
     actionsGetGithubActionsPermissionsOrganization: (
-      org: string,
+      { org, ...query }: ActionsGetGithubActionsPermissionsOrganizationParams,
       params: RequestParams = {},
     ) =>
       this.request<ActionsGetGithubActionsPermissionsOrganizationData, any>({
@@ -49409,7 +52912,10 @@ export class Api<
      * @summary Get an organization public key
      * @request GET:/orgs/{org}/actions/secrets/public-key
      */
-    actionsGetOrgPublicKey: (org: string, params: RequestParams = {}) =>
+    actionsGetOrgPublicKey: (
+      { org, ...query }: ActionsGetOrgPublicKeyParams,
+      params: RequestParams = {},
+    ) =>
       this.request<ActionsGetOrgPublicKeyData, any>({
         path: \`/orgs/\${org}/actions/secrets/public-key\`,
         method: "GET",
@@ -49426,8 +52932,7 @@ export class Api<
      * @request GET:/orgs/{org}/actions/secrets/{secret_name}
      */
     actionsGetOrgSecret: (
-      org: string,
-      secretName: string,
+      { org, secretName, ...query }: ActionsGetOrgSecretParams,
       params: RequestParams = {},
     ) =>
       this.request<ActionsGetOrgSecretData, any>({
@@ -49446,8 +52951,7 @@ export class Api<
      * @request GET:/orgs/{org}/actions/runners/{runner_id}
      */
     actionsGetSelfHostedRunnerForOrg: (
-      org: string,
-      runnerId: number,
+      { org, runnerId, ...query }: ActionsGetSelfHostedRunnerForOrgParams,
       params: RequestParams = {},
     ) =>
       this.request<ActionsGetSelfHostedRunnerForOrgData, any>({
@@ -49466,8 +52970,11 @@ export class Api<
      * @request GET:/orgs/{org}/actions/runner-groups/{runner_group_id}
      */
     actionsGetSelfHostedRunnerGroupForOrg: (
-      org: string,
-      runnerGroupId: number,
+      {
+        org,
+        runnerGroupId,
+        ...query
+      }: ActionsGetSelfHostedRunnerGroupForOrgParams,
       params: RequestParams = {},
     ) =>
       this.request<ActionsGetSelfHostedRunnerGroupForOrgData, any>({
@@ -49506,8 +53013,11 @@ export class Api<
      * @request GET:/orgs/{org}/actions/runner-groups/{runner_group_id}/repositories
      */
     actionsListRepoAccessToSelfHostedRunnerGroupInOrg: (
-      org: string,
-      runnerGroupId: number,
+      {
+        org,
+        runnerGroupId,
+        ...query
+      }: ActionsListRepoAccessToSelfHostedRunnerGroupInOrgParams,
       params: RequestParams = {},
     ) =>
       this.request<ActionsListRepoAccessToSelfHostedRunnerGroupInOrgData, any>({
@@ -49526,7 +53036,7 @@ export class Api<
      * @request GET:/orgs/{org}/actions/runners/downloads
      */
     actionsListRunnerApplicationsForOrg: (
-      org: string,
+      { org, ...query }: ActionsListRunnerApplicationsForOrgParams,
       params: RequestParams = {},
     ) =>
       this.request<ActionsListRunnerApplicationsForOrgData, any>({
@@ -49545,8 +53055,7 @@ export class Api<
      * @request GET:/orgs/{org}/actions/secrets/{secret_name}/repositories
      */
     actionsListSelectedReposForOrgSecret: (
-      org: string,
-      secretName: string,
+      { org, secretName, ...query }: ActionsListSelectedReposForOrgSecretParams,
       params: RequestParams = {},
     ) =>
       this.request<ActionsListSelectedReposForOrgSecretData, any>({
@@ -49655,9 +53164,12 @@ export class Api<
      * @request DELETE:/orgs/{org}/actions/runner-groups/{runner_group_id}/repositories/{repository_id}
      */
     actionsRemoveRepoAccessToSelfHostedRunnerGroupInOrg: (
-      org: string,
-      runnerGroupId: number,
-      repositoryId: number,
+      {
+        org,
+        runnerGroupId,
+        repositoryId,
+        ...query
+      }: ActionsRemoveRepoAccessToSelfHostedRunnerGroupInOrgParams,
       params: RequestParams = {},
     ) =>
       this.request<
@@ -49678,9 +53190,12 @@ export class Api<
      * @request DELETE:/orgs/{org}/actions/secrets/{secret_name}/repositories/{repository_id}
      */
     actionsRemoveSelectedRepoFromOrgSecret: (
-      org: string,
-      secretName: string,
-      repositoryId: number,
+      {
+        org,
+        secretName,
+        repositoryId,
+        ...query
+      }: ActionsRemoveSelectedRepoFromOrgSecretParams,
       params: RequestParams = {},
     ) =>
       this.request<ActionsRemoveSelectedRepoFromOrgSecretData, void>({
@@ -49698,9 +53213,12 @@ export class Api<
      * @request DELETE:/orgs/{org}/actions/runner-groups/{runner_group_id}/runners/{runner_id}
      */
     actionsRemoveSelfHostedRunnerFromGroupForOrg: (
-      org: string,
-      runnerGroupId: number,
-      runnerId: number,
+      {
+        org,
+        runnerGroupId,
+        runnerId,
+        ...query
+      }: ActionsRemoveSelfHostedRunnerFromGroupForOrgParams,
       params: RequestParams = {},
     ) =>
       this.request<ActionsRemoveSelfHostedRunnerFromGroupForOrgData, any>({
@@ -49718,7 +53236,7 @@ export class Api<
      * @request PUT:/orgs/{org}/actions/permissions/selected-actions
      */
     actionsSetAllowedActionsOrganization: (
-      org: string,
+      { org, ...query }: ActionsSetAllowedActionsOrganizationParams,
       data: SelectedActions,
       params: RequestParams = {},
     ) =>
@@ -49739,7 +53257,7 @@ export class Api<
      * @request PUT:/orgs/{org}/actions/permissions
      */
     actionsSetGithubActionsPermissionsOrganization: (
-      org: string,
+      { org, ...query }: ActionsSetGithubActionsPermissionsOrganizationParams,
       data: ActionsSetGithubActionsPermissionsOrganizationPayload,
       params: RequestParams = {},
     ) =>
@@ -49760,8 +53278,11 @@ export class Api<
      * @request PUT:/orgs/{org}/actions/runner-groups/{runner_group_id}/repositories
      */
     actionsSetRepoAccessToSelfHostedRunnerGroupInOrg: (
-      org: string,
-      runnerGroupId: number,
+      {
+        org,
+        runnerGroupId,
+        ...query
+      }: ActionsSetRepoAccessToSelfHostedRunnerGroupInOrgParams,
       data: ActionsSetRepoAccessToSelfHostedRunnerGroupInOrgPayload,
       params: RequestParams = {},
     ) =>
@@ -49782,8 +53303,7 @@ export class Api<
      * @request PUT:/orgs/{org}/actions/secrets/{secret_name}/repositories
      */
     actionsSetSelectedReposForOrgSecret: (
-      org: string,
-      secretName: string,
+      { org, secretName, ...query }: ActionsSetSelectedReposForOrgSecretParams,
       data: ActionsSetSelectedReposForOrgSecretPayload,
       params: RequestParams = {},
     ) =>
@@ -49804,7 +53324,10 @@ export class Api<
      * @request PUT:/orgs/{org}/actions/permissions/repositories
      */
     actionsSetSelectedRepositoriesEnabledGithubActionsOrganization: (
-      org: string,
+      {
+        org,
+        ...query
+      }: ActionsSetSelectedRepositoriesEnabledGithubActionsOrganizationParams,
       data: ActionsSetSelectedRepositoriesEnabledGithubActionsOrganizationPayload,
       params: RequestParams = {},
     ) =>
@@ -49828,8 +53351,11 @@ export class Api<
      * @request PUT:/orgs/{org}/actions/runner-groups/{runner_group_id}/runners
      */
     actionsSetSelfHostedRunnersInGroupForOrg: (
-      org: string,
-      runnerGroupId: number,
+      {
+        org,
+        runnerGroupId,
+        ...query
+      }: ActionsSetSelfHostedRunnersInGroupForOrgParams,
       data: ActionsSetSelfHostedRunnersInGroupForOrgPayload,
       params: RequestParams = {},
     ) =>
@@ -49850,8 +53376,11 @@ export class Api<
      * @request PATCH:/orgs/{org}/actions/runner-groups/{runner_group_id}
      */
     actionsUpdateSelfHostedRunnerGroupForOrg: (
-      org: string,
-      runnerGroupId: number,
+      {
+        org,
+        runnerGroupId,
+        ...query
+      }: ActionsUpdateSelfHostedRunnerGroupForOrgParams,
       data: ActionsUpdateSelfHostedRunnerGroupForOrgPayload,
       params: RequestParams = {},
     ) =>
@@ -49892,7 +53421,10 @@ export class Api<
      * @summary Get an organization installation for the authenticated app
      * @request GET:/orgs/{org}/installation
      */
-    appsGetOrgInstallation: (org: string, params: RequestParams = {}) =>
+    appsGetOrgInstallation: (
+      { org, ...query }: AppsGetOrgInstallationParams,
+      params: RequestParams = {},
+    ) =>
       this.request<AppsGetOrgInstallationData, any>({
         path: \`/orgs/\${org}/installation\`,
         method: "GET",
@@ -49909,7 +53441,7 @@ export class Api<
      * @request GET:/orgs/{org}/settings/billing/actions
      */
     billingGetGithubActionsBillingOrg: (
-      org: string,
+      { org, ...query }: BillingGetGithubActionsBillingOrgParams,
       params: RequestParams = {},
     ) =>
       this.request<BillingGetGithubActionsBillingOrgData, any>({
@@ -49928,7 +53460,7 @@ export class Api<
      * @request GET:/orgs/{org}/settings/billing/packages
      */
     billingGetGithubPackagesBillingOrg: (
-      org: string,
+      { org, ...query }: BillingGetGithubPackagesBillingOrgParams,
       params: RequestParams = {},
     ) =>
       this.request<BillingGetGithubPackagesBillingOrgData, any>({
@@ -49947,7 +53479,7 @@ export class Api<
      * @request GET:/orgs/{org}/settings/billing/shared-storage
      */
     billingGetSharedStorageBillingOrg: (
-      org: string,
+      { org, ...query }: BillingGetSharedStorageBillingOrgParams,
       params: RequestParams = {},
     ) =>
       this.request<BillingGetSharedStorageBillingOrgData, any>({
@@ -49966,7 +53498,7 @@ export class Api<
      * @request GET:/orgs/{org}/interaction-limits
      */
     interactionsGetRestrictionsForOrg: (
-      org: string,
+      { org, ...query }: InteractionsGetRestrictionsForOrgParams,
       params: RequestParams = {},
     ) =>
       this.request<InteractionsGetRestrictionsForOrgData, any>({
@@ -49985,7 +53517,7 @@ export class Api<
      * @request DELETE:/orgs/{org}/interaction-limits
      */
     interactionsRemoveRestrictionsForOrg: (
-      org: string,
+      { org, ...query }: InteractionsRemoveRestrictionsForOrgParams,
       params: RequestParams = {},
     ) =>
       this.request<InteractionsRemoveRestrictionsForOrgData, any>({
@@ -50003,7 +53535,7 @@ export class Api<
      * @request PUT:/orgs/{org}/interaction-limits
      */
     interactionsSetRestrictionsForOrg: (
-      org: string,
+      { org, ...query }: InteractionsSetRestrictionsForOrgParams,
       data: InteractionLimit,
       params: RequestParams = {},
     ) =>
@@ -50045,8 +53577,7 @@ export class Api<
      * @request DELETE:/orgs/{org}/migrations/{migration_id}/archive
      */
     migrationsDeleteArchiveForOrg: (
-      org: string,
-      migrationId: number,
+      { org, migrationId, ...query }: MigrationsDeleteArchiveForOrgParams,
       params: RequestParams = {},
     ) =>
       this.request<MigrationsDeleteArchiveForOrgData, BasicError>({
@@ -50064,8 +53595,7 @@ export class Api<
      * @request GET:/orgs/{org}/migrations/{migration_id}/archive
      */
     migrationsDownloadArchiveForOrg: (
-      org: string,
-      migrationId: number,
+      { org, migrationId, ...query }: MigrationsDownloadArchiveForOrgParams,
       params: RequestParams = {},
     ) =>
       this.request<any, void | BasicError>({
@@ -50083,8 +53613,7 @@ export class Api<
      * @request GET:/orgs/{org}/migrations/{migration_id}
      */
     migrationsGetStatusForOrg: (
-      org: string,
-      migrationId: number,
+      { org, migrationId, ...query }: MigrationsGetStatusForOrgParams,
       params: RequestParams = {},
     ) =>
       this.request<MigrationsGetStatusForOrgData, BasicError>({
@@ -50143,7 +53672,7 @@ export class Api<
      * @request POST:/orgs/{org}/migrations
      */
     migrationsStartForOrg: (
-      org: string,
+      { org, ...query }: MigrationsStartForOrgParams,
       data: MigrationsStartForOrgPayload,
       params: RequestParams = {},
     ) =>
@@ -50165,9 +53694,12 @@ export class Api<
      * @request DELETE:/orgs/{org}/migrations/{migration_id}/repos/{repo_name}/lock
      */
     migrationsUnlockRepoForOrg: (
-      org: string,
-      migrationId: number,
-      repoName: string,
+      {
+        org,
+        migrationId,
+        repoName,
+        ...query
+      }: MigrationsUnlockRepoForOrgParams,
       params: RequestParams = {},
     ) =>
       this.request<MigrationsUnlockRepoForOrgData, BasicError>({
@@ -50185,8 +53717,7 @@ export class Api<
      * @request PUT:/orgs/{org}/blocks/{username}
      */
     orgsBlockUser: (
-      org: string,
-      username: string,
+      { org, username, ...query }: OrgsBlockUserParams,
       params: RequestParams = {},
     ) =>
       this.request<OrgsBlockUserData, ValidationError>({
@@ -50204,8 +53735,7 @@ export class Api<
      * @request DELETE:/orgs/{org}/invitations/{invitation_id}
      */
     orgsCancelInvitation: (
-      org: string,
-      invitationId: number,
+      { org, invitationId, ...query }: OrgsCancelInvitationParams,
       params: RequestParams = {},
     ) =>
       this.request<OrgsCancelInvitationData, BasicError | ValidationError>({
@@ -50223,8 +53753,7 @@ export class Api<
      * @request GET:/orgs/{org}/blocks/{username}
      */
     orgsCheckBlockedUser: (
-      org: string,
-      username: string,
+      { org, username, ...query }: OrgsCheckBlockedUserParams,
       params: RequestParams = {},
     ) =>
       this.request<OrgsCheckBlockedUserData, OrgsCheckBlockedUserError>({
@@ -50242,8 +53771,7 @@ export class Api<
      * @request GET:/orgs/{org}/members/{username}
      */
     orgsCheckMembershipForUser: (
-      org: string,
-      username: string,
+      { org, username, ...query }: OrgsCheckMembershipForUserParams,
       params: RequestParams = {},
     ) =>
       this.request<OrgsCheckMembershipForUserData, void>({
@@ -50261,8 +53789,7 @@ export class Api<
      * @request GET:/orgs/{org}/public_members/{username}
      */
     orgsCheckPublicMembershipForUser: (
-      org: string,
-      username: string,
+      { org, username, ...query }: OrgsCheckPublicMembershipForUserParams,
       params: RequestParams = {},
     ) =>
       this.request<OrgsCheckPublicMembershipForUserData, void>({
@@ -50280,8 +53807,7 @@ export class Api<
      * @request PUT:/orgs/{org}/outside_collaborators/{username}
      */
     orgsConvertMemberToOutsideCollaborator: (
-      org: string,
-      username: string,
+      { org, username, ...query }: OrgsConvertMemberToOutsideCollaboratorParams,
       params: RequestParams = {},
     ) =>
       this.request<
@@ -50302,7 +53828,7 @@ export class Api<
      * @request POST:/orgs/{org}/invitations
      */
     orgsCreateInvitation: (
-      org: string,
+      { org, ...query }: OrgsCreateInvitationParams,
       data: OrgsCreateInvitationPayload,
       params: RequestParams = {},
     ) =>
@@ -50324,7 +53850,7 @@ export class Api<
      * @request POST:/orgs/{org}/hooks
      */
     orgsCreateWebhook: (
-      org: string,
+      { org, ...query }: OrgsCreateWebhookParams,
       data: OrgsCreateWebhookPayload,
       params: RequestParams = {},
     ) =>
@@ -50346,8 +53872,7 @@ export class Api<
      * @request DELETE:/orgs/{org}/hooks/{hook_id}
      */
     orgsDeleteWebhook: (
-      org: string,
-      hookId: number,
+      { org, hookId, ...query }: OrgsDeleteWebhookParams,
       params: RequestParams = {},
     ) =>
       this.request<OrgsDeleteWebhookData, BasicError>({
@@ -50364,7 +53889,7 @@ export class Api<
      * @summary Get an organization
      * @request GET:/orgs/{org}
      */
-    orgsGet: (org: string, params: RequestParams = {}) =>
+    orgsGet: ({ org, ...query }: OrgsGetParams, params: RequestParams = {}) =>
       this.request<OrgsGetData, BasicError>({
         path: \`/orgs/\${org}\`,
         method: "GET",
@@ -50401,8 +53926,7 @@ export class Api<
      * @request GET:/orgs/{org}/memberships/{username}
      */
     orgsGetMembershipForUser: (
-      org: string,
-      username: string,
+      { org, username, ...query }: OrgsGetMembershipForUserParams,
       params: RequestParams = {},
     ) =>
       this.request<OrgsGetMembershipForUserData, BasicError>({
@@ -50420,7 +53944,10 @@ export class Api<
      * @summary Get an organization webhook
      * @request GET:/orgs/{org}/hooks/{hook_id}
      */
-    orgsGetWebhook: (org: string, hookId: number, params: RequestParams = {}) =>
+    orgsGetWebhook: (
+      { org, hookId, ...query }: OrgsGetWebhookParams,
+      params: RequestParams = {},
+    ) =>
       this.request<OrgsGetWebhookData, BasicError>({
         path: \`/orgs/\${org}/hooks/\${hookId}\`,
         method: "GET",
@@ -50437,8 +53964,7 @@ export class Api<
      * @request GET:/orgs/{org}/hooks/{hook_id}/config
      */
     orgsGetWebhookConfigForOrg: (
-      org: string,
-      hookId: number,
+      { org, hookId, ...query }: OrgsGetWebhookConfigForOrgParams,
       params: RequestParams = {},
     ) =>
       this.request<OrgsGetWebhookConfigForOrgData, any>({
@@ -50476,7 +54002,10 @@ export class Api<
      * @summary List users blocked by an organization
      * @request GET:/orgs/{org}/blocks
      */
-    orgsListBlockedUsers: (org: string, params: RequestParams = {}) =>
+    orgsListBlockedUsers: (
+      { org, ...query }: OrgsListBlockedUsersParams,
+      params: RequestParams = {},
+    ) =>
       this.request<
         OrgsListBlockedUsersData,
         {
@@ -50618,7 +54147,10 @@ export class Api<
      * @summary List SAML SSO authorizations for an organization
      * @request GET:/orgs/{org}/credential-authorizations
      */
-    orgsListSamlSsoAuthorizations: (org: string, params: RequestParams = {}) =>
+    orgsListSamlSsoAuthorizations: (
+      { org, ...query }: OrgsListSamlSsoAuthorizationsParams,
+      params: RequestParams = {},
+    ) =>
       this.request<OrgsListSamlSsoAuthorizationsData, any>({
         path: \`/orgs/\${org}/credential-authorizations\`,
         method: "GET",
@@ -50655,8 +54187,7 @@ export class Api<
      * @request POST:/orgs/{org}/hooks/{hook_id}/pings
      */
     orgsPingWebhook: (
-      org: string,
-      hookId: number,
+      { org, hookId, ...query }: OrgsPingWebhookParams,
       params: RequestParams = {},
     ) =>
       this.request<OrgsPingWebhookData, BasicError>({
@@ -50674,8 +54205,7 @@ export class Api<
      * @request DELETE:/orgs/{org}/members/{username}
      */
     orgsRemoveMember: (
-      org: string,
-      username: string,
+      { org, username, ...query }: OrgsRemoveMemberParams,
       params: RequestParams = {},
     ) =>
       this.request<OrgsRemoveMemberData, BasicError>({
@@ -50693,8 +54223,7 @@ export class Api<
      * @request DELETE:/orgs/{org}/memberships/{username}
      */
     orgsRemoveMembershipForUser: (
-      org: string,
-      username: string,
+      { org, username, ...query }: OrgsRemoveMembershipForUserParams,
       params: RequestParams = {},
     ) =>
       this.request<OrgsRemoveMembershipForUserData, BasicError>({
@@ -50712,8 +54241,7 @@ export class Api<
      * @request DELETE:/orgs/{org}/outside_collaborators/{username}
      */
     orgsRemoveOutsideCollaborator: (
-      org: string,
-      username: string,
+      { org, username, ...query }: OrgsRemoveOutsideCollaboratorParams,
       params: RequestParams = {},
     ) =>
       this.request<
@@ -50734,8 +54262,11 @@ export class Api<
      * @request DELETE:/orgs/{org}/public_members/{username}
      */
     orgsRemovePublicMembershipForAuthenticatedUser: (
-      org: string,
-      username: string,
+      {
+        org,
+        username,
+        ...query
+      }: OrgsRemovePublicMembershipForAuthenticatedUserParams,
       params: RequestParams = {},
     ) =>
       this.request<OrgsRemovePublicMembershipForAuthenticatedUserData, any>({
@@ -50753,8 +54284,7 @@ export class Api<
      * @request DELETE:/orgs/{org}/credential-authorizations/{credential_id}
      */
     orgsRemoveSamlSsoAuthorization: (
-      org: string,
-      credentialId: number,
+      { org, credentialId, ...query }: OrgsRemoveSamlSsoAuthorizationParams,
       params: RequestParams = {},
     ) =>
       this.request<OrgsRemoveSamlSsoAuthorizationData, BasicError>({
@@ -50772,8 +54302,7 @@ export class Api<
      * @request PUT:/orgs/{org}/memberships/{username}
      */
     orgsSetMembershipForUser: (
-      org: string,
-      username: string,
+      { org, username, ...query }: OrgsSetMembershipForUserParams,
       data: OrgsSetMembershipForUserPayload,
       params: RequestParams = {},
     ) =>
@@ -50795,8 +54324,11 @@ export class Api<
      * @request PUT:/orgs/{org}/public_members/{username}
      */
     orgsSetPublicMembershipForAuthenticatedUser: (
-      org: string,
-      username: string,
+      {
+        org,
+        username,
+        ...query
+      }: OrgsSetPublicMembershipForAuthenticatedUserParams,
       params: RequestParams = {},
     ) =>
       this.request<OrgsSetPublicMembershipForAuthenticatedUserData, BasicError>(
@@ -50816,8 +54348,7 @@ export class Api<
      * @request DELETE:/orgs/{org}/blocks/{username}
      */
     orgsUnblockUser: (
-      org: string,
-      username: string,
+      { org, username, ...query }: OrgsUnblockUserParams,
       params: RequestParams = {},
     ) =>
       this.request<OrgsUnblockUserData, any>({
@@ -50835,7 +54366,7 @@ export class Api<
      * @request PATCH:/orgs/{org}
      */
     orgsUpdate: (
-      org: string,
+      { org, ...query }: OrgsUpdateParams,
       data: OrgsUpdatePayload,
       params: RequestParams = {},
     ) =>
@@ -50857,8 +54388,7 @@ export class Api<
      * @request PATCH:/orgs/{org}/hooks/{hook_id}
      */
     orgsUpdateWebhook: (
-      org: string,
-      hookId: number,
+      { org, hookId, ...query }: OrgsUpdateWebhookParams,
       data: OrgsUpdateWebhookPayload,
       params: RequestParams = {},
     ) =>
@@ -50880,8 +54410,7 @@ export class Api<
      * @request PATCH:/orgs/{org}/hooks/{hook_id}/config
      */
     orgsUpdateWebhookConfigForOrg: (
-      org: string,
-      hookId: number,
+      { org, hookId, ...query }: OrgsUpdateWebhookConfigForOrgParams,
       data: OrgsUpdateWebhookConfigForOrgPayload,
       params: RequestParams = {},
     ) =>
@@ -50903,7 +54432,7 @@ export class Api<
      * @request POST:/orgs/{org}/projects
      */
     projectsCreateForOrg: (
-      org: string,
+      { org, ...query }: ProjectsCreateForOrgParams,
       data: ProjectsCreateForOrgPayload,
       params: RequestParams = {},
     ) =>
@@ -50948,10 +54477,13 @@ export class Api<
      * @request POST:/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions
      */
     reactionsCreateForTeamDiscussionCommentInOrg: (
-      org: string,
-      teamSlug: string,
-      discussionNumber: number,
-      commentNumber: number,
+      {
+        org,
+        teamSlug,
+        discussionNumber,
+        commentNumber,
+        ...query
+      }: ReactionsCreateForTeamDiscussionCommentInOrgParams,
       data: ReactionsCreateForTeamDiscussionCommentInOrgPayload,
       params: RequestParams = {},
     ) =>
@@ -50973,9 +54505,12 @@ export class Api<
      * @request POST:/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions
      */
     reactionsCreateForTeamDiscussionInOrg: (
-      org: string,
-      teamSlug: string,
-      discussionNumber: number,
+      {
+        org,
+        teamSlug,
+        discussionNumber,
+        ...query
+      }: ReactionsCreateForTeamDiscussionInOrgParams,
       data: ReactionsCreateForTeamDiscussionInOrgPayload,
       params: RequestParams = {},
     ) =>
@@ -50997,10 +54532,13 @@ export class Api<
      * @request DELETE:/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions/{reaction_id}
      */
     reactionsDeleteForTeamDiscussion: (
-      org: string,
-      teamSlug: string,
-      discussionNumber: number,
-      reactionId: number,
+      {
+        org,
+        teamSlug,
+        discussionNumber,
+        reactionId,
+        ...query
+      }: ReactionsDeleteForTeamDiscussionParams,
       params: RequestParams = {},
     ) =>
       this.request<ReactionsDeleteForTeamDiscussionData, any>({
@@ -51018,11 +54556,14 @@ export class Api<
      * @request DELETE:/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions/{reaction_id}
      */
     reactionsDeleteForTeamDiscussionComment: (
-      org: string,
-      teamSlug: string,
-      discussionNumber: number,
-      commentNumber: number,
-      reactionId: number,
+      {
+        org,
+        teamSlug,
+        discussionNumber,
+        commentNumber,
+        reactionId,
+        ...query
+      }: ReactionsDeleteForTeamDiscussionCommentParams,
       params: RequestParams = {},
     ) =>
       this.request<ReactionsDeleteForTeamDiscussionCommentData, any>({
@@ -51091,7 +54632,7 @@ export class Api<
      * @request POST:/orgs/{org}/repos
      */
     reposCreateInOrg: (
-      org: string,
+      { org, ...query }: ReposCreateInOrgParams,
       data: ReposCreateInOrgPayload,
       params: RequestParams = {},
     ) =>
@@ -51133,9 +54674,12 @@ export class Api<
      * @request PUT:/orgs/{org}/teams/{team_slug}/memberships/{username}
      */
     teamsAddOrUpdateMembershipForUserInOrg: (
-      org: string,
-      teamSlug: string,
-      username: string,
+      {
+        org,
+        teamSlug,
+        username,
+        ...query
+      }: TeamsAddOrUpdateMembershipForUserInOrgParams,
       data: TeamsAddOrUpdateMembershipForUserInOrgPayload,
       params: RequestParams = {},
     ) =>
@@ -51160,9 +54704,12 @@ export class Api<
      * @request PUT:/orgs/{org}/teams/{team_slug}/projects/{project_id}
      */
     teamsAddOrUpdateProjectPermissionsInOrg: (
-      org: string,
-      teamSlug: string,
-      projectId: number,
+      {
+        org,
+        teamSlug,
+        projectId,
+        ...query
+      }: TeamsAddOrUpdateProjectPermissionsInOrgParams,
       data: TeamsAddOrUpdateProjectPermissionsInOrgPayload,
       params: RequestParams = {},
     ) =>
@@ -51186,10 +54733,13 @@ export class Api<
      * @request PUT:/orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}
      */
     teamsAddOrUpdateRepoPermissionsInOrg: (
-      org: string,
-      teamSlug: string,
-      owner: string,
-      repo: string,
+      {
+        org,
+        teamSlug,
+        owner,
+        repo,
+        ...query
+      }: TeamsAddOrUpdateRepoPermissionsInOrgParams,
       data: TeamsAddOrUpdateRepoPermissionsInOrgPayload,
       params: RequestParams = {},
     ) =>
@@ -51210,9 +54760,12 @@ export class Api<
      * @request GET:/orgs/{org}/teams/{team_slug}/projects/{project_id}
      */
     teamsCheckPermissionsForProjectInOrg: (
-      org: string,
-      teamSlug: string,
-      projectId: number,
+      {
+        org,
+        teamSlug,
+        projectId,
+        ...query
+      }: TeamsCheckPermissionsForProjectInOrgParams,
       params: RequestParams = {},
     ) =>
       this.request<TeamsCheckPermissionsForProjectInOrgData, void>({
@@ -51231,10 +54784,13 @@ export class Api<
      * @request GET:/orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}
      */
     teamsCheckPermissionsForRepoInOrg: (
-      org: string,
-      teamSlug: string,
-      owner: string,
-      repo: string,
+      {
+        org,
+        teamSlug,
+        owner,
+        repo,
+        ...query
+      }: TeamsCheckPermissionsForRepoInOrgParams,
       params: RequestParams = {},
     ) =>
       this.request<TeamsCheckPermissionsForRepoInOrgData, void>({
@@ -51253,7 +54809,7 @@ export class Api<
      * @request POST:/orgs/{org}/teams
      */
     teamsCreate: (
-      org: string,
+      { org, ...query }: TeamsCreateParams,
       data: TeamsCreatePayload,
       params: RequestParams = {},
     ) =>
@@ -51275,9 +54831,12 @@ export class Api<
      * @request POST:/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments
      */
     teamsCreateDiscussionCommentInOrg: (
-      org: string,
-      teamSlug: string,
-      discussionNumber: number,
+      {
+        org,
+        teamSlug,
+        discussionNumber,
+        ...query
+      }: TeamsCreateDiscussionCommentInOrgParams,
       data: TeamsCreateDiscussionCommentInOrgPayload,
       params: RequestParams = {},
     ) =>
@@ -51299,8 +54858,7 @@ export class Api<
      * @request POST:/orgs/{org}/teams/{team_slug}/discussions
      */
     teamsCreateDiscussionInOrg: (
-      org: string,
-      teamSlug: string,
+      { org, teamSlug, ...query }: TeamsCreateDiscussionInOrgParams,
       data: TeamsCreateDiscussionInOrgPayload,
       params: RequestParams = {},
     ) =>
@@ -51322,8 +54880,11 @@ export class Api<
      * @request PATCH:/orgs/{org}/teams/{team_slug}/team-sync/group-mappings
      */
     teamsCreateOrUpdateIdpGroupConnectionsInOrg: (
-      org: string,
-      teamSlug: string,
+      {
+        org,
+        teamSlug,
+        ...query
+      }: TeamsCreateOrUpdateIdpGroupConnectionsInOrgParams,
       data: TeamsCreateOrUpdateIdpGroupConnectionsInOrgPayload,
       params: RequestParams = {},
     ) =>
@@ -51345,10 +54906,13 @@ export class Api<
      * @request DELETE:/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}
      */
     teamsDeleteDiscussionCommentInOrg: (
-      org: string,
-      teamSlug: string,
-      discussionNumber: number,
-      commentNumber: number,
+      {
+        org,
+        teamSlug,
+        discussionNumber,
+        commentNumber,
+        ...query
+      }: TeamsDeleteDiscussionCommentInOrgParams,
       params: RequestParams = {},
     ) =>
       this.request<TeamsDeleteDiscussionCommentInOrgData, any>({
@@ -51366,9 +54930,12 @@ export class Api<
      * @request DELETE:/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}
      */
     teamsDeleteDiscussionInOrg: (
-      org: string,
-      teamSlug: string,
-      discussionNumber: number,
+      {
+        org,
+        teamSlug,
+        discussionNumber,
+        ...query
+      }: TeamsDeleteDiscussionInOrgParams,
       params: RequestParams = {},
     ) =>
       this.request<TeamsDeleteDiscussionInOrgData, any>({
@@ -51386,8 +54953,7 @@ export class Api<
      * @request DELETE:/orgs/{org}/teams/{team_slug}
      */
     teamsDeleteInOrg: (
-      org: string,
-      teamSlug: string,
+      { org, teamSlug, ...query }: TeamsDeleteInOrgParams,
       params: RequestParams = {},
     ) =>
       this.request<TeamsDeleteInOrgData, any>({
@@ -51405,8 +54971,7 @@ export class Api<
      * @request GET:/orgs/{org}/teams/{team_slug}
      */
     teamsGetByName: (
-      org: string,
-      teamSlug: string,
+      { org, teamSlug, ...query }: TeamsGetByNameParams,
       params: RequestParams = {},
     ) =>
       this.request<TeamsGetByNameData, BasicError>({
@@ -51425,10 +54990,13 @@ export class Api<
      * @request GET:/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}
      */
     teamsGetDiscussionCommentInOrg: (
-      org: string,
-      teamSlug: string,
-      discussionNumber: number,
-      commentNumber: number,
+      {
+        org,
+        teamSlug,
+        discussionNumber,
+        commentNumber,
+        ...query
+      }: TeamsGetDiscussionCommentInOrgParams,
       params: RequestParams = {},
     ) =>
       this.request<TeamsGetDiscussionCommentInOrgData, any>({
@@ -51447,9 +55015,12 @@ export class Api<
      * @request GET:/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}
      */
     teamsGetDiscussionInOrg: (
-      org: string,
-      teamSlug: string,
-      discussionNumber: number,
+      {
+        org,
+        teamSlug,
+        discussionNumber,
+        ...query
+      }: TeamsGetDiscussionInOrgParams,
       params: RequestParams = {},
     ) =>
       this.request<TeamsGetDiscussionInOrgData, any>({
@@ -51468,9 +55039,12 @@ export class Api<
      * @request GET:/orgs/{org}/teams/{team_slug}/memberships/{username}
      */
     teamsGetMembershipForUserInOrg: (
-      org: string,
-      teamSlug: string,
-      username: string,
+      {
+        org,
+        teamSlug,
+        username,
+        ...query
+      }: TeamsGetMembershipForUserInOrgParams,
       params: RequestParams = {},
     ) =>
       this.request<TeamsGetMembershipForUserInOrgData, void>({
@@ -51594,8 +55168,7 @@ export class Api<
      * @request GET:/orgs/{org}/teams/{team_slug}/team-sync/group-mappings
      */
     teamsListIdpGroupsInOrg: (
-      org: string,
-      teamSlug: string,
+      { org, teamSlug, ...query }: TeamsListIdpGroupsInOrgParams,
       params: RequestParams = {},
     ) =>
       this.request<TeamsListIdpGroupsInOrgData, any>({
@@ -51694,9 +55267,12 @@ export class Api<
      * @request DELETE:/orgs/{org}/teams/{team_slug}/memberships/{username}
      */
     teamsRemoveMembershipForUserInOrg: (
-      org: string,
-      teamSlug: string,
-      username: string,
+      {
+        org,
+        teamSlug,
+        username,
+        ...query
+      }: TeamsRemoveMembershipForUserInOrgParams,
       params: RequestParams = {},
     ) =>
       this.request<TeamsRemoveMembershipForUserInOrgData, void>({
@@ -51714,9 +55290,7 @@ export class Api<
      * @request DELETE:/orgs/{org}/teams/{team_slug}/projects/{project_id}
      */
     teamsRemoveProjectInOrg: (
-      org: string,
-      teamSlug: string,
-      projectId: number,
+      { org, teamSlug, projectId, ...query }: TeamsRemoveProjectInOrgParams,
       params: RequestParams = {},
     ) =>
       this.request<TeamsRemoveProjectInOrgData, any>({
@@ -51734,10 +55308,7 @@ export class Api<
      * @request DELETE:/orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}
      */
     teamsRemoveRepoInOrg: (
-      org: string,
-      teamSlug: string,
-      owner: string,
-      repo: string,
+      { org, teamSlug, owner, repo, ...query }: TeamsRemoveRepoInOrgParams,
       params: RequestParams = {},
     ) =>
       this.request<TeamsRemoveRepoInOrgData, any>({
@@ -51755,10 +55326,13 @@ export class Api<
      * @request PATCH:/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}
      */
     teamsUpdateDiscussionCommentInOrg: (
-      org: string,
-      teamSlug: string,
-      discussionNumber: number,
-      commentNumber: number,
+      {
+        org,
+        teamSlug,
+        discussionNumber,
+        commentNumber,
+        ...query
+      }: TeamsUpdateDiscussionCommentInOrgParams,
       data: TeamsUpdateDiscussionCommentInOrgPayload,
       params: RequestParams = {},
     ) =>
@@ -51780,9 +55354,12 @@ export class Api<
      * @request PATCH:/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}
      */
     teamsUpdateDiscussionInOrg: (
-      org: string,
-      teamSlug: string,
-      discussionNumber: number,
+      {
+        org,
+        teamSlug,
+        discussionNumber,
+        ...query
+      }: TeamsUpdateDiscussionInOrgParams,
       data: TeamsUpdateDiscussionInOrgPayload,
       params: RequestParams = {},
     ) =>
@@ -51804,8 +55381,7 @@ export class Api<
      * @request PATCH:/orgs/{org}/teams/{team_slug}
      */
     teamsUpdateInOrg: (
-      org: string,
-      teamSlug: string,
+      { org, teamSlug, ...query }: TeamsUpdateInOrgParams,
       data: TeamsUpdateInOrgPayload,
       params: RequestParams = {},
     ) =>
@@ -51828,8 +55404,7 @@ export class Api<
      * @request PUT:/projects/{project_id}/collaborators/{username}
      */
     projectsAddCollaborator: (
-      projectId: number,
-      username: string,
+      { projectId, username, ...query }: ProjectsAddCollaboratorParams,
       data: ProjectsAddCollaboratorPayload,
       params: RequestParams = {},
     ) =>
@@ -51858,7 +55433,7 @@ export class Api<
      * @request POST:/projects/columns/{column_id}/cards
      */
     projectsCreateCard: (
-      columnId: number,
+      { columnId, ...query }: ProjectsCreateCardParams,
       data: ProjectsCreateCardPayload,
       params: RequestParams = {},
     ) =>
@@ -51880,7 +55455,7 @@ export class Api<
      * @request POST:/projects/{project_id}/columns
      */
     projectsCreateColumn: (
-      projectId: number,
+      { projectId, ...query }: ProjectsCreateColumnParams,
       data: ProjectsCreateColumnPayload,
       params: RequestParams = {},
     ) =>
@@ -51904,7 +55479,10 @@ export class Api<
      * @summary Delete a project
      * @request DELETE:/projects/{project_id}
      */
-    projectsDelete: (projectId: number, params: RequestParams = {}) =>
+    projectsDelete: (
+      { projectId, ...query }: ProjectsDeleteParams,
+      params: RequestParams = {},
+    ) =>
       this.request<ProjectsDeleteData, ProjectsDeleteError>({
         path: \`/projects/\${projectId}\`,
         method: "DELETE",
@@ -51919,7 +55497,10 @@ export class Api<
      * @summary Delete a project card
      * @request DELETE:/projects/columns/cards/{card_id}
      */
-    projectsDeleteCard: (cardId: number, params: RequestParams = {}) =>
+    projectsDeleteCard: (
+      { cardId, ...query }: ProjectsDeleteCardParams,
+      params: RequestParams = {},
+    ) =>
       this.request<ProjectsDeleteCardData, ProjectsDeleteCardError>({
         path: \`/projects/columns/cards/\${cardId}\`,
         method: "DELETE",
@@ -51934,7 +55515,10 @@ export class Api<
      * @summary Delete a project column
      * @request DELETE:/projects/columns/{column_id}
      */
-    projectsDeleteColumn: (columnId: number, params: RequestParams = {}) =>
+    projectsDeleteColumn: (
+      { columnId, ...query }: ProjectsDeleteColumnParams,
+      params: RequestParams = {},
+    ) =>
       this.request<ProjectsDeleteColumnData, BasicError>({
         path: \`/projects/columns/\${columnId}\`,
         method: "DELETE",
@@ -51949,7 +55533,10 @@ export class Api<
      * @summary Get a project
      * @request GET:/projects/{project_id}
      */
-    projectsGet: (projectId: number, params: RequestParams = {}) =>
+    projectsGet: (
+      { projectId, ...query }: ProjectsGetParams,
+      params: RequestParams = {},
+    ) =>
       this.request<ProjectsGetData, BasicError>({
         path: \`/projects/\${projectId}\`,
         method: "GET",
@@ -51965,7 +55552,10 @@ export class Api<
      * @summary Get a project card
      * @request GET:/projects/columns/cards/{card_id}
      */
-    projectsGetCard: (cardId: number, params: RequestParams = {}) =>
+    projectsGetCard: (
+      { cardId, ...query }: ProjectsGetCardParams,
+      params: RequestParams = {},
+    ) =>
       this.request<ProjectsGetCardData, BasicError>({
         path: \`/projects/columns/cards/\${cardId}\`,
         method: "GET",
@@ -51981,7 +55571,10 @@ export class Api<
      * @summary Get a project column
      * @request GET:/projects/columns/{column_id}
      */
-    projectsGetColumn: (columnId: number, params: RequestParams = {}) =>
+    projectsGetColumn: (
+      { columnId, ...query }: ProjectsGetColumnParams,
+      params: RequestParams = {},
+    ) =>
       this.request<ProjectsGetColumnData, BasicError>({
         path: \`/projects/columns/\${columnId}\`,
         method: "GET",
@@ -51998,8 +55591,7 @@ export class Api<
      * @request GET:/projects/{project_id}/collaborators/{username}/permission
      */
     projectsGetPermissionForUser: (
-      projectId: number,
-      username: string,
+      { projectId, username, ...query }: ProjectsGetPermissionForUserParams,
       params: RequestParams = {},
     ) =>
       this.request<
@@ -52094,7 +55686,7 @@ export class Api<
      * @request POST:/projects/columns/cards/{card_id}/moves
      */
     projectsMoveCard: (
-      cardId: number,
+      { cardId, ...query }: ProjectsMoveCardParams,
       data: ProjectsMoveCardPayload,
       params: RequestParams = {},
     ) =>
@@ -52116,7 +55708,7 @@ export class Api<
      * @request POST:/projects/columns/{column_id}/moves
      */
     projectsMoveColumn: (
-      columnId: number,
+      { columnId, ...query }: ProjectsMoveColumnParams,
       data: ProjectsMoveColumnPayload,
       params: RequestParams = {},
     ) =>
@@ -52138,8 +55730,7 @@ export class Api<
      * @request DELETE:/projects/{project_id}/collaborators/{username}
      */
     projectsRemoveCollaborator: (
-      projectId: number,
-      username: string,
+      { projectId, username, ...query }: ProjectsRemoveCollaboratorParams,
       params: RequestParams = {},
     ) =>
       this.request<
@@ -52165,7 +55756,7 @@ export class Api<
      * @request PATCH:/projects/{project_id}
      */
     projectsUpdate: (
-      projectId: number,
+      { projectId, ...query }: ProjectsUpdateParams,
       data: ProjectsUpdatePayload,
       params: RequestParams = {},
     ) =>
@@ -52187,7 +55778,7 @@ export class Api<
      * @request PATCH:/projects/columns/cards/{card_id}
      */
     projectsUpdateCard: (
-      cardId: number,
+      { cardId, ...query }: ProjectsUpdateCardParams,
       data: ProjectsUpdateCardPayload,
       params: RequestParams = {},
     ) =>
@@ -52209,7 +55800,7 @@ export class Api<
      * @request PATCH:/projects/columns/{column_id}
      */
     projectsUpdateColumn: (
-      columnId: number,
+      { columnId, ...query }: ProjectsUpdateColumnParams,
       data: ProjectsUpdateColumnPayload,
       params: RequestParams = {},
     ) =>
@@ -52249,7 +55840,10 @@ export class Api<
      * @request DELETE:/reactions/{reaction_id}
      * @deprecated
      */
-    reactionsDeleteLegacy: (reactionId: number, params: RequestParams = {}) =>
+    reactionsDeleteLegacy: (
+      { reactionId, ...query }: ReactionsDeleteLegacyParams,
+      params: RequestParams = {},
+    ) =>
       this.request<
         ReactionsDeleteLegacyData,
         | BasicError
@@ -52273,9 +55867,7 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/actions/runs/{run_id}/cancel
      */
     actionsCancelWorkflowRun: (
-      owner: string,
-      repo: string,
-      runId: number,
+      { owner, repo, runId, ...query }: ActionsCancelWorkflowRunParams,
       params: RequestParams = {},
     ) =>
       this.request<ActionsCancelWorkflowRunData, any>({
@@ -52293,9 +55885,12 @@ export class Api<
      * @request PUT:/repos/{owner}/{repo}/actions/secrets/{secret_name}
      */
     actionsCreateOrUpdateRepoSecret: (
-      owner: string,
-      repo: string,
-      secretName: string,
+      {
+        owner,
+        repo,
+        secretName,
+        ...query
+      }: ActionsCreateOrUpdateRepoSecretParams,
       data: ActionsCreateOrUpdateRepoSecretPayload,
       params: RequestParams = {},
     ) =>
@@ -52316,8 +55911,7 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/actions/runners/registration-token
      */
     actionsCreateRegistrationTokenForRepo: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: ActionsCreateRegistrationTokenForRepoParams,
       params: RequestParams = {},
     ) =>
       this.request<ActionsCreateRegistrationTokenForRepoData, any>({
@@ -52336,8 +55930,7 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/actions/runners/remove-token
      */
     actionsCreateRemoveTokenForRepo: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: ActionsCreateRemoveTokenForRepoParams,
       params: RequestParams = {},
     ) =>
       this.request<ActionsCreateRemoveTokenForRepoData, any>({
@@ -52356,9 +55949,12 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches
      */
     actionsCreateWorkflowDispatch: (
-      owner: string,
-      repo: string,
-      workflowId: number | string,
+      {
+        owner,
+        repo,
+        workflowId,
+        ...query
+      }: ActionsCreateWorkflowDispatchParams,
       data: ActionsCreateWorkflowDispatchPayload,
       params: RequestParams = {},
     ) =>
@@ -52379,9 +55975,7 @@ export class Api<
      * @request DELETE:/repos/{owner}/{repo}/actions/artifacts/{artifact_id}
      */
     actionsDeleteArtifact: (
-      owner: string,
-      repo: string,
-      artifactId: number,
+      { owner, repo, artifactId, ...query }: ActionsDeleteArtifactParams,
       params: RequestParams = {},
     ) =>
       this.request<ActionsDeleteArtifactData, any>({
@@ -52399,9 +55993,7 @@ export class Api<
      * @request DELETE:/repos/{owner}/{repo}/actions/secrets/{secret_name}
      */
     actionsDeleteRepoSecret: (
-      owner: string,
-      repo: string,
-      secretName: string,
+      { owner, repo, secretName, ...query }: ActionsDeleteRepoSecretParams,
       params: RequestParams = {},
     ) =>
       this.request<ActionsDeleteRepoSecretData, any>({
@@ -52419,9 +56011,12 @@ export class Api<
      * @request DELETE:/repos/{owner}/{repo}/actions/runners/{runner_id}
      */
     actionsDeleteSelfHostedRunnerFromRepo: (
-      owner: string,
-      repo: string,
-      runnerId: number,
+      {
+        owner,
+        repo,
+        runnerId,
+        ...query
+      }: ActionsDeleteSelfHostedRunnerFromRepoParams,
       params: RequestParams = {},
     ) =>
       this.request<ActionsDeleteSelfHostedRunnerFromRepoData, any>({
@@ -52439,9 +56034,7 @@ export class Api<
      * @request DELETE:/repos/{owner}/{repo}/actions/runs/{run_id}
      */
     actionsDeleteWorkflowRun: (
-      owner: string,
-      repo: string,
-      runId: number,
+      { owner, repo, runId, ...query }: ActionsDeleteWorkflowRunParams,
       params: RequestParams = {},
     ) =>
       this.request<ActionsDeleteWorkflowRunData, any>({
@@ -52459,9 +56052,7 @@ export class Api<
      * @request DELETE:/repos/{owner}/{repo}/actions/runs/{run_id}/logs
      */
     actionsDeleteWorkflowRunLogs: (
-      owner: string,
-      repo: string,
-      runId: number,
+      { owner, repo, runId, ...query }: ActionsDeleteWorkflowRunLogsParams,
       params: RequestParams = {},
     ) =>
       this.request<ActionsDeleteWorkflowRunLogsData, any>({
@@ -52479,9 +56070,7 @@ export class Api<
      * @request PUT:/repos/{owner}/{repo}/actions/workflows/{workflow_id}/disable
      */
     actionsDisableWorkflow: (
-      owner: string,
-      repo: string,
-      workflowId: number | string,
+      { owner, repo, workflowId, ...query }: ActionsDisableWorkflowParams,
       params: RequestParams = {},
     ) =>
       this.request<ActionsDisableWorkflowData, any>({
@@ -52499,10 +56088,13 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/actions/artifacts/{artifact_id}/{archive_format}
      */
     actionsDownloadArtifact: (
-      owner: string,
-      repo: string,
-      artifactId: number,
-      archiveFormat: string,
+      {
+        owner,
+        repo,
+        artifactId,
+        archiveFormat,
+        ...query
+      }: ActionsDownloadArtifactParams,
       params: RequestParams = {},
     ) =>
       this.request<any, void>({
@@ -52520,9 +56112,12 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/actions/jobs/{job_id}/logs
      */
     actionsDownloadJobLogsForWorkflowRun: (
-      owner: string,
-      repo: string,
-      jobId: number,
+      {
+        owner,
+        repo,
+        jobId,
+        ...query
+      }: ActionsDownloadJobLogsForWorkflowRunParams,
       params: RequestParams = {},
     ) =>
       this.request<any, void>({
@@ -52540,9 +56135,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/actions/runs/{run_id}/logs
      */
     actionsDownloadWorkflowRunLogs: (
-      owner: string,
-      repo: string,
-      runId: number,
+      { owner, repo, runId, ...query }: ActionsDownloadWorkflowRunLogsParams,
       params: RequestParams = {},
     ) =>
       this.request<any, void>({
@@ -52560,9 +56153,7 @@ export class Api<
      * @request PUT:/repos/{owner}/{repo}/actions/workflows/{workflow_id}/enable
      */
     actionsEnableWorkflow: (
-      owner: string,
-      repo: string,
-      workflowId: number | string,
+      { owner, repo, workflowId, ...query }: ActionsEnableWorkflowParams,
       params: RequestParams = {},
     ) =>
       this.request<ActionsEnableWorkflowData, any>({
@@ -52580,8 +56171,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/actions/permissions/selected-actions
      */
     actionsGetAllowedActionsRepository: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: ActionsGetAllowedActionsRepositoryParams,
       params: RequestParams = {},
     ) =>
       this.request<ActionsGetAllowedActionsRepositoryData, any>({
@@ -52600,9 +56190,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/actions/artifacts/{artifact_id}
      */
     actionsGetArtifact: (
-      owner: string,
-      repo: string,
-      artifactId: number,
+      { owner, repo, artifactId, ...query }: ActionsGetArtifactParams,
       params: RequestParams = {},
     ) =>
       this.request<ActionsGetArtifactData, any>({
@@ -52621,8 +56209,11 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/actions/permissions
      */
     actionsGetGithubActionsPermissionsRepository: (
-      owner: string,
-      repo: string,
+      {
+        owner,
+        repo,
+        ...query
+      }: ActionsGetGithubActionsPermissionsRepositoryParams,
       params: RequestParams = {},
     ) =>
       this.request<ActionsGetGithubActionsPermissionsRepositoryData, any>({
@@ -52641,9 +56232,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/actions/jobs/{job_id}
      */
     actionsGetJobForWorkflowRun: (
-      owner: string,
-      repo: string,
-      jobId: number,
+      { owner, repo, jobId, ...query }: ActionsGetJobForWorkflowRunParams,
       params: RequestParams = {},
     ) =>
       this.request<ActionsGetJobForWorkflowRunData, any>({
@@ -52662,8 +56251,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/actions/secrets/public-key
      */
     actionsGetRepoPublicKey: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: ActionsGetRepoPublicKeyParams,
       params: RequestParams = {},
     ) =>
       this.request<ActionsGetRepoPublicKeyData, any>({
@@ -52682,9 +56270,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/actions/secrets/{secret_name}
      */
     actionsGetRepoSecret: (
-      owner: string,
-      repo: string,
-      secretName: string,
+      { owner, repo, secretName, ...query }: ActionsGetRepoSecretParams,
       params: RequestParams = {},
     ) =>
       this.request<ActionsGetRepoSecretData, any>({
@@ -52703,9 +56289,12 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/actions/runners/{runner_id}
      */
     actionsGetSelfHostedRunnerForRepo: (
-      owner: string,
-      repo: string,
-      runnerId: number,
+      {
+        owner,
+        repo,
+        runnerId,
+        ...query
+      }: ActionsGetSelfHostedRunnerForRepoParams,
       params: RequestParams = {},
     ) =>
       this.request<ActionsGetSelfHostedRunnerForRepoData, any>({
@@ -52724,9 +56313,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/actions/workflows/{workflow_id}
      */
     actionsGetWorkflow: (
-      owner: string,
-      repo: string,
-      workflowId: number | string,
+      { owner, repo, workflowId, ...query }: ActionsGetWorkflowParams,
       params: RequestParams = {},
     ) =>
       this.request<ActionsGetWorkflowData, any>({
@@ -52745,9 +56332,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/actions/runs/{run_id}
      */
     actionsGetWorkflowRun: (
-      owner: string,
-      repo: string,
-      runId: number,
+      { owner, repo, runId, ...query }: ActionsGetWorkflowRunParams,
       params: RequestParams = {},
     ) =>
       this.request<ActionsGetWorkflowRunData, any>({
@@ -52766,9 +56351,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/actions/runs/{run_id}/timing
      */
     actionsGetWorkflowRunUsage: (
-      owner: string,
-      repo: string,
-      runId: number,
+      { owner, repo, runId, ...query }: ActionsGetWorkflowRunUsageParams,
       params: RequestParams = {},
     ) =>
       this.request<ActionsGetWorkflowRunUsageData, any>({
@@ -52787,9 +56370,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/actions/workflows/{workflow_id}/timing
      */
     actionsGetWorkflowUsage: (
-      owner: string,
-      repo: string,
-      workflowId: number | string,
+      { owner, repo, workflowId, ...query }: ActionsGetWorkflowUsageParams,
       params: RequestParams = {},
     ) =>
       this.request<ActionsGetWorkflowUsageData, any>({
@@ -52888,8 +56469,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/actions/runners/downloads
      */
     actionsListRunnerApplicationsForRepo: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: ActionsListRunnerApplicationsForRepoParams,
       params: RequestParams = {},
     ) =>
       this.request<ActionsListRunnerApplicationsForRepoData, any>({
@@ -52988,9 +56568,7 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/actions/runs/{run_id}/rerun
      */
     actionsReRunWorkflow: (
-      owner: string,
-      repo: string,
-      runId: number,
+      { owner, repo, runId, ...query }: ActionsReRunWorkflowParams,
       params: RequestParams = {},
     ) =>
       this.request<ActionsReRunWorkflowData, any>({
@@ -53008,8 +56586,7 @@ export class Api<
      * @request PUT:/repos/{owner}/{repo}/actions/permissions/selected-actions
      */
     actionsSetAllowedActionsRepository: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: ActionsSetAllowedActionsRepositoryParams,
       data: SelectedActions,
       params: RequestParams = {},
     ) =>
@@ -53030,8 +56607,11 @@ export class Api<
      * @request PUT:/repos/{owner}/{repo}/actions/permissions
      */
     actionsSetGithubActionsPermissionsRepository: (
-      owner: string,
-      repo: string,
+      {
+        owner,
+        repo,
+        ...query
+      }: ActionsSetGithubActionsPermissionsRepositoryParams,
       data: ActionsSetGithubActionsPermissionsRepositoryPayload,
       params: RequestParams = {},
     ) =>
@@ -53052,8 +56632,7 @@ export class Api<
      * @request DELETE:/repos/{owner}/{repo}/subscription
      */
     activityDeleteRepoSubscription: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: ActivityDeleteRepoSubscriptionParams,
       params: RequestParams = {},
     ) =>
       this.request<ActivityDeleteRepoSubscriptionData, any>({
@@ -53071,8 +56650,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/subscription
      */
     activityGetRepoSubscription: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: ActivityGetRepoSubscriptionParams,
       params: RequestParams = {},
     ) =>
       this.request<ActivityGetRepoSubscriptionData, BasicError | void>({
@@ -53175,8 +56753,7 @@ export class Api<
      * @request PUT:/repos/{owner}/{repo}/notifications
      */
     activityMarkRepoNotificationsAsRead: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: ActivityMarkRepoNotificationsAsReadParams,
       data: ActivityMarkRepoNotificationsAsReadPayload,
       params: RequestParams = {},
     ) =>
@@ -53197,8 +56774,7 @@ export class Api<
      * @request PUT:/repos/{owner}/{repo}/subscription
      */
     activitySetRepoSubscription: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: ActivitySetRepoSubscriptionParams,
       data: ActivitySetRepoSubscriptionPayload,
       params: RequestParams = {},
     ) =>
@@ -53220,8 +56796,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/installation
      */
     appsGetRepoInstallation: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: AppsGetRepoInstallationParams,
       params: RequestParams = {},
     ) =>
       this.request<AppsGetRepoInstallationData, BasicError>({
@@ -53240,8 +56815,7 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/check-runs
      */
     checksCreate: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: ChecksCreateParams,
       data: ChecksCreatePayload,
       params: RequestParams = {},
     ) =>
@@ -53263,8 +56837,7 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/check-suites
      */
     checksCreateSuite: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: ChecksCreateSuiteParams,
       data: ChecksCreateSuitePayload,
       params: RequestParams = {},
     ) =>
@@ -53286,9 +56859,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/check-runs/{check_run_id}
      */
     checksGet: (
-      owner: string,
-      repo: string,
-      checkRunId: number,
+      { owner, repo, checkRunId, ...query }: ChecksGetParams,
       params: RequestParams = {},
     ) =>
       this.request<ChecksGetData, any>({
@@ -53307,9 +56878,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/check-suites/{check_suite_id}
      */
     checksGetSuite: (
-      owner: string,
-      repo: string,
-      checkSuiteId: number,
+      { owner, repo, checkSuiteId, ...query }: ChecksGetSuiteParams,
       params: RequestParams = {},
     ) =>
       this.request<ChecksGetSuiteData, any>({
@@ -53408,9 +56977,7 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/check-suites/{check_suite_id}/rerequest
      */
     checksRerequestSuite: (
-      owner: string,
-      repo: string,
-      checkSuiteId: number,
+      { owner, repo, checkSuiteId, ...query }: ChecksRerequestSuiteParams,
       params: RequestParams = {},
     ) =>
       this.request<ChecksRerequestSuiteData, any>({
@@ -53428,8 +56995,7 @@ export class Api<
      * @request PATCH:/repos/{owner}/{repo}/check-suites/preferences
      */
     checksSetSuitesPreferences: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: ChecksSetSuitesPreferencesParams,
       data: ChecksSetSuitesPreferencesPayload,
       params: RequestParams = {},
     ) =>
@@ -53451,9 +57017,7 @@ export class Api<
      * @request PATCH:/repos/{owner}/{repo}/check-runs/{check_run_id}
      */
     checksUpdate: (
-      owner: string,
-      repo: string,
-      checkRunId: number,
+      { owner, repo, checkRunId, ...query }: ChecksUpdateParams,
       data: ChecksUpdatePayload,
       params: RequestParams = {},
     ) =>
@@ -53475,9 +57039,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/code-scanning/alerts/{alert_number}
      */
     codeScanningGetAlert: (
-      owner: string,
-      repo: string,
-      alertNumber: number,
+      { owner, repo, alertNumber, ...query }: CodeScanningGetAlertParams,
       params: RequestParams = {},
     ) =>
       this.request<
@@ -53552,9 +57114,7 @@ export class Api<
      * @request PATCH:/repos/{owner}/{repo}/code-scanning/alerts/{alert_number}
      */
     codeScanningUpdateAlert: (
-      owner: string,
-      repo: string,
-      alertNumber: AlertNumber,
+      { owner, repo, alertNumber, ...query }: CodeScanningUpdateAlertParams,
       data: CodeScanningUpdateAlertPayload,
       params: RequestParams = {},
     ) =>
@@ -53576,8 +57136,7 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/code-scanning/sarifs
      */
     codeScanningUploadSarif: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: CodeScanningUploadSarifParams,
       data: CodeScanningUploadSarifPayload,
       params: RequestParams = {},
     ) =>
@@ -53598,8 +57157,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/community/code_of_conduct
      */
     codesOfConductGetForRepo: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: CodesOfConductGetForRepoParams,
       params: RequestParams = {},
     ) =>
       this.request<CodesOfConductGetForRepoData, any>({
@@ -53618,8 +57176,7 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/git/blobs
      */
     gitCreateBlob: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: GitCreateBlobParams,
       data: GitCreateBlobPayload,
       params: RequestParams = {},
     ) =>
@@ -53641,8 +57198,7 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/git/commits
      */
     gitCreateCommit: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: GitCreateCommitParams,
       data: GitCreateCommitPayload,
       params: RequestParams = {},
     ) =>
@@ -53664,8 +57220,7 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/git/refs
      */
     gitCreateRef: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: GitCreateRefParams,
       data: GitCreateRefPayload,
       params: RequestParams = {},
     ) =>
@@ -53687,8 +57242,7 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/git/tags
      */
     gitCreateTag: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: GitCreateTagParams,
       data: GitCreateTagPayload,
       params: RequestParams = {},
     ) =>
@@ -53710,8 +57264,7 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/git/trees
      */
     gitCreateTree: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: GitCreateTreeParams,
       data: GitCreateTreePayload,
       params: RequestParams = {},
     ) =>
@@ -53733,9 +57286,7 @@ export class Api<
      * @request DELETE:/repos/{owner}/{repo}/git/refs/{ref}
      */
     gitDeleteRef: (
-      owner: string,
-      repo: string,
-      ref: string,
+      { owner, repo, ref, ...query }: GitDeleteRefParams,
       params: RequestParams = {},
     ) =>
       this.request<GitDeleteRefData, ValidationError>({
@@ -53753,9 +57304,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/git/blobs/{file_sha}
      */
     gitGetBlob: (
-      owner: string,
-      repo: string,
-      fileSha: string,
+      { owner, repo, fileSha, ...query }: GitGetBlobParams,
       params: RequestParams = {},
     ) =>
       this.request<GitGetBlobData, BasicError | ValidationError>({
@@ -53774,9 +57323,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/git/commits/{commit_sha}
      */
     gitGetCommit: (
-      owner: string,
-      repo: string,
-      commitSha: string,
+      { owner, repo, commitSha, ...query }: GitGetCommitParams,
       params: RequestParams = {},
     ) =>
       this.request<GitGetCommitData, BasicError>({
@@ -53795,9 +57342,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/git/ref/{ref}
      */
     gitGetRef: (
-      owner: string,
-      repo: string,
-      ref: string,
+      { owner, repo, ref, ...query }: GitGetRefParams,
       params: RequestParams = {},
     ) =>
       this.request<GitGetRefData, BasicError>({
@@ -53816,9 +57361,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/git/tags/{tag_sha}
      */
     gitGetTag: (
-      owner: string,
-      repo: string,
-      tagSha: string,
+      { owner, repo, tagSha, ...query }: GitGetTagParams,
       params: RequestParams = {},
     ) =>
       this.request<GitGetTagData, BasicError>({
@@ -53877,9 +57420,7 @@ export class Api<
      * @request PATCH:/repos/{owner}/{repo}/git/refs/{ref}
      */
     gitUpdateRef: (
-      owner: string,
-      repo: string,
-      ref: string,
+      { owner, repo, ref, ...query }: GitUpdateRefParams,
       data: GitUpdateRefPayload,
       params: RequestParams = {},
     ) =>
@@ -53901,8 +57442,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/interaction-limits
      */
     interactionsGetRestrictionsForRepo: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: InteractionsGetRestrictionsForRepoParams,
       params: RequestParams = {},
     ) =>
       this.request<InteractionsGetRestrictionsForRepoData, any>({
@@ -53921,8 +57461,7 @@ export class Api<
      * @request DELETE:/repos/{owner}/{repo}/interaction-limits
      */
     interactionsRemoveRestrictionsForRepo: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: InteractionsRemoveRestrictionsForRepoParams,
       params: RequestParams = {},
     ) =>
       this.request<InteractionsRemoveRestrictionsForRepoData, void>({
@@ -53940,8 +57479,7 @@ export class Api<
      * @request PUT:/repos/{owner}/{repo}/interaction-limits
      */
     interactionsSetRestrictionsForRepo: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: InteractionsSetRestrictionsForRepoParams,
       data: InteractionLimit,
       params: RequestParams = {},
     ) =>
@@ -53963,9 +57501,7 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/issues/{issue_number}/assignees
      */
     issuesAddAssignees: (
-      owner: string,
-      repo: string,
-      issueNumber: number,
+      { owner, repo, issueNumber, ...query }: IssuesAddAssigneesParams,
       data: IssuesAddAssigneesPayload,
       params: RequestParams = {},
     ) =>
@@ -53987,9 +57523,7 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/issues/{issue_number}/labels
      */
     issuesAddLabels: (
-      owner: string,
-      repo: string,
-      issueNumber: number,
+      { owner, repo, issueNumber, ...query }: IssuesAddLabelsParams,
       data: IssuesAddLabelsPayload,
       params: RequestParams = {},
     ) =>
@@ -54011,9 +57545,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/assignees/{assignee}
      */
     issuesCheckUserCanBeAssigned: (
-      owner: string,
-      repo: string,
-      assignee: string,
+      { owner, repo, assignee, ...query }: IssuesCheckUserCanBeAssignedParams,
       params: RequestParams = {},
     ) =>
       this.request<
@@ -54034,8 +57566,7 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/issues
      */
     issuesCreate: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: IssuesCreateParams,
       data: IssuesCreatePayload,
       params: RequestParams = {},
     ) =>
@@ -54066,9 +57597,7 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/issues/{issue_number}/comments
      */
     issuesCreateComment: (
-      owner: string,
-      repo: string,
-      issueNumber: number,
+      { owner, repo, issueNumber, ...query }: IssuesCreateCommentParams,
       data: IssuesCreateCommentPayload,
       params: RequestParams = {},
     ) =>
@@ -54090,8 +57619,7 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/labels
      */
     issuesCreateLabel: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: IssuesCreateLabelParams,
       data: IssuesCreateLabelPayload,
       params: RequestParams = {},
     ) =>
@@ -54113,8 +57641,7 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/milestones
      */
     issuesCreateMilestone: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: IssuesCreateMilestoneParams,
       data: IssuesCreateMilestonePayload,
       params: RequestParams = {},
     ) =>
@@ -54136,9 +57663,7 @@ export class Api<
      * @request DELETE:/repos/{owner}/{repo}/issues/comments/{comment_id}
      */
     issuesDeleteComment: (
-      owner: string,
-      repo: string,
-      commentId: number,
+      { owner, repo, commentId, ...query }: IssuesDeleteCommentParams,
       params: RequestParams = {},
     ) =>
       this.request<IssuesDeleteCommentData, any>({
@@ -54156,9 +57681,7 @@ export class Api<
      * @request DELETE:/repos/{owner}/{repo}/labels/{name}
      */
     issuesDeleteLabel: (
-      owner: string,
-      repo: string,
-      name: string,
+      { owner, repo, name, ...query }: IssuesDeleteLabelParams,
       params: RequestParams = {},
     ) =>
       this.request<IssuesDeleteLabelData, any>({
@@ -54176,9 +57699,7 @@ export class Api<
      * @request DELETE:/repos/{owner}/{repo}/milestones/{milestone_number}
      */
     issuesDeleteMilestone: (
-      owner: string,
-      repo: string,
-      milestoneNumber: number,
+      { owner, repo, milestoneNumber, ...query }: IssuesDeleteMilestoneParams,
       params: RequestParams = {},
     ) =>
       this.request<IssuesDeleteMilestoneData, BasicError>({
@@ -54196,9 +57717,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/issues/{issue_number}
      */
     issuesGet: (
-      owner: string,
-      repo: string,
-      issueNumber: number,
+      { owner, repo, issueNumber, ...query }: IssuesGetParams,
       params: RequestParams = {},
     ) =>
       this.request<IssuesGetData, BasicError>({
@@ -54217,9 +57736,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/issues/comments/{comment_id}
      */
     issuesGetComment: (
-      owner: string,
-      repo: string,
-      commentId: number,
+      { owner, repo, commentId, ...query }: IssuesGetCommentParams,
       params: RequestParams = {},
     ) =>
       this.request<IssuesGetCommentData, BasicError>({
@@ -54238,9 +57755,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/issues/events/{event_id}
      */
     issuesGetEvent: (
-      owner: string,
-      repo: string,
-      eventId: number,
+      { owner, repo, eventId, ...query }: IssuesGetEventParams,
       params: RequestParams = {},
     ) =>
       this.request<IssuesGetEventData, BasicError>({
@@ -54259,9 +57774,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/labels/{name}
      */
     issuesGetLabel: (
-      owner: string,
-      repo: string,
-      name: string,
+      { owner, repo, name, ...query }: IssuesGetLabelParams,
       params: RequestParams = {},
     ) =>
       this.request<IssuesGetLabelData, BasicError>({
@@ -54280,9 +57793,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/milestones/{milestone_number}
      */
     issuesGetMilestone: (
-      owner: string,
-      repo: string,
-      milestoneNumber: number,
+      { owner, repo, milestoneNumber, ...query }: IssuesGetMilestoneParams,
       params: RequestParams = {},
     ) =>
       this.request<IssuesGetMilestoneData, BasicError>({
@@ -54535,9 +58046,7 @@ export class Api<
      * @request PUT:/repos/{owner}/{repo}/issues/{issue_number}/lock
      */
     issuesLock: (
-      owner: string,
-      repo: string,
-      issueNumber: number,
+      { owner, repo, issueNumber, ...query }: IssuesLockParams,
       data: IssuesLockPayload,
       params: RequestParams = {},
     ) =>
@@ -54558,9 +58067,7 @@ export class Api<
      * @request DELETE:/repos/{owner}/{repo}/issues/{issue_number}/labels
      */
     issuesRemoveAllLabels: (
-      owner: string,
-      repo: string,
-      issueNumber: number,
+      { owner, repo, issueNumber, ...query }: IssuesRemoveAllLabelsParams,
       params: RequestParams = {},
     ) =>
       this.request<IssuesRemoveAllLabelsData, BasicError>({
@@ -54578,9 +58085,7 @@ export class Api<
      * @request DELETE:/repos/{owner}/{repo}/issues/{issue_number}/assignees
      */
     issuesRemoveAssignees: (
-      owner: string,
-      repo: string,
-      issueNumber: number,
+      { owner, repo, issueNumber, ...query }: IssuesRemoveAssigneesParams,
       data: IssuesRemoveAssigneesPayload,
       params: RequestParams = {},
     ) =>
@@ -54602,10 +58107,7 @@ export class Api<
      * @request DELETE:/repos/{owner}/{repo}/issues/{issue_number}/labels/{name}
      */
     issuesRemoveLabel: (
-      owner: string,
-      repo: string,
-      issueNumber: number,
-      name: string,
+      { owner, repo, issueNumber, name, ...query }: IssuesRemoveLabelParams,
       params: RequestParams = {},
     ) =>
       this.request<IssuesRemoveLabelData, BasicError>({
@@ -54624,9 +58126,7 @@ export class Api<
      * @request PUT:/repos/{owner}/{repo}/issues/{issue_number}/labels
      */
     issuesSetLabels: (
-      owner: string,
-      repo: string,
-      issueNumber: number,
+      { owner, repo, issueNumber, ...query }: IssuesSetLabelsParams,
       data: IssuesSetLabelsPayload,
       params: RequestParams = {},
     ) =>
@@ -54648,9 +58148,7 @@ export class Api<
      * @request DELETE:/repos/{owner}/{repo}/issues/{issue_number}/lock
      */
     issuesUnlock: (
-      owner: string,
-      repo: string,
-      issueNumber: number,
+      { owner, repo, issueNumber, ...query }: IssuesUnlockParams,
       params: RequestParams = {},
     ) =>
       this.request<IssuesUnlockData, BasicError>({
@@ -54668,9 +58166,7 @@ export class Api<
      * @request PATCH:/repos/{owner}/{repo}/issues/{issue_number}
      */
     issuesUpdate: (
-      owner: string,
-      repo: string,
-      issueNumber: number,
+      { owner, repo, issueNumber, ...query }: IssuesUpdateParams,
       data: IssuesUpdatePayload,
       params: RequestParams = {},
     ) =>
@@ -54701,9 +58197,7 @@ export class Api<
      * @request PATCH:/repos/{owner}/{repo}/issues/comments/{comment_id}
      */
     issuesUpdateComment: (
-      owner: string,
-      repo: string,
-      commentId: number,
+      { owner, repo, commentId, ...query }: IssuesUpdateCommentParams,
       data: IssuesUpdateCommentPayload,
       params: RequestParams = {},
     ) =>
@@ -54725,9 +58219,7 @@ export class Api<
      * @request PATCH:/repos/{owner}/{repo}/labels/{name}
      */
     issuesUpdateLabel: (
-      owner: string,
-      repo: string,
-      name: string,
+      { owner, repo, name, ...query }: IssuesUpdateLabelParams,
       data: IssuesUpdateLabelPayload,
       params: RequestParams = {},
     ) =>
@@ -54749,9 +58241,7 @@ export class Api<
      * @request PATCH:/repos/{owner}/{repo}/milestones/{milestone_number}
      */
     issuesUpdateMilestone: (
-      owner: string,
-      repo: string,
-      milestoneNumber: number,
+      { owner, repo, milestoneNumber, ...query }: IssuesUpdateMilestoneParams,
       data: IssuesUpdateMilestonePayload,
       params: RequestParams = {},
     ) =>
@@ -54773,8 +58263,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/license
      */
     licensesGetForRepo: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: LicensesGetForRepoParams,
       params: RequestParams = {},
     ) =>
       this.request<LicensesGetForRepoData, any>({
@@ -54793,8 +58282,7 @@ export class Api<
      * @request DELETE:/repos/{owner}/{repo}/import
      */
     migrationsCancelImport: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: MigrationsCancelImportParams,
       params: RequestParams = {},
     ) =>
       this.request<MigrationsCancelImportData, any>({
@@ -54832,8 +58320,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/import
      */
     migrationsGetImportStatus: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: MigrationsGetImportStatusParams,
       params: RequestParams = {},
     ) =>
       this.request<MigrationsGetImportStatusData, BasicError>({
@@ -54852,8 +58339,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/import/large_files
      */
     migrationsGetLargeFiles: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: MigrationsGetLargeFilesParams,
       params: RequestParams = {},
     ) =>
       this.request<MigrationsGetLargeFilesData, any>({
@@ -54872,9 +58358,7 @@ export class Api<
      * @request PATCH:/repos/{owner}/{repo}/import/authors/{author_id}
      */
     migrationsMapCommitAuthor: (
-      owner: string,
-      repo: string,
-      authorId: number,
+      { owner, repo, authorId, ...query }: MigrationsMapCommitAuthorParams,
       data: MigrationsMapCommitAuthorPayload,
       params: RequestParams = {},
     ) =>
@@ -54898,8 +58382,7 @@ export class Api<
      * @request PATCH:/repos/{owner}/{repo}/import/lfs
      */
     migrationsSetLfsPreference: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: MigrationsSetLfsPreferenceParams,
       data: MigrationsSetLfsPreferencePayload,
       params: RequestParams = {},
     ) =>
@@ -54921,8 +58404,7 @@ export class Api<
      * @request PUT:/repos/{owner}/{repo}/import
      */
     migrationsStartImport: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: MigrationsStartImportParams,
       data: MigrationsStartImportPayload,
       params: RequestParams = {},
     ) =>
@@ -54944,8 +58426,7 @@ export class Api<
      * @request PATCH:/repos/{owner}/{repo}/import
      */
     migrationsUpdateImport: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: MigrationsUpdateImportParams,
       data: MigrationsUpdateImportPayload,
       params: RequestParams = {},
     ) =>
@@ -54967,8 +58448,7 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/projects
      */
     projectsCreateForRepo: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: ProjectsCreateForRepoParams,
       data: ProjectsCreateForRepoPayload,
       params: RequestParams = {},
     ) =>
@@ -55015,9 +58495,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/pulls/{pull_number}/merge
      */
     pullsCheckIfMerged: (
-      owner: string,
-      repo: string,
-      pullNumber: number,
+      { owner, repo, pullNumber, ...query }: PullsCheckIfMergedParams,
       params: RequestParams = {},
     ) =>
       this.request<PullsCheckIfMergedData, void>({
@@ -55035,8 +58513,7 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/pulls
      */
     pullsCreate: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: PullsCreateParams,
       data: PullsCreatePayload,
       params: RequestParams = {},
     ) =>
@@ -55058,10 +58535,13 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies
      */
     pullsCreateReplyForReviewComment: (
-      owner: string,
-      repo: string,
-      pullNumber: number,
-      commentId: number,
+      {
+        owner,
+        repo,
+        pullNumber,
+        commentId,
+        ...query
+      }: PullsCreateReplyForReviewCommentParams,
       data: PullsCreateReplyForReviewCommentPayload,
       params: RequestParams = {},
     ) =>
@@ -55083,9 +58563,7 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/pulls/{pull_number}/reviews
      */
     pullsCreateReview: (
-      owner: string,
-      repo: string,
-      pullNumber: number,
+      { owner, repo, pullNumber, ...query }: PullsCreateReviewParams,
       data: PullsCreateReviewPayload,
       params: RequestParams = {},
     ) =>
@@ -55107,9 +58585,7 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/pulls/{pull_number}/comments
      */
     pullsCreateReviewComment: (
-      owner: string,
-      repo: string,
-      pullNumber: number,
+      { owner, repo, pullNumber, ...query }: PullsCreateReviewCommentParams,
       data: PullsCreateReviewCommentPayload,
       params: RequestParams = {},
     ) =>
@@ -55131,10 +58607,13 @@ export class Api<
      * @request DELETE:/repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}
      */
     pullsDeletePendingReview: (
-      owner: string,
-      repo: string,
-      pullNumber: number,
-      reviewId: number,
+      {
+        owner,
+        repo,
+        pullNumber,
+        reviewId,
+        ...query
+      }: PullsDeletePendingReviewParams,
       params: RequestParams = {},
     ) =>
       this.request<
@@ -55156,9 +58635,7 @@ export class Api<
      * @request DELETE:/repos/{owner}/{repo}/pulls/comments/{comment_id}
      */
     pullsDeleteReviewComment: (
-      owner: string,
-      repo: string,
-      commentId: number,
+      { owner, repo, commentId, ...query }: PullsDeleteReviewCommentParams,
       params: RequestParams = {},
     ) =>
       this.request<PullsDeleteReviewCommentData, BasicError>({
@@ -55176,10 +58653,7 @@ export class Api<
      * @request PUT:/repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/dismissals
      */
     pullsDismissReview: (
-      owner: string,
-      repo: string,
-      pullNumber: number,
-      reviewId: number,
+      { owner, repo, pullNumber, reviewId, ...query }: PullsDismissReviewParams,
       data: PullsDismissReviewPayload,
       params: RequestParams = {},
     ) =>
@@ -55201,9 +58675,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/pulls/{pull_number}
      */
     pullsGet: (
-      owner: string,
-      repo: string,
-      pullNumber: number,
+      { owner, repo, pullNumber, ...query }: PullsGetParams,
       params: RequestParams = {},
     ) =>
       this.request<PullsGetData, BasicError>({
@@ -55222,10 +58694,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}
      */
     pullsGetReview: (
-      owner: string,
-      repo: string,
-      pullNumber: number,
-      reviewId: number,
+      { owner, repo, pullNumber, reviewId, ...query }: PullsGetReviewParams,
       params: RequestParams = {},
     ) =>
       this.request<PullsGetReviewData, BasicError>({
@@ -55244,9 +58713,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/pulls/comments/{comment_id}
      */
     pullsGetReviewComment: (
-      owner: string,
-      repo: string,
-      commentId: number,
+      { owner, repo, commentId, ...query }: PullsGetReviewCommentParams,
       params: RequestParams = {},
     ) =>
       this.request<PullsGetReviewCommentData, BasicError>({
@@ -55431,9 +58898,7 @@ export class Api<
      * @request PUT:/repos/{owner}/{repo}/pulls/{pull_number}/merge
      */
     pullsMerge: (
-      owner: string,
-      repo: string,
-      pullNumber: number,
+      { owner, repo, pullNumber, ...query }: PullsMergeParams,
       data: PullsMergePayload,
       params: RequestParams = {},
     ) =>
@@ -55455,9 +58920,12 @@ export class Api<
      * @request DELETE:/repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers
      */
     pullsRemoveRequestedReviewers: (
-      owner: string,
-      repo: string,
-      pullNumber: number,
+      {
+        owner,
+        repo,
+        pullNumber,
+        ...query
+      }: PullsRemoveRequestedReviewersParams,
       data: PullsRemoveRequestedReviewersPayload,
       params: RequestParams = {},
     ) =>
@@ -55478,9 +58946,7 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers
      */
     pullsRequestReviewers: (
-      owner: string,
-      repo: string,
-      pullNumber: number,
+      { owner, repo, pullNumber, ...query }: PullsRequestReviewersParams,
       data: PullsRequestReviewersPayload,
       params: RequestParams = {},
     ) =>
@@ -55502,10 +58968,7 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/events
      */
     pullsSubmitReview: (
-      owner: string,
-      repo: string,
-      pullNumber: number,
-      reviewId: number,
+      { owner, repo, pullNumber, reviewId, ...query }: PullsSubmitReviewParams,
       data: PullsSubmitReviewPayload,
       params: RequestParams = {},
     ) =>
@@ -55527,9 +58990,7 @@ export class Api<
      * @request PATCH:/repos/{owner}/{repo}/pulls/{pull_number}
      */
     pullsUpdate: (
-      owner: string,
-      repo: string,
-      pullNumber: number,
+      { owner, repo, pullNumber, ...query }: PullsUpdateParams,
       data: PullsUpdatePayload,
       params: RequestParams = {},
     ) =>
@@ -55551,9 +59012,7 @@ export class Api<
      * @request PUT:/repos/{owner}/{repo}/pulls/{pull_number}/update-branch
      */
     pullsUpdateBranch: (
-      owner: string,
-      repo: string,
-      pullNumber: number,
+      { owner, repo, pullNumber, ...query }: PullsUpdateBranchParams,
       data: PullsUpdateBranchPayload,
       params: RequestParams = {},
     ) =>
@@ -55583,10 +59042,7 @@ export class Api<
      * @request PUT:/repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}
      */
     pullsUpdateReview: (
-      owner: string,
-      repo: string,
-      pullNumber: number,
-      reviewId: number,
+      { owner, repo, pullNumber, reviewId, ...query }: PullsUpdateReviewParams,
       data: PullsUpdateReviewPayload,
       params: RequestParams = {},
     ) =>
@@ -55608,9 +59064,7 @@ export class Api<
      * @request PATCH:/repos/{owner}/{repo}/pulls/comments/{comment_id}
      */
     pullsUpdateReviewComment: (
-      owner: string,
-      repo: string,
-      commentId: number,
+      { owner, repo, commentId, ...query }: PullsUpdateReviewCommentParams,
       data: PullsUpdateReviewCommentPayload,
       params: RequestParams = {},
     ) =>
@@ -55632,9 +59086,12 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/comments/{comment_id}/reactions
      */
     reactionsCreateForCommitComment: (
-      owner: string,
-      repo: string,
-      commentId: number,
+      {
+        owner,
+        repo,
+        commentId,
+        ...query
+      }: ReactionsCreateForCommitCommentParams,
       data: ReactionsCreateForCommitCommentPayload,
       params: RequestParams = {},
     ) =>
@@ -55663,9 +59120,7 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/issues/{issue_number}/reactions
      */
     reactionsCreateForIssue: (
-      owner: string,
-      repo: string,
-      issueNumber: number,
+      { owner, repo, issueNumber, ...query }: ReactionsCreateForIssueParams,
       data: ReactionsCreateForIssuePayload,
       params: RequestParams = {},
     ) =>
@@ -55694,9 +59149,12 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/issues/comments/{comment_id}/reactions
      */
     reactionsCreateForIssueComment: (
-      owner: string,
-      repo: string,
-      commentId: number,
+      {
+        owner,
+        repo,
+        commentId,
+        ...query
+      }: ReactionsCreateForIssueCommentParams,
       data: ReactionsCreateForIssueCommentPayload,
       params: RequestParams = {},
     ) =>
@@ -55725,9 +59183,12 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions
      */
     reactionsCreateForPullRequestReviewComment: (
-      owner: string,
-      repo: string,
-      commentId: number,
+      {
+        owner,
+        repo,
+        commentId,
+        ...query
+      }: ReactionsCreateForPullRequestReviewCommentParams,
       data: ReactionsCreateForPullRequestReviewCommentPayload,
       params: RequestParams = {},
     ) =>
@@ -55756,10 +59217,13 @@ export class Api<
      * @request DELETE:/repos/{owner}/{repo}/comments/{comment_id}/reactions/{reaction_id}
      */
     reactionsDeleteForCommitComment: (
-      owner: string,
-      repo: string,
-      commentId: number,
-      reactionId: number,
+      {
+        owner,
+        repo,
+        commentId,
+        reactionId,
+        ...query
+      }: ReactionsDeleteForCommitCommentParams,
       params: RequestParams = {},
     ) =>
       this.request<ReactionsDeleteForCommitCommentData, any>({
@@ -55777,10 +59241,13 @@ export class Api<
      * @request DELETE:/repos/{owner}/{repo}/issues/{issue_number}/reactions/{reaction_id}
      */
     reactionsDeleteForIssue: (
-      owner: string,
-      repo: string,
-      issueNumber: number,
-      reactionId: number,
+      {
+        owner,
+        repo,
+        issueNumber,
+        reactionId,
+        ...query
+      }: ReactionsDeleteForIssueParams,
       params: RequestParams = {},
     ) =>
       this.request<ReactionsDeleteForIssueData, any>({
@@ -55798,10 +59265,13 @@ export class Api<
      * @request DELETE:/repos/{owner}/{repo}/issues/comments/{comment_id}/reactions/{reaction_id}
      */
     reactionsDeleteForIssueComment: (
-      owner: string,
-      repo: string,
-      commentId: number,
-      reactionId: number,
+      {
+        owner,
+        repo,
+        commentId,
+        reactionId,
+        ...query
+      }: ReactionsDeleteForIssueCommentParams,
       params: RequestParams = {},
     ) =>
       this.request<ReactionsDeleteForIssueCommentData, any>({
@@ -55819,10 +59289,13 @@ export class Api<
      * @request DELETE:/repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions/{reaction_id}
      */
     reactionsDeleteForPullRequestComment: (
-      owner: string,
-      repo: string,
-      commentId: number,
-      reactionId: number,
+      {
+        owner,
+        repo,
+        commentId,
+        reactionId,
+        ...query
+      }: ReactionsDeleteForPullRequestCommentParams,
       params: RequestParams = {},
     ) =>
       this.request<ReactionsDeleteForPullRequestCommentData, any>({
@@ -55953,9 +59426,7 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps
      */
     reposAddAppAccessRestrictions: (
-      owner: string,
-      repo: string,
-      branch: string,
+      { owner, repo, branch, ...query }: ReposAddAppAccessRestrictionsParams,
       data: ReposAddAppAccessRestrictionsPayload,
       params: RequestParams = {},
     ) =>
@@ -55977,9 +59448,7 @@ export class Api<
      * @request PUT:/repos/{owner}/{repo}/collaborators/{username}
      */
     reposAddCollaborator: (
-      owner: string,
-      repo: string,
-      username: string,
+      { owner, repo, username, ...query }: ReposAddCollaboratorParams,
       data: ReposAddCollaboratorPayload,
       params: RequestParams = {},
     ) =>
@@ -56001,9 +59470,7 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts
      */
     reposAddStatusCheckContexts: (
-      owner: string,
-      repo: string,
-      branch: string,
+      { owner, repo, branch, ...query }: ReposAddStatusCheckContextsParams,
       data: ReposAddStatusCheckContextsPayload,
       params: RequestParams = {},
     ) =>
@@ -56028,9 +59495,7 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams
      */
     reposAddTeamAccessRestrictions: (
-      owner: string,
-      repo: string,
-      branch: string,
+      { owner, repo, branch, ...query }: ReposAddTeamAccessRestrictionsParams,
       data: ReposAddTeamAccessRestrictionsPayload,
       params: RequestParams = {},
     ) =>
@@ -56052,9 +59517,7 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users
      */
     reposAddUserAccessRestrictions: (
-      owner: string,
-      repo: string,
-      branch: string,
+      { owner, repo, branch, ...query }: ReposAddUserAccessRestrictionsParams,
       data: ReposAddUserAccessRestrictionsPayload,
       params: RequestParams = {},
     ) =>
@@ -56076,9 +59539,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/collaborators/{username}
      */
     reposCheckCollaborator: (
-      owner: string,
-      repo: string,
-      username: string,
+      { owner, repo, username, ...query }: ReposCheckCollaboratorParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposCheckCollaboratorData, void>({
@@ -56096,8 +59557,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/vulnerability-alerts
      */
     reposCheckVulnerabilityAlerts: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: ReposCheckVulnerabilityAlertsParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposCheckVulnerabilityAlertsData, void>({
@@ -56115,10 +59575,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/compare/{base}...{head}
      */
     reposCompareCommits: (
-      owner: string,
-      repo: string,
-      base: string,
-      head: string,
+      { owner, repo, base, head, ...query }: ReposCompareCommitsParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposCompareCommitsData, BasicError>({
@@ -56137,9 +59594,7 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/commits/{commit_sha}/comments
      */
     reposCreateCommitComment: (
-      owner: string,
-      repo: string,
-      commitSha: string,
+      { owner, repo, commitSha, ...query }: ReposCreateCommitCommentParams,
       data: ReposCreateCommitCommentPayload,
       params: RequestParams = {},
     ) =>
@@ -56161,9 +59616,12 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/branches/{branch}/protection/required_signatures
      */
     reposCreateCommitSignatureProtection: (
-      owner: string,
-      repo: string,
-      branch: string,
+      {
+        owner,
+        repo,
+        branch,
+        ...query
+      }: ReposCreateCommitSignatureProtectionParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposCreateCommitSignatureProtectionData, BasicError>({
@@ -56182,9 +59640,7 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/statuses/{sha}
      */
     reposCreateCommitStatus: (
-      owner: string,
-      repo: string,
-      sha: string,
+      { owner, repo, sha, ...query }: ReposCreateCommitStatusParams,
       data: ReposCreateCommitStatusPayload,
       params: RequestParams = {},
     ) =>
@@ -56206,8 +59662,7 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/keys
      */
     reposCreateDeployKey: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: ReposCreateDeployKeyParams,
       data: ReposCreateDeployKeyPayload,
       params: RequestParams = {},
     ) =>
@@ -56229,8 +59684,7 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/deployments
      */
     reposCreateDeployment: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: ReposCreateDeploymentParams,
       data: ReposCreateDeploymentPayload,
       params: RequestParams = {},
     ) =>
@@ -56252,9 +59706,12 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/deployments/{deployment_id}/statuses
      */
     reposCreateDeploymentStatus: (
-      owner: string,
-      repo: string,
-      deploymentId: number,
+      {
+        owner,
+        repo,
+        deploymentId,
+        ...query
+      }: ReposCreateDeploymentStatusParams,
       data: ReposCreateDeploymentStatusPayload,
       params: RequestParams = {},
     ) =>
@@ -56276,8 +59733,7 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/dispatches
      */
     reposCreateDispatchEvent: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: ReposCreateDispatchEventParams,
       data: ReposCreateDispatchEventPayload,
       params: RequestParams = {},
     ) =>
@@ -56298,8 +59754,7 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/forks
      */
     reposCreateFork: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: ReposCreateForkParams,
       data: ReposCreateForkPayload,
       params: RequestParams = {},
     ) =>
@@ -56321,9 +59776,7 @@ export class Api<
      * @request PUT:/repos/{owner}/{repo}/contents/{path}
      */
     reposCreateOrUpdateFileContents: (
-      owner: string,
-      repo: string,
-      path: string,
+      { owner, repo, path, ...query }: ReposCreateOrUpdateFileContentsParams,
       data: ReposCreateOrUpdateFileContentsPayload,
       params: RequestParams = {},
     ) =>
@@ -56348,8 +59801,7 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/pages
      */
     reposCreatePagesSite: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: ReposCreatePagesSiteParams,
       data: ReposCreatePagesSitePayload,
       params: RequestParams = {},
     ) =>
@@ -56379,8 +59831,7 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/releases
      */
     reposCreateRelease: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: ReposCreateReleaseParams,
       data: ReposCreateReleasePayload,
       params: RequestParams = {},
     ) =>
@@ -56402,8 +59853,7 @@ export class Api<
      * @request POST:/repos/{template_owner}/{template_repo}/generate
      */
     reposCreateUsingTemplate: (
-      templateOwner: string,
-      templateRepo: string,
+      { templateOwner, templateRepo, ...query }: ReposCreateUsingTemplateParams,
       data: ReposCreateUsingTemplatePayload,
       params: RequestParams = {},
     ) =>
@@ -56425,8 +59875,7 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/hooks
      */
     reposCreateWebhook: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: ReposCreateWebhookParams,
       data: ReposCreateWebhookPayload,
       params: RequestParams = {},
     ) =>
@@ -56447,7 +59896,10 @@ export class Api<
      * @summary Delete a repository
      * @request DELETE:/repos/{owner}/{repo}
      */
-    reposDelete: (owner: string, repo: string, params: RequestParams = {}) =>
+    reposDelete: (
+      { owner, repo, ...query }: ReposDeleteParams,
+      params: RequestParams = {},
+    ) =>
       this.request<ReposDeleteData, ReposDeleteError>({
         path: \`/repos/\${owner}/\${repo}\`,
         method: "DELETE",
@@ -56463,9 +59915,7 @@ export class Api<
      * @request DELETE:/repos/{owner}/{repo}/branches/{branch}/protection/restrictions
      */
     reposDeleteAccessRestrictions: (
-      owner: string,
-      repo: string,
-      branch: string,
+      { owner, repo, branch, ...query }: ReposDeleteAccessRestrictionsParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposDeleteAccessRestrictionsData, any>({
@@ -56483,9 +59933,7 @@ export class Api<
      * @request DELETE:/repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins
      */
     reposDeleteAdminBranchProtection: (
-      owner: string,
-      repo: string,
-      branch: string,
+      { owner, repo, branch, ...query }: ReposDeleteAdminBranchProtectionParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposDeleteAdminBranchProtectionData, BasicError>({
@@ -56503,9 +59951,7 @@ export class Api<
      * @request DELETE:/repos/{owner}/{repo}/branches/{branch}/protection
      */
     reposDeleteBranchProtection: (
-      owner: string,
-      repo: string,
-      branch: string,
+      { owner, repo, branch, ...query }: ReposDeleteBranchProtectionParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposDeleteBranchProtectionData, BasicError>({
@@ -56523,9 +59969,7 @@ export class Api<
      * @request DELETE:/repos/{owner}/{repo}/comments/{comment_id}
      */
     reposDeleteCommitComment: (
-      owner: string,
-      repo: string,
-      commentId: number,
+      { owner, repo, commentId, ...query }: ReposDeleteCommitCommentParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposDeleteCommitCommentData, BasicError>({
@@ -56543,9 +59987,12 @@ export class Api<
      * @request DELETE:/repos/{owner}/{repo}/branches/{branch}/protection/required_signatures
      */
     reposDeleteCommitSignatureProtection: (
-      owner: string,
-      repo: string,
-      branch: string,
+      {
+        owner,
+        repo,
+        branch,
+        ...query
+      }: ReposDeleteCommitSignatureProtectionParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposDeleteCommitSignatureProtectionData, BasicError>({
@@ -56563,9 +60010,7 @@ export class Api<
      * @request DELETE:/repos/{owner}/{repo}/keys/{key_id}
      */
     reposDeleteDeployKey: (
-      owner: string,
-      repo: string,
-      keyId: number,
+      { owner, repo, keyId, ...query }: ReposDeleteDeployKeyParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposDeleteDeployKeyData, any>({
@@ -56583,9 +60028,7 @@ export class Api<
      * @request DELETE:/repos/{owner}/{repo}/deployments/{deployment_id}
      */
     reposDeleteDeployment: (
-      owner: string,
-      repo: string,
-      deploymentId: number,
+      { owner, repo, deploymentId, ...query }: ReposDeleteDeploymentParams,
       params: RequestParams = {},
     ) =>
       this.request<
@@ -56606,9 +60049,7 @@ export class Api<
      * @request DELETE:/repos/{owner}/{repo}/contents/{path}
      */
     reposDeleteFile: (
-      owner: string,
-      repo: string,
-      path: string,
+      { owner, repo, path, ...query }: ReposDeleteFileParams,
       data: ReposDeleteFilePayload,
       params: RequestParams = {},
     ) =>
@@ -56639,9 +60080,7 @@ export class Api<
      * @request DELETE:/repos/{owner}/{repo}/invitations/{invitation_id}
      */
     reposDeleteInvitation: (
-      owner: string,
-      repo: string,
-      invitationId: number,
+      { owner, repo, invitationId, ...query }: ReposDeleteInvitationParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposDeleteInvitationData, any>({
@@ -56659,8 +60098,7 @@ export class Api<
      * @request DELETE:/repos/{owner}/{repo}/pages
      */
     reposDeletePagesSite: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: ReposDeletePagesSiteParams,
       params: RequestParams = {},
     ) =>
       this.request<
@@ -56686,9 +60124,12 @@ export class Api<
      * @request DELETE:/repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews
      */
     reposDeletePullRequestReviewProtection: (
-      owner: string,
-      repo: string,
-      branch: string,
+      {
+        owner,
+        repo,
+        branch,
+        ...query
+      }: ReposDeletePullRequestReviewProtectionParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposDeletePullRequestReviewProtectionData, BasicError>({
@@ -56706,9 +60147,7 @@ export class Api<
      * @request DELETE:/repos/{owner}/{repo}/releases/{release_id}
      */
     reposDeleteRelease: (
-      owner: string,
-      repo: string,
-      releaseId: number,
+      { owner, repo, releaseId, ...query }: ReposDeleteReleaseParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposDeleteReleaseData, any>({
@@ -56726,9 +60165,7 @@ export class Api<
      * @request DELETE:/repos/{owner}/{repo}/releases/assets/{asset_id}
      */
     reposDeleteReleaseAsset: (
-      owner: string,
-      repo: string,
-      assetId: number,
+      { owner, repo, assetId, ...query }: ReposDeleteReleaseAssetParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposDeleteReleaseAssetData, any>({
@@ -56746,9 +60183,7 @@ export class Api<
      * @request DELETE:/repos/{owner}/{repo}/hooks/{hook_id}
      */
     reposDeleteWebhook: (
-      owner: string,
-      repo: string,
-      hookId: number,
+      { owner, repo, hookId, ...query }: ReposDeleteWebhookParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposDeleteWebhookData, BasicError>({
@@ -56766,8 +60201,7 @@ export class Api<
      * @request DELETE:/repos/{owner}/{repo}/automated-security-fixes
      */
     reposDisableAutomatedSecurityFixes: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: ReposDisableAutomatedSecurityFixesParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposDisableAutomatedSecurityFixesData, any>({
@@ -56785,8 +60219,7 @@ export class Api<
      * @request DELETE:/repos/{owner}/{repo}/vulnerability-alerts
      */
     reposDisableVulnerabilityAlerts: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: ReposDisableVulnerabilityAlertsParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposDisableVulnerabilityAlertsData, any>({
@@ -56804,9 +60237,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/tarball/{ref}
      */
     reposDownloadTarballArchive: (
-      owner: string,
-      repo: string,
-      ref: string,
+      { owner, repo, ref, ...query }: ReposDownloadTarballArchiveParams,
       params: RequestParams = {},
     ) =>
       this.request<any, void>({
@@ -56824,9 +60255,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/zipball/{ref}
      */
     reposDownloadZipballArchive: (
-      owner: string,
-      repo: string,
-      ref: string,
+      { owner, repo, ref, ...query }: ReposDownloadZipballArchiveParams,
       params: RequestParams = {},
     ) =>
       this.request<any, void>({
@@ -56844,8 +60273,7 @@ export class Api<
      * @request PUT:/repos/{owner}/{repo}/automated-security-fixes
      */
     reposEnableAutomatedSecurityFixes: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: ReposEnableAutomatedSecurityFixesParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposEnableAutomatedSecurityFixesData, any>({
@@ -56863,8 +60291,7 @@ export class Api<
      * @request PUT:/repos/{owner}/{repo}/vulnerability-alerts
      */
     reposEnableVulnerabilityAlerts: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: ReposEnableVulnerabilityAlertsParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposEnableVulnerabilityAlertsData, any>({
@@ -56881,7 +60308,10 @@ export class Api<
      * @summary Get a repository
      * @request GET:/repos/{owner}/{repo}
      */
-    reposGet: (owner: string, repo: string, params: RequestParams = {}) =>
+    reposGet: (
+      { owner, repo, ...query }: ReposGetParams,
+      params: RequestParams = {},
+    ) =>
       this.request<ReposGetData, BasicError>({
         path: \`/repos/\${owner}/\${repo}\`,
         method: "GET",
@@ -56898,9 +60328,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/branches/{branch}/protection/restrictions
      */
     reposGetAccessRestrictions: (
-      owner: string,
-      repo: string,
-      branch: string,
+      { owner, repo, branch, ...query }: ReposGetAccessRestrictionsParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposGetAccessRestrictionsData, BasicError>({
@@ -56919,9 +60347,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins
      */
     reposGetAdminBranchProtection: (
-      owner: string,
-      repo: string,
-      branch: string,
+      { owner, repo, branch, ...query }: ReposGetAdminBranchProtectionParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposGetAdminBranchProtectionData, any>({
@@ -56940,9 +60366,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts
      */
     reposGetAllStatusCheckContexts: (
-      owner: string,
-      repo: string,
-      branch: string,
+      { owner, repo, branch, ...query }: ReposGetAllStatusCheckContextsParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposGetAllStatusCheckContextsData, BasicError>({
@@ -56961,8 +60385,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/topics
      */
     reposGetAllTopics: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: ReposGetAllTopicsParams,
       params: RequestParams = {},
     ) =>
       this.request<
@@ -56988,9 +60411,12 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps
      */
     reposGetAppsWithAccessToProtectedBranch: (
-      owner: string,
-      repo: string,
-      branch: string,
+      {
+        owner,
+        repo,
+        branch,
+        ...query
+      }: ReposGetAppsWithAccessToProtectedBranchParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposGetAppsWithAccessToProtectedBranchData, BasicError>({
@@ -57009,9 +60435,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/branches/{branch}
      */
     reposGetBranch: (
-      owner: string,
-      repo: string,
-      branch: string,
+      { owner, repo, branch, ...query }: ReposGetBranchParams,
       params: RequestParams = {},
     ) =>
       this.request<
@@ -57037,9 +60461,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/branches/{branch}/protection
      */
     reposGetBranchProtection: (
-      owner: string,
-      repo: string,
-      branch: string,
+      { owner, repo, branch, ...query }: ReposGetBranchProtectionParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposGetBranchProtectionData, BasicError>({
@@ -57078,8 +60500,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/stats/code_frequency
      */
     reposGetCodeFrequencyStats: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: ReposGetCodeFrequencyStatsParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposGetCodeFrequencyStatsData, any>({
@@ -57098,9 +60519,12 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/collaborators/{username}/permission
      */
     reposGetCollaboratorPermissionLevel: (
-      owner: string,
-      repo: string,
-      username: string,
+      {
+        owner,
+        repo,
+        username,
+        ...query
+      }: ReposGetCollaboratorPermissionLevelParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposGetCollaboratorPermissionLevelData, BasicError>({
@@ -57119,9 +60543,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/commits/{ref}/status
      */
     reposGetCombinedStatusForRef: (
-      owner: string,
-      repo: string,
-      ref: string,
+      { owner, repo, ref, ...query }: ReposGetCombinedStatusForRefParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposGetCombinedStatusForRefData, BasicError>({
@@ -57140,9 +60562,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/commits/{ref}
      */
     reposGetCommit: (
-      owner: string,
-      repo: string,
-      ref: string,
+      { owner, repo, ref, ...query }: ReposGetCommitParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposGetCommitData, BasicError | ValidationError>({
@@ -57161,8 +60581,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/stats/commit_activity
      */
     reposGetCommitActivityStats: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: ReposGetCommitActivityStatsParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposGetCommitActivityStatsData, any>({
@@ -57181,9 +60600,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/comments/{comment_id}
      */
     reposGetCommitComment: (
-      owner: string,
-      repo: string,
-      commentId: number,
+      { owner, repo, commentId, ...query }: ReposGetCommitCommentParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposGetCommitCommentData, BasicError>({
@@ -57202,9 +60619,12 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/branches/{branch}/protection/required_signatures
      */
     reposGetCommitSignatureProtection: (
-      owner: string,
-      repo: string,
-      branch: string,
+      {
+        owner,
+        repo,
+        branch,
+        ...query
+      }: ReposGetCommitSignatureProtectionParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposGetCommitSignatureProtectionData, BasicError>({
@@ -57223,8 +60643,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/community/profile
      */
     reposGetCommunityProfileMetrics: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: ReposGetCommunityProfileMetricsParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposGetCommunityProfileMetricsData, any>({
@@ -57263,8 +60682,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/stats/contributors
      */
     reposGetContributorsStats: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: ReposGetContributorsStatsParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposGetContributorsStatsData, any>({
@@ -57283,9 +60701,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/keys/{key_id}
      */
     reposGetDeployKey: (
-      owner: string,
-      repo: string,
-      keyId: number,
+      { owner, repo, keyId, ...query }: ReposGetDeployKeyParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposGetDeployKeyData, BasicError>({
@@ -57304,9 +60720,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/deployments/{deployment_id}
      */
     reposGetDeployment: (
-      owner: string,
-      repo: string,
-      deploymentId: number,
+      { owner, repo, deploymentId, ...query }: ReposGetDeploymentParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposGetDeploymentData, BasicError>({
@@ -57325,10 +60739,13 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/deployments/{deployment_id}/statuses/{status_id}
      */
     reposGetDeploymentStatus: (
-      owner: string,
-      repo: string,
-      deploymentId: number,
-      statusId: number,
+      {
+        owner,
+        repo,
+        deploymentId,
+        statusId,
+        ...query
+      }: ReposGetDeploymentStatusParams,
       params: RequestParams = {},
     ) =>
       this.request<
@@ -57354,8 +60771,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/pages/builds/latest
      */
     reposGetLatestPagesBuild: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: ReposGetLatestPagesBuildParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposGetLatestPagesBuildData, any>({
@@ -57374,8 +60790,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/releases/latest
      */
     reposGetLatestRelease: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: ReposGetLatestReleaseParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposGetLatestReleaseData, any>({
@@ -57393,7 +60808,10 @@ export class Api<
      * @summary Get a GitHub Pages site
      * @request GET:/repos/{owner}/{repo}/pages
      */
-    reposGetPages: (owner: string, repo: string, params: RequestParams = {}) =>
+    reposGetPages: (
+      { owner, repo, ...query }: ReposGetPagesParams,
+      params: RequestParams = {},
+    ) =>
       this.request<ReposGetPagesData, BasicError>({
         path: \`/repos/\${owner}/\${repo}/pages\`,
         method: "GET",
@@ -57410,9 +60828,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/pages/builds/{build_id}
      */
     reposGetPagesBuild: (
-      owner: string,
-      repo: string,
-      buildId: number,
+      { owner, repo, buildId, ...query }: ReposGetPagesBuildParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposGetPagesBuildData, any>({
@@ -57431,8 +60847,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/stats/participation
      */
     reposGetParticipationStats: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: ReposGetParticipationStatsParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposGetParticipationStatsData, BasicError>({
@@ -57451,9 +60866,12 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews
      */
     reposGetPullRequestReviewProtection: (
-      owner: string,
-      repo: string,
-      branch: string,
+      {
+        owner,
+        repo,
+        branch,
+        ...query
+      }: ReposGetPullRequestReviewProtectionParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposGetPullRequestReviewProtectionData, any>({
@@ -57472,8 +60890,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/stats/punch_card
      */
     reposGetPunchCardStats: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: ReposGetPunchCardStatsParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposGetPunchCardStatsData, any>({
@@ -57512,9 +60929,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/releases/{release_id}
      */
     reposGetRelease: (
-      owner: string,
-      repo: string,
-      releaseId: number,
+      { owner, repo, releaseId, ...query }: ReposGetReleaseParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposGetReleaseData, BasicError>({
@@ -57533,9 +60948,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/releases/assets/{asset_id}
      */
     reposGetReleaseAsset: (
-      owner: string,
-      repo: string,
-      assetId: number,
+      { owner, repo, assetId, ...query }: ReposGetReleaseAssetParams,
       params: RequestParams = {},
     ) =>
       this.request<
@@ -57561,9 +60974,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/releases/tags/{tag}
      */
     reposGetReleaseByTag: (
-      owner: string,
-      repo: string,
-      tag: string,
+      { owner, repo, tag, ...query }: ReposGetReleaseByTagParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposGetReleaseByTagData, BasicError>({
@@ -57582,9 +60993,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks
      */
     reposGetStatusChecksProtection: (
-      owner: string,
-      repo: string,
-      branch: string,
+      { owner, repo, branch, ...query }: ReposGetStatusChecksProtectionParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposGetStatusChecksProtectionData, BasicError>({
@@ -57603,9 +61012,12 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams
      */
     reposGetTeamsWithAccessToProtectedBranch: (
-      owner: string,
-      repo: string,
-      branch: string,
+      {
+        owner,
+        repo,
+        branch,
+        ...query
+      }: ReposGetTeamsWithAccessToProtectedBranchParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposGetTeamsWithAccessToProtectedBranchData, BasicError>({
@@ -57624,8 +61036,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/traffic/popular/paths
      */
     reposGetTopPaths: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: ReposGetTopPathsParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposGetTopPathsData, BasicError>({
@@ -57644,8 +61055,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/traffic/popular/referrers
      */
     reposGetTopReferrers: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: ReposGetTopReferrersParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposGetTopReferrersData, BasicError>({
@@ -57664,9 +61074,12 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users
      */
     reposGetUsersWithAccessToProtectedBranch: (
-      owner: string,
-      repo: string,
-      branch: string,
+      {
+        owner,
+        repo,
+        branch,
+        ...query
+      }: ReposGetUsersWithAccessToProtectedBranchParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposGetUsersWithAccessToProtectedBranchData, BasicError>({
@@ -57705,9 +61118,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/hooks/{hook_id}
      */
     reposGetWebhook: (
-      owner: string,
-      repo: string,
-      hookId: number,
+      { owner, repo, hookId, ...query }: ReposGetWebhookParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposGetWebhookData, BasicError>({
@@ -57726,9 +61137,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/hooks/{hook_id}/config
      */
     reposGetWebhookConfigForRepo: (
-      owner: string,
-      repo: string,
-      hookId: number,
+      { owner, repo, hookId, ...query }: ReposGetWebhookConfigForRepoParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposGetWebhookConfigForRepoData, any>({
@@ -57767,9 +61176,12 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/commits/{commit_sha}/branches-where-head
      */
     reposListBranchesForHeadCommit: (
-      owner: string,
-      repo: string,
-      commitSha: string,
+      {
+        owner,
+        repo,
+        commitSha,
+        ...query
+      }: ReposListBranchesForHeadCommitParams,
       params: RequestParams = {},
     ) =>
       this.request<
@@ -58020,8 +61432,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/languages
      */
     reposListLanguages: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: ReposListLanguagesParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposListLanguagesData, any>({
@@ -58191,8 +61602,7 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/merges
      */
     reposMerge: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: ReposMergeParams,
       data: ReposMergePayload,
       params: RequestParams = {},
     ) =>
@@ -58214,9 +61624,7 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/hooks/{hook_id}/pings
      */
     reposPingWebhook: (
-      owner: string,
-      repo: string,
-      hookId: number,
+      { owner, repo, hookId, ...query }: ReposPingWebhookParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposPingWebhookData, BasicError>({
@@ -58234,9 +61642,7 @@ export class Api<
      * @request DELETE:/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps
      */
     reposRemoveAppAccessRestrictions: (
-      owner: string,
-      repo: string,
-      branch: string,
+      { owner, repo, branch, ...query }: ReposRemoveAppAccessRestrictionsParams,
       data: ReposRemoveAppAccessRestrictionsPayload,
       params: RequestParams = {},
     ) =>
@@ -58258,9 +61664,7 @@ export class Api<
      * @request DELETE:/repos/{owner}/{repo}/collaborators/{username}
      */
     reposRemoveCollaborator: (
-      owner: string,
-      repo: string,
-      username: string,
+      { owner, repo, username, ...query }: ReposRemoveCollaboratorParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposRemoveCollaboratorData, any>({
@@ -58278,9 +61682,7 @@ export class Api<
      * @request DELETE:/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts
      */
     reposRemoveStatusCheckContexts: (
-      owner: string,
-      repo: string,
-      branch: string,
+      { owner, repo, branch, ...query }: ReposRemoveStatusCheckContextsParams,
       data: ReposRemoveStatusCheckContextsPayload,
       params: RequestParams = {},
     ) =>
@@ -58305,9 +61707,7 @@ export class Api<
      * @request DELETE:/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks
      */
     reposRemoveStatusCheckProtection: (
-      owner: string,
-      repo: string,
-      branch: string,
+      { owner, repo, branch, ...query }: ReposRemoveStatusCheckProtectionParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposRemoveStatusCheckProtectionData, any>({
@@ -58325,9 +61725,12 @@ export class Api<
      * @request DELETE:/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams
      */
     reposRemoveTeamAccessRestrictions: (
-      owner: string,
-      repo: string,
-      branch: string,
+      {
+        owner,
+        repo,
+        branch,
+        ...query
+      }: ReposRemoveTeamAccessRestrictionsParams,
       data: ReposRemoveTeamAccessRestrictionsPayload,
       params: RequestParams = {},
     ) =>
@@ -58349,9 +61752,12 @@ export class Api<
      * @request DELETE:/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users
      */
     reposRemoveUserAccessRestrictions: (
-      owner: string,
-      repo: string,
-      branch: string,
+      {
+        owner,
+        repo,
+        branch,
+        ...query
+      }: ReposRemoveUserAccessRestrictionsParams,
       data: ReposRemoveUserAccessRestrictionsPayload,
       params: RequestParams = {},
     ) =>
@@ -58373,9 +61779,7 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/branches/{branch}/rename
      */
     reposRenameBranch: (
-      owner: string,
-      repo: string,
-      branch: string,
+      { owner, repo, branch, ...query }: ReposRenameBranchParams,
       data: ReposRenameBranchPayload,
       params: RequestParams = {},
     ) =>
@@ -58397,8 +61801,7 @@ export class Api<
      * @request PUT:/repos/{owner}/{repo}/topics
      */
     reposReplaceAllTopics: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: ReposReplaceAllTopicsParams,
       data: ReposReplaceAllTopicsPayload,
       params: RequestParams = {},
     ) =>
@@ -58428,8 +61831,7 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/pages/builds
      */
     reposRequestPagesBuild: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: ReposRequestPagesBuildParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposRequestPagesBuildData, any>({
@@ -58448,9 +61850,7 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins
      */
     reposSetAdminBranchProtection: (
-      owner: string,
-      repo: string,
-      branch: string,
+      { owner, repo, branch, ...query }: ReposSetAdminBranchProtectionParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposSetAdminBranchProtectionData, any>({
@@ -58469,9 +61869,7 @@ export class Api<
      * @request PUT:/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps
      */
     reposSetAppAccessRestrictions: (
-      owner: string,
-      repo: string,
-      branch: string,
+      { owner, repo, branch, ...query }: ReposSetAppAccessRestrictionsParams,
       data: ReposSetAppAccessRestrictionsPayload,
       params: RequestParams = {},
     ) =>
@@ -58493,9 +61891,7 @@ export class Api<
      * @request PUT:/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts
      */
     reposSetStatusCheckContexts: (
-      owner: string,
-      repo: string,
-      branch: string,
+      { owner, repo, branch, ...query }: ReposSetStatusCheckContextsParams,
       data: ReposSetStatusCheckContextsPayload,
       params: RequestParams = {},
     ) =>
@@ -58520,9 +61916,7 @@ export class Api<
      * @request PUT:/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams
      */
     reposSetTeamAccessRestrictions: (
-      owner: string,
-      repo: string,
-      branch: string,
+      { owner, repo, branch, ...query }: ReposSetTeamAccessRestrictionsParams,
       data: ReposSetTeamAccessRestrictionsPayload,
       params: RequestParams = {},
     ) =>
@@ -58544,9 +61938,7 @@ export class Api<
      * @request PUT:/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users
      */
     reposSetUserAccessRestrictions: (
-      owner: string,
-      repo: string,
-      branch: string,
+      { owner, repo, branch, ...query }: ReposSetUserAccessRestrictionsParams,
       data: ReposSetUserAccessRestrictionsPayload,
       params: RequestParams = {},
     ) =>
@@ -58568,9 +61960,7 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/hooks/{hook_id}/tests
      */
     reposTestPushWebhook: (
-      owner: string,
-      repo: string,
-      hookId: number,
+      { owner, repo, hookId, ...query }: ReposTestPushWebhookParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposTestPushWebhookData, BasicError>({
@@ -58588,8 +61978,7 @@ export class Api<
      * @request POST:/repos/{owner}/{repo}/transfer
      */
     reposTransfer: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: ReposTransferParams,
       data: ReposTransferPayload,
       params: RequestParams = {},
     ) =>
@@ -58611,8 +62000,7 @@ export class Api<
      * @request PATCH:/repos/{owner}/{repo}
      */
     reposUpdate: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: ReposUpdateParams,
       data: ReposUpdatePayload,
       params: RequestParams = {},
     ) =>
@@ -58634,9 +62022,7 @@ export class Api<
      * @request PUT:/repos/{owner}/{repo}/branches/{branch}/protection
      */
     reposUpdateBranchProtection: (
-      owner: string,
-      repo: string,
-      branch: string,
+      { owner, repo, branch, ...query }: ReposUpdateBranchProtectionParams,
       data: ReposUpdateBranchProtectionPayload,
       params: RequestParams = {},
     ) =>
@@ -58666,9 +62052,7 @@ export class Api<
      * @request PATCH:/repos/{owner}/{repo}/comments/{comment_id}
      */
     reposUpdateCommitComment: (
-      owner: string,
-      repo: string,
-      commentId: number,
+      { owner, repo, commentId, ...query }: ReposUpdateCommitCommentParams,
       data: ReposUpdateCommitCommentPayload,
       params: RequestParams = {},
     ) =>
@@ -58690,8 +62074,7 @@ export class Api<
      * @request PUT:/repos/{owner}/{repo}/pages
      */
     reposUpdateInformationAboutPagesSite: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: ReposUpdateInformationAboutPagesSiteParams,
       data: ReposUpdateInformationAboutPagesSitePayload,
       params: RequestParams = {},
     ) =>
@@ -58715,9 +62098,7 @@ export class Api<
      * @request PATCH:/repos/{owner}/{repo}/invitations/{invitation_id}
      */
     reposUpdateInvitation: (
-      owner: string,
-      repo: string,
-      invitationId: number,
+      { owner, repo, invitationId, ...query }: ReposUpdateInvitationParams,
       data: ReposUpdateInvitationPayload,
       params: RequestParams = {},
     ) =>
@@ -58739,9 +62120,12 @@ export class Api<
      * @request PATCH:/repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews
      */
     reposUpdatePullRequestReviewProtection: (
-      owner: string,
-      repo: string,
-      branch: string,
+      {
+        owner,
+        repo,
+        branch,
+        ...query
+      }: ReposUpdatePullRequestReviewProtectionParams,
       data: ReposUpdatePullRequestReviewProtectionPayload,
       params: RequestParams = {},
     ) =>
@@ -58765,9 +62149,7 @@ export class Api<
      * @request PATCH:/repos/{owner}/{repo}/releases/{release_id}
      */
     reposUpdateRelease: (
-      owner: string,
-      repo: string,
-      releaseId: number,
+      { owner, repo, releaseId, ...query }: ReposUpdateReleaseParams,
       data: ReposUpdateReleasePayload,
       params: RequestParams = {},
     ) =>
@@ -58789,9 +62171,7 @@ export class Api<
      * @request PATCH:/repos/{owner}/{repo}/releases/assets/{asset_id}
      */
     reposUpdateReleaseAsset: (
-      owner: string,
-      repo: string,
-      assetId: number,
+      { owner, repo, assetId, ...query }: ReposUpdateReleaseAssetParams,
       data: ReposUpdateReleaseAssetPayload,
       params: RequestParams = {},
     ) =>
@@ -58813,9 +62193,7 @@ export class Api<
      * @request PATCH:/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks
      */
     reposUpdateStatusCheckProtection: (
-      owner: string,
-      repo: string,
-      branch: string,
+      { owner, repo, branch, ...query }: ReposUpdateStatusCheckProtectionParams,
       data: ReposUpdateStatusCheckProtectionPayload,
       params: RequestParams = {},
     ) =>
@@ -58840,9 +62218,7 @@ export class Api<
      * @request PATCH:/repos/{owner}/{repo}/hooks/{hook_id}
      */
     reposUpdateWebhook: (
-      owner: string,
-      repo: string,
-      hookId: number,
+      { owner, repo, hookId, ...query }: ReposUpdateWebhookParams,
       data: ReposUpdateWebhookPayload,
       params: RequestParams = {},
     ) =>
@@ -58864,9 +62240,7 @@ export class Api<
      * @request PATCH:/repos/{owner}/{repo}/hooks/{hook_id}/config
      */
     reposUpdateWebhookConfigForRepo: (
-      owner: string,
-      repo: string,
-      hookId: number,
+      { owner, repo, hookId, ...query }: ReposUpdateWebhookConfigForRepoParams,
       data: ReposUpdateWebhookConfigForRepoPayload,
       params: RequestParams = {},
     ) =>
@@ -58910,9 +62284,7 @@ export class Api<
      * @request GET:/repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
      */
     secretScanningGetAlert: (
-      owner: string,
-      repo: string,
-      alertNumber: AlertNumber,
+      { owner, repo, alertNumber, ...query }: SecretScanningGetAlertParams,
       params: RequestParams = {},
     ) =>
       this.request<
@@ -58965,9 +62337,7 @@ export class Api<
      * @request PATCH:/repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
      */
     secretScanningUpdateAlert: (
-      owner: string,
-      repo: string,
-      alertNumber: AlertNumber,
+      { owner, repo, alertNumber, ...query }: SecretScanningUpdateAlertParams,
       data: SecretScanningUpdateAlertPayload,
       params: RequestParams = {},
     ) =>
@@ -59018,8 +62388,11 @@ export class Api<
      * @request DELETE:/scim/v2/enterprises/{enterprise}/Groups/{scim_group_id}
      */
     enterpriseAdminDeleteScimGroupFromEnterprise: (
-      enterprise: string,
-      scimGroupId: string,
+      {
+        enterprise,
+        scimGroupId,
+        ...query
+      }: EnterpriseAdminDeleteScimGroupFromEnterpriseParams,
       params: RequestParams = {},
     ) =>
       this.request<EnterpriseAdminDeleteScimGroupFromEnterpriseData, any>({
@@ -59037,8 +62410,11 @@ export class Api<
      * @request DELETE:/scim/v2/enterprises/{enterprise}/Users/{scim_user_id}
      */
     enterpriseAdminDeleteUserFromEnterprise: (
-      enterprise: string,
-      scimUserId: string,
+      {
+        enterprise,
+        scimUserId,
+        ...query
+      }: EnterpriseAdminDeleteUserFromEnterpriseParams,
       params: RequestParams = {},
     ) =>
       this.request<EnterpriseAdminDeleteUserFromEnterpriseData, any>({
@@ -59056,8 +62432,11 @@ export class Api<
      * @request GET:/scim/v2/enterprises/{enterprise}/Groups/{scim_group_id}
      */
     enterpriseAdminGetProvisioningInformationForEnterpriseGroup: (
-      enterprise: string,
-      scimGroupId: string,
+      {
+        enterprise,
+        scimGroupId,
+        ...query
+      }: EnterpriseAdminGetProvisioningInformationForEnterpriseGroupParams,
       params: RequestParams = {},
     ) =>
       this.request<
@@ -59079,8 +62458,11 @@ export class Api<
      * @request GET:/scim/v2/enterprises/{enterprise}/Users/{scim_user_id}
      */
     enterpriseAdminGetProvisioningInformationForEnterpriseUser: (
-      enterprise: string,
-      scimUserId: string,
+      {
+        enterprise,
+        scimUserId,
+        ...query
+      }: EnterpriseAdminGetProvisioningInformationForEnterpriseUserParams,
       params: RequestParams = {},
     ) =>
       this.request<
@@ -59150,7 +62532,10 @@ export class Api<
      * @request POST:/scim/v2/enterprises/{enterprise}/Groups
      */
     enterpriseAdminProvisionAndInviteEnterpriseGroup: (
-      enterprise: string,
+      {
+        enterprise,
+        ...query
+      }: EnterpriseAdminProvisionAndInviteEnterpriseGroupParams,
       data: EnterpriseAdminProvisionAndInviteEnterpriseGroupPayload,
       params: RequestParams = {},
     ) =>
@@ -59172,7 +62557,10 @@ export class Api<
      * @request POST:/scim/v2/enterprises/{enterprise}/Users
      */
     enterpriseAdminProvisionAndInviteEnterpriseUser: (
-      enterprise: string,
+      {
+        enterprise,
+        ...query
+      }: EnterpriseAdminProvisionAndInviteEnterpriseUserParams,
       data: EnterpriseAdminProvisionAndInviteEnterpriseUserPayload,
       params: RequestParams = {},
     ) =>
@@ -59194,8 +62582,11 @@ export class Api<
      * @request PUT:/scim/v2/enterprises/{enterprise}/Groups/{scim_group_id}
      */
     enterpriseAdminSetInformationForProvisionedEnterpriseGroup: (
-      enterprise: string,
-      scimGroupId: string,
+      {
+        enterprise,
+        scimGroupId,
+        ...query
+      }: EnterpriseAdminSetInformationForProvisionedEnterpriseGroupParams,
       data: EnterpriseAdminSetInformationForProvisionedEnterpriseGroupPayload,
       params: RequestParams = {},
     ) =>
@@ -59220,8 +62611,11 @@ export class Api<
      * @request PUT:/scim/v2/enterprises/{enterprise}/Users/{scim_user_id}
      */
     enterpriseAdminSetInformationForProvisionedEnterpriseUser: (
-      enterprise: string,
-      scimUserId: string,
+      {
+        enterprise,
+        scimUserId,
+        ...query
+      }: EnterpriseAdminSetInformationForProvisionedEnterpriseUserParams,
       data: EnterpriseAdminSetInformationForProvisionedEnterpriseUserPayload,
       params: RequestParams = {},
     ) =>
@@ -59246,8 +62640,11 @@ export class Api<
      * @request PATCH:/scim/v2/enterprises/{enterprise}/Groups/{scim_group_id}
      */
     enterpriseAdminUpdateAttributeForEnterpriseGroup: (
-      enterprise: string,
-      scimGroupId: string,
+      {
+        enterprise,
+        scimGroupId,
+        ...query
+      }: EnterpriseAdminUpdateAttributeForEnterpriseGroupParams,
       data: EnterpriseAdminUpdateAttributeForEnterpriseGroupPayload,
       params: RequestParams = {},
     ) =>
@@ -59269,8 +62666,11 @@ export class Api<
      * @request PATCH:/scim/v2/enterprises/{enterprise}/Users/{scim_user_id}
      */
     enterpriseAdminUpdateAttributeForEnterpriseUser: (
-      enterprise: string,
-      scimUserId: string,
+      {
+        enterprise,
+        scimUserId,
+        ...query
+      }: EnterpriseAdminUpdateAttributeForEnterpriseUserParams,
       data: EnterpriseAdminUpdateAttributeForEnterpriseUserPayload,
       params: RequestParams = {},
     ) =>
@@ -59292,8 +62692,7 @@ export class Api<
      * @request DELETE:/scim/v2/organizations/{org}/Users/{scim_user_id}
      */
     scimDeleteUserFromOrg: (
-      org: string,
-      scimUserId: string,
+      { org, scimUserId, ...query }: ScimDeleteUserFromOrgParams,
       params: RequestParams = {},
     ) =>
       this.request<ScimDeleteUserFromOrgData, ScimError>({
@@ -59311,8 +62710,11 @@ export class Api<
      * @request GET:/scim/v2/organizations/{org}/Users/{scim_user_id}
      */
     scimGetProvisioningInformationForUser: (
-      org: string,
-      scimUserId: string,
+      {
+        org,
+        scimUserId,
+        ...query
+      }: ScimGetProvisioningInformationForUserParams,
       params: RequestParams = {},
     ) =>
       this.request<ScimGetProvisioningInformationForUserData, ScimError>({
@@ -59351,7 +62753,7 @@ export class Api<
      * @request POST:/scim/v2/organizations/{org}/Users
      */
     scimProvisionAndInviteUser: (
-      org: string,
+      { org, ...query }: ScimProvisionAndInviteUserParams,
       data: ScimProvisionAndInviteUserPayload,
       params: RequestParams = {},
     ) =>
@@ -59373,8 +62775,7 @@ export class Api<
      * @request PUT:/scim/v2/organizations/{org}/Users/{scim_user_id}
      */
     scimSetInformationForProvisionedUser: (
-      org: string,
-      scimUserId: string,
+      { org, scimUserId, ...query }: ScimSetInformationForProvisionedUserParams,
       data: ScimSetInformationForProvisionedUserPayload,
       params: RequestParams = {},
     ) =>
@@ -59396,8 +62797,7 @@ export class Api<
      * @request PATCH:/scim/v2/organizations/{org}/Users/{scim_user_id}
      */
     scimUpdateAttributeForUser: (
-      org: string,
-      scimUserId: string,
+      { org, scimUserId, ...query }: ScimUpdateAttributeForUserParams,
       data: ScimUpdateAttributeForUserPayload,
       params: RequestParams = {},
     ) =>
@@ -59593,9 +62993,12 @@ export class Api<
      * @deprecated
      */
     reactionsCreateForTeamDiscussionCommentLegacy: (
-      teamId: number,
-      discussionNumber: number,
-      commentNumber: number,
+      {
+        teamId,
+        discussionNumber,
+        commentNumber,
+        ...query
+      }: ReactionsCreateForTeamDiscussionCommentLegacyParams,
       data: ReactionsCreateForTeamDiscussionCommentLegacyPayload,
       params: RequestParams = {},
     ) =>
@@ -59618,8 +63021,11 @@ export class Api<
      * @deprecated
      */
     reactionsCreateForTeamDiscussionLegacy: (
-      teamId: number,
-      discussionNumber: number,
+      {
+        teamId,
+        discussionNumber,
+        ...query
+      }: ReactionsCreateForTeamDiscussionLegacyParams,
       data: ReactionsCreateForTeamDiscussionLegacyPayload,
       params: RequestParams = {},
     ) =>
@@ -59693,8 +63099,7 @@ export class Api<
      * @deprecated
      */
     teamsAddMemberLegacy: (
-      teamId: number,
-      username: string,
+      { teamId, username, ...query }: TeamsAddMemberLegacyParams,
       params: RequestParams = {},
     ) =>
       this.request<TeamsAddMemberLegacyData, TeamsAddMemberLegacyError>({
@@ -59713,8 +63118,11 @@ export class Api<
      * @deprecated
      */
     teamsAddOrUpdateMembershipForUserLegacy: (
-      teamId: number,
-      username: string,
+      {
+        teamId,
+        username,
+        ...query
+      }: TeamsAddOrUpdateMembershipForUserLegacyParams,
       data: TeamsAddOrUpdateMembershipForUserLegacyPayload,
       params: RequestParams = {},
     ) =>
@@ -59740,8 +63148,11 @@ export class Api<
      * @deprecated
      */
     teamsAddOrUpdateProjectPermissionsLegacy: (
-      teamId: number,
-      projectId: number,
+      {
+        teamId,
+        projectId,
+        ...query
+      }: TeamsAddOrUpdateProjectPermissionsLegacyParams,
       data: TeamsAddOrUpdateProjectPermissionsLegacyPayload,
       params: RequestParams = {},
     ) =>
@@ -59766,9 +63177,12 @@ export class Api<
      * @deprecated
      */
     teamsAddOrUpdateRepoPermissionsLegacy: (
-      teamId: number,
-      owner: string,
-      repo: string,
+      {
+        teamId,
+        owner,
+        repo,
+        ...query
+      }: TeamsAddOrUpdateRepoPermissionsLegacyParams,
       data: TeamsAddOrUpdateRepoPermissionsLegacyPayload,
       params: RequestParams = {},
     ) =>
@@ -59793,8 +63207,11 @@ export class Api<
      * @deprecated
      */
     teamsCheckPermissionsForProjectLegacy: (
-      teamId: number,
-      projectId: number,
+      {
+        teamId,
+        projectId,
+        ...query
+      }: TeamsCheckPermissionsForProjectLegacyParams,
       params: RequestParams = {},
     ) =>
       this.request<
@@ -59820,9 +63237,12 @@ export class Api<
      * @deprecated
      */
     teamsCheckPermissionsForRepoLegacy: (
-      teamId: number,
-      owner: string,
-      repo: string,
+      {
+        teamId,
+        owner,
+        repo,
+        ...query
+      }: TeamsCheckPermissionsForRepoLegacyParams,
       params: RequestParams = {},
     ) =>
       this.request<TeamsCheckPermissionsForRepoLegacyData, void>({
@@ -59842,8 +63262,11 @@ export class Api<
      * @deprecated
      */
     teamsCreateDiscussionCommentLegacy: (
-      teamId: number,
-      discussionNumber: number,
+      {
+        teamId,
+        discussionNumber,
+        ...query
+      }: TeamsCreateDiscussionCommentLegacyParams,
       data: TeamsCreateDiscussionCommentLegacyPayload,
       params: RequestParams = {},
     ) =>
@@ -59866,7 +63289,7 @@ export class Api<
      * @deprecated
      */
     teamsCreateDiscussionLegacy: (
-      teamId: number,
+      { teamId, ...query }: TeamsCreateDiscussionLegacyParams,
       data: TeamsCreateDiscussionLegacyPayload,
       params: RequestParams = {},
     ) =>
@@ -59889,7 +63312,7 @@ export class Api<
      * @deprecated
      */
     teamsCreateOrUpdateIdpGroupConnectionsLegacy: (
-      teamId: number,
+      { teamId, ...query }: TeamsCreateOrUpdateIdpGroupConnectionsLegacyParams,
       data: TeamsCreateOrUpdateIdpGroupConnectionsLegacyPayload,
       params: RequestParams = {},
     ) =>
@@ -59915,9 +63338,12 @@ export class Api<
      * @deprecated
      */
     teamsDeleteDiscussionCommentLegacy: (
-      teamId: number,
-      discussionNumber: number,
-      commentNumber: number,
+      {
+        teamId,
+        discussionNumber,
+        commentNumber,
+        ...query
+      }: TeamsDeleteDiscussionCommentLegacyParams,
       params: RequestParams = {},
     ) =>
       this.request<TeamsDeleteDiscussionCommentLegacyData, any>({
@@ -59936,8 +63362,7 @@ export class Api<
      * @deprecated
      */
     teamsDeleteDiscussionLegacy: (
-      teamId: number,
-      discussionNumber: number,
+      { teamId, discussionNumber, ...query }: TeamsDeleteDiscussionLegacyParams,
       params: RequestParams = {},
     ) =>
       this.request<TeamsDeleteDiscussionLegacyData, any>({
@@ -59955,7 +63380,10 @@ export class Api<
      * @request DELETE:/teams/{team_id}
      * @deprecated
      */
-    teamsDeleteLegacy: (teamId: number, params: RequestParams = {}) =>
+    teamsDeleteLegacy: (
+      { teamId, ...query }: TeamsDeleteLegacyParams,
+      params: RequestParams = {},
+    ) =>
       this.request<TeamsDeleteLegacyData, BasicError | ValidationError>({
         path: \`/teams/\${teamId}\`,
         method: "DELETE",
@@ -59972,9 +63400,12 @@ export class Api<
      * @deprecated
      */
     teamsGetDiscussionCommentLegacy: (
-      teamId: number,
-      discussionNumber: number,
-      commentNumber: number,
+      {
+        teamId,
+        discussionNumber,
+        commentNumber,
+        ...query
+      }: TeamsGetDiscussionCommentLegacyParams,
       params: RequestParams = {},
     ) =>
       this.request<TeamsGetDiscussionCommentLegacyData, any>({
@@ -59994,8 +63425,7 @@ export class Api<
      * @deprecated
      */
     teamsGetDiscussionLegacy: (
-      teamId: number,
-      discussionNumber: number,
+      { teamId, discussionNumber, ...query }: TeamsGetDiscussionLegacyParams,
       params: RequestParams = {},
     ) =>
       this.request<TeamsGetDiscussionLegacyData, any>({
@@ -60014,7 +63444,10 @@ export class Api<
      * @request GET:/teams/{team_id}
      * @deprecated
      */
-    teamsGetLegacy: (teamId: number, params: RequestParams = {}) =>
+    teamsGetLegacy: (
+      { teamId, ...query }: TeamsGetLegacyParams,
+      params: RequestParams = {},
+    ) =>
       this.request<TeamsGetLegacyData, BasicError>({
         path: \`/teams/\${teamId}\`,
         method: "GET",
@@ -60032,8 +63465,7 @@ export class Api<
      * @deprecated
      */
     teamsGetMemberLegacy: (
-      teamId: number,
-      username: string,
+      { teamId, username, ...query }: TeamsGetMemberLegacyParams,
       params: RequestParams = {},
     ) =>
       this.request<TeamsGetMemberLegacyData, void>({
@@ -60052,8 +63484,7 @@ export class Api<
      * @deprecated
      */
     teamsGetMembershipForUserLegacy: (
-      teamId: number,
-      username: string,
+      { teamId, username, ...query }: TeamsGetMembershipForUserLegacyParams,
       params: RequestParams = {},
     ) =>
       this.request<TeamsGetMembershipForUserLegacyData, BasicError>({
@@ -60139,7 +63570,10 @@ export class Api<
      * @request GET:/teams/{team_id}/team-sync/group-mappings
      * @deprecated
      */
-    teamsListIdpGroupsForLegacy: (teamId: number, params: RequestParams = {}) =>
+    teamsListIdpGroupsForLegacy: (
+      { teamId, ...query }: TeamsListIdpGroupsForLegacyParams,
+      params: RequestParams = {},
+    ) =>
       this.request<TeamsListIdpGroupsForLegacyData, BasicError>({
         path: \`/teams/\${teamId}/team-sync/group-mappings\`,
         method: "GET",
@@ -60248,8 +63682,7 @@ export class Api<
      * @deprecated
      */
     teamsRemoveMemberLegacy: (
-      teamId: number,
-      username: string,
+      { teamId, username, ...query }: TeamsRemoveMemberLegacyParams,
       params: RequestParams = {},
     ) =>
       this.request<TeamsRemoveMemberLegacyData, void>({
@@ -60268,8 +63701,7 @@ export class Api<
      * @deprecated
      */
     teamsRemoveMembershipForUserLegacy: (
-      teamId: number,
-      username: string,
+      { teamId, username, ...query }: TeamsRemoveMembershipForUserLegacyParams,
       params: RequestParams = {},
     ) =>
       this.request<TeamsRemoveMembershipForUserLegacyData, void>({
@@ -60288,8 +63720,7 @@ export class Api<
      * @deprecated
      */
     teamsRemoveProjectLegacy: (
-      teamId: number,
-      projectId: number,
+      { teamId, projectId, ...query }: TeamsRemoveProjectLegacyParams,
       params: RequestParams = {},
     ) =>
       this.request<
@@ -60316,9 +63747,7 @@ export class Api<
      * @deprecated
      */
     teamsRemoveRepoLegacy: (
-      teamId: number,
-      owner: string,
-      repo: string,
+      { teamId, owner, repo, ...query }: TeamsRemoveRepoLegacyParams,
       params: RequestParams = {},
     ) =>
       this.request<TeamsRemoveRepoLegacyData, any>({
@@ -60337,9 +63766,12 @@ export class Api<
      * @deprecated
      */
     teamsUpdateDiscussionCommentLegacy: (
-      teamId: number,
-      discussionNumber: number,
-      commentNumber: number,
+      {
+        teamId,
+        discussionNumber,
+        commentNumber,
+        ...query
+      }: TeamsUpdateDiscussionCommentLegacyParams,
       data: TeamsUpdateDiscussionCommentLegacyPayload,
       params: RequestParams = {},
     ) =>
@@ -60362,8 +63794,7 @@ export class Api<
      * @deprecated
      */
     teamsUpdateDiscussionLegacy: (
-      teamId: number,
-      discussionNumber: number,
+      { teamId, discussionNumber, ...query }: TeamsUpdateDiscussionLegacyParams,
       data: TeamsUpdateDiscussionLegacyPayload,
       params: RequestParams = {},
     ) =>
@@ -60386,7 +63817,7 @@ export class Api<
      * @deprecated
      */
     teamsUpdateLegacy: (
-      teamId: number,
+      { teamId, ...query }: TeamsUpdateLegacyParams,
       data: TeamsUpdateLegacyPayload,
       params: RequestParams = {},
     ) =>
@@ -60409,8 +63840,11 @@ export class Api<
      * @request GET:/user/starred/{owner}/{repo}
      */
     activityCheckRepoIsStarredByAuthenticatedUser: (
-      owner: string,
-      repo: string,
+      {
+        owner,
+        repo,
+        ...query
+      }: ActivityCheckRepoIsStarredByAuthenticatedUserParams,
       params: RequestParams = {},
     ) =>
       this.request<
@@ -60476,8 +63910,7 @@ export class Api<
      * @request PUT:/user/starred/{owner}/{repo}
      */
     activityStarRepoForAuthenticatedUser: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: ActivityStarRepoForAuthenticatedUserParams,
       params: RequestParams = {},
     ) =>
       this.request<ActivityStarRepoForAuthenticatedUserData, BasicError>({
@@ -60495,8 +63928,7 @@ export class Api<
      * @request DELETE:/user/starred/{owner}/{repo}
      */
     activityUnstarRepoForAuthenticatedUser: (
-      owner: string,
-      repo: string,
+      { owner, repo, ...query }: ActivityUnstarRepoForAuthenticatedUserParams,
       params: RequestParams = {},
     ) =>
       this.request<ActivityUnstarRepoForAuthenticatedUserData, BasicError>({
@@ -60514,8 +63946,11 @@ export class Api<
      * @request PUT:/user/installations/{installation_id}/repositories/{repository_id}
      */
     appsAddRepoToInstallation: (
-      installationId: number,
-      repositoryId: number,
+      {
+        installationId,
+        repositoryId,
+        ...query
+      }: AppsAddRepoToInstallationParams,
       params: RequestParams = {},
     ) =>
       this.request<AppsAddRepoToInstallationData, BasicError>({
@@ -60629,8 +64064,11 @@ export class Api<
      * @request DELETE:/user/installations/{installation_id}/repositories/{repository_id}
      */
     appsRemoveRepoFromInstallation: (
-      installationId: number,
-      repositoryId: number,
+      {
+        installationId,
+        repositoryId,
+        ...query
+      }: AppsRemoveRepoFromInstallationParams,
       params: RequestParams = {},
     ) =>
       this.request<AppsRemoveRepoFromInstallationData, BasicError>({
@@ -60729,7 +64167,10 @@ export class Api<
      * @request DELETE:/user/migrations/{migration_id}/archive
      */
     migrationsDeleteArchiveForAuthenticatedUser: (
-      migrationId: number,
+      {
+        migrationId,
+        ...query
+      }: MigrationsDeleteArchiveForAuthenticatedUserParams,
       params: RequestParams = {},
     ) =>
       this.request<MigrationsDeleteArchiveForAuthenticatedUserData, BasicError>(
@@ -60749,7 +64190,7 @@ export class Api<
      * @request GET:/user/migrations/{migration_id}/archive
      */
     migrationsGetArchiveForAuthenticatedUser: (
-      migrationId: number,
+      { migrationId, ...query }: MigrationsGetArchiveForAuthenticatedUserParams,
       params: RequestParams = {},
     ) =>
       this.request<any, void | BasicError>({
@@ -60851,8 +64292,11 @@ export class Api<
      * @request DELETE:/user/migrations/{migration_id}/repos/{repo_name}/lock
      */
     migrationsUnlockRepoForAuthenticatedUser: (
-      migrationId: number,
-      repoName: string,
+      {
+        migrationId,
+        repoName,
+        ...query
+      }: MigrationsUnlockRepoForAuthenticatedUserParams,
       params: RequestParams = {},
     ) =>
       this.request<MigrationsUnlockRepoForAuthenticatedUserData, BasicError>({
@@ -60870,7 +64314,7 @@ export class Api<
      * @request GET:/user/memberships/orgs/{org}
      */
     orgsGetMembershipForAuthenticatedUser: (
-      org: string,
+      { org, ...query }: OrgsGetMembershipForAuthenticatedUserParams,
       params: RequestParams = {},
     ) =>
       this.request<OrgsGetMembershipForAuthenticatedUserData, BasicError>({
@@ -60932,7 +64376,7 @@ export class Api<
      * @request PATCH:/user/memberships/orgs/{org}
      */
     orgsUpdateMembershipForAuthenticatedUser: (
-      org: string,
+      { org, ...query }: OrgsUpdateMembershipForAuthenticatedUserParams,
       data: OrgsUpdateMembershipForAuthenticatedUserPayload,
       params: RequestParams = {},
     ) =>
@@ -60985,7 +64429,10 @@ export class Api<
      * @summary Accept a repository invitation
      * @request PATCH:/user/repository_invitations/{invitation_id}
      */
-    reposAcceptInvitation: (invitationId: number, params: RequestParams = {}) =>
+    reposAcceptInvitation: (
+      { invitationId, ...query }: ReposAcceptInvitationParams,
+      params: RequestParams = {},
+    ) =>
       this.request<ReposAcceptInvitationData, BasicError>({
         path: \`/user/repository_invitations/\${invitationId}\`,
         method: "PATCH",
@@ -61025,7 +64472,7 @@ export class Api<
      * @request DELETE:/user/repository_invitations/{invitation_id}
      */
     reposDeclineInvitation: (
-      invitationId: number,
+      { invitationId, ...query }: ReposDeclineInvitationParams,
       params: RequestParams = {},
     ) =>
       this.request<ReposDeclineInvitationData, BasicError>({
@@ -61129,7 +64576,10 @@ export class Api<
      * @summary Block a user
      * @request PUT:/user/blocks/{username}
      */
-    usersBlock: (username: string, params: RequestParams = {}) =>
+    usersBlock: (
+      { username, ...query }: UsersBlockParams,
+      params: RequestParams = {},
+    ) =>
       this.request<UsersBlockData, BasicError | ValidationError>({
         path: \`/user/blocks/\${username}\`,
         method: "PUT",
@@ -61144,7 +64594,10 @@ export class Api<
      * @summary Check if a user is blocked by the authenticated user
      * @request GET:/user/blocks/{username}
      */
-    usersCheckBlocked: (username: string, params: RequestParams = {}) =>
+    usersCheckBlocked: (
+      { username, ...query }: UsersCheckBlockedParams,
+      params: RequestParams = {},
+    ) =>
       this.request<UsersCheckBlockedData, UsersCheckBlockedError>({
         path: \`/user/blocks/\${username}\`,
         method: "GET",
@@ -61160,7 +64613,7 @@ export class Api<
      * @request GET:/user/following/{username}
      */
     usersCheckPersonIsFollowedByAuthenticated: (
-      username: string,
+      { username, ...query }: UsersCheckPersonIsFollowedByAuthenticatedParams,
       params: RequestParams = {},
     ) =>
       this.request<
@@ -61252,7 +64705,7 @@ export class Api<
      * @request DELETE:/user/gpg_keys/{gpg_key_id}
      */
     usersDeleteGpgKeyForAuthenticated: (
-      gpgKeyId: number,
+      { gpgKeyId, ...query }: UsersDeleteGpgKeyForAuthenticatedParams,
       params: RequestParams = {},
     ) =>
       this.request<
@@ -61273,7 +64726,7 @@ export class Api<
      * @request DELETE:/user/keys/{key_id}
      */
     usersDeletePublicSshKeyForAuthenticated: (
-      keyId: number,
+      { keyId, ...query }: UsersDeletePublicSshKeyForAuthenticatedParams,
       params: RequestParams = {},
     ) =>
       this.request<UsersDeletePublicSshKeyForAuthenticatedData, BasicError>({
@@ -61290,7 +64743,10 @@ export class Api<
      * @summary Follow a user
      * @request PUT:/user/following/{username}
      */
-    usersFollow: (username: string, params: RequestParams = {}) =>
+    usersFollow: (
+      { username, ...query }: UsersFollowParams,
+      params: RequestParams = {},
+    ) =>
       this.request<UsersFollowData, BasicError>({
         path: \`/user/following/\${username}\`,
         method: "PUT",
@@ -61322,7 +64778,7 @@ export class Api<
      * @request GET:/user/gpg_keys/{gpg_key_id}
      */
     usersGetGpgKeyForAuthenticated: (
-      gpgKeyId: number,
+      { gpgKeyId, ...query }: UsersGetGpgKeyForAuthenticatedParams,
       params: RequestParams = {},
     ) =>
       this.request<UsersGetGpgKeyForAuthenticatedData, BasicError>({
@@ -61341,7 +64797,7 @@ export class Api<
      * @request GET:/user/keys/{key_id}
      */
     usersGetPublicSshKeyForAuthenticated: (
-      keyId: number,
+      { keyId, ...query }: UsersGetPublicSshKeyForAuthenticatedParams,
       params: RequestParams = {},
     ) =>
       this.request<UsersGetPublicSshKeyForAuthenticatedData, BasicError>({
@@ -61526,7 +64982,10 @@ export class Api<
      * @summary Unblock a user
      * @request DELETE:/user/blocks/{username}
      */
-    usersUnblock: (username: string, params: RequestParams = {}) =>
+    usersUnblock: (
+      { username, ...query }: UsersUnblockParams,
+      params: RequestParams = {},
+    ) =>
       this.request<UsersUnblockData, BasicError>({
         path: \`/user/blocks/\${username}\`,
         method: "DELETE",
@@ -61541,7 +65000,10 @@ export class Api<
      * @summary Unfollow a user
      * @request DELETE:/user/following/{username}
      */
-    usersUnfollow: (username: string, params: RequestParams = {}) =>
+    usersUnfollow: (
+      { username, ...query }: UsersUnfollowParams,
+      params: RequestParams = {},
+    ) =>
       this.request<UsersUnfollowData, BasicError>({
         path: \`/user/following/\${username}\`,
         method: "DELETE",
@@ -61722,7 +65184,10 @@ export class Api<
      * @summary Get a user installation for the authenticated app
      * @request GET:/users/{username}/installation
      */
-    appsGetUserInstallation: (username: string, params: RequestParams = {}) =>
+    appsGetUserInstallation: (
+      { username, ...query }: AppsGetUserInstallationParams,
+      params: RequestParams = {},
+    ) =>
       this.request<AppsGetUserInstallationData, any>({
         path: \`/users/\${username}/installation\`,
         method: "GET",
@@ -61739,7 +65204,7 @@ export class Api<
      * @request GET:/users/{username}/settings/billing/actions
      */
     billingGetGithubActionsBillingUser: (
-      username: string,
+      { username, ...query }: BillingGetGithubActionsBillingUserParams,
       params: RequestParams = {},
     ) =>
       this.request<BillingGetGithubActionsBillingUserData, any>({
@@ -61758,7 +65223,7 @@ export class Api<
      * @request GET:/users/{username}/settings/billing/packages
      */
     billingGetGithubPackagesBillingUser: (
-      username: string,
+      { username, ...query }: BillingGetGithubPackagesBillingUserParams,
       params: RequestParams = {},
     ) =>
       this.request<BillingGetGithubPackagesBillingUserData, any>({
@@ -61777,7 +65242,7 @@ export class Api<
      * @request GET:/users/{username}/settings/billing/shared-storage
      */
     billingGetSharedStorageBillingUser: (
-      username: string,
+      { username, ...query }: BillingGetSharedStorageBillingUserParams,
       params: RequestParams = {},
     ) =>
       this.request<BillingGetSharedStorageBillingUserData, any>({
@@ -61883,8 +65348,7 @@ export class Api<
      * @request GET:/users/{username}/following/{target_user}
      */
     usersCheckFollowingForUser: (
-      username: string,
-      targetUser: string,
+      { username, targetUser, ...query }: UsersCheckFollowingForUserParams,
       params: RequestParams = {},
     ) =>
       this.request<UsersCheckFollowingForUserData, void>({
@@ -61901,7 +65365,10 @@ export class Api<
      * @summary Get a user
      * @request GET:/users/{username}
      */
-    usersGetByUsername: (username: string, params: RequestParams = {}) =>
+    usersGetByUsername: (
+      { username, ...query }: UsersGetByUsernameParams,
+      params: RequestParams = {},
+    ) =>
       this.request<UsersGetByUsernameData, BasicError>({
         path: \`/users/\${username}\`,
         method: "GET",
@@ -62123,6 +65590,11 @@ export enum StepModeEnum {
 }
 
 export type StopListData = Step[];
+
+export interface StopListParams {
+  /** id of the trip */
+  tripId: string;
+}
 
 export interface Trip {
   /**
@@ -62454,7 +65926,10 @@ export class Api<
      * @request GET:/trip/{trip_id}/stop
      * @secure
      */
-    stopList: (tripId: string, params: RequestParams = {}) =>
+    stopList: (
+      { tripId, ...query }: StopListParams,
+      params: RequestParams = {},
+    ) =>
       this.request<StopListData, any>({
         path: \`/trip/\${tripId}/stop\`,
         method: "GET",
@@ -62506,6 +65981,14 @@ export interface GetGifByIdData {
   data?: Gif;
   /** The Meta Object contains basic information regarding the request, whether it was successful, and the response given by the API.  Check \`responses\` to see a description of types of response codes the API might give you under different cirumstances. */
   meta?: Meta;
+}
+
+export interface GetGifByIdParams {
+  /**
+   * Filters results by specified GIF ID.
+   * @format int32
+   */
+  gifId: number;
 }
 
 export interface GetGifsByIdData {
@@ -63482,7 +66965,10 @@ export class Api<
      * @request GET:/gifs/{gifId}
      * @secure
      */
-    getGifById: (gifId: number, params: RequestParams = {}) =>
+    getGifById: (
+      { gifId, ...query }: GetGifByIdParams,
+      params: RequestParams = {},
+    ) =>
       this.request<GetGifByIdData, any>({
         path: \`/gifs/\${gifId}\`,
         method: "GET",
@@ -63688,6 +67174,12 @@ exports[`extended > 'link-example' 1`] = `
 
 export type GetPullRequestsByIdData = Pullrequest;
 
+export interface GetPullRequestsByIdParams {
+  pid: string;
+  slug: string;
+  username: string;
+}
+
 export type GetPullRequestsByRepositoryData = Pullrequest[];
 
 export interface GetPullRequestsByRepositoryParams {
@@ -63704,11 +67196,30 @@ export enum GetPullRequestsByRepositoryParams1StateEnum {
 
 export type GetRepositoriesByOwnerData = Repository[];
 
+export interface GetRepositoriesByOwnerParams {
+  username: string;
+}
+
 export type GetRepositoryData = Repository;
+
+export interface GetRepositoryParams {
+  slug: string;
+  username: string;
+}
 
 export type GetUserByNameData = User;
 
+export interface GetUserByNameParams {
+  username: string;
+}
+
 export type MergePullRequestData = any;
+
+export interface MergePullRequestParams {
+  pid: string;
+  slug: string;
+  username: string;
+}
 
 export interface Pullrequest {
   author?: User;
@@ -64102,9 +67613,7 @@ export class Api<
      * @request GET:/2.0/repositories/{username}/{slug}/pullrequests/{pid}
      */
     getPullRequestsById: (
-      username: string,
-      slug: string,
-      pid: string,
+      { username, slug, pid, ...query }: GetPullRequestsByIdParams,
       params: RequestParams = {},
     ) =>
       this.request<GetPullRequestsByIdData, any>({
@@ -64138,7 +67647,10 @@ export class Api<
      * @name GetRepositoriesByOwner
      * @request GET:/2.0/repositories/{username}
      */
-    getRepositoriesByOwner: (username: string, params: RequestParams = {}) =>
+    getRepositoriesByOwner: (
+      { username, ...query }: GetRepositoriesByOwnerParams,
+      params: RequestParams = {},
+    ) =>
       this.request<GetRepositoriesByOwnerData, any>({
         path: \`/2.0/repositories/\${username}\`,
         method: "GET",
@@ -64153,8 +67665,7 @@ export class Api<
      * @request GET:/2.0/repositories/{username}/{slug}
      */
     getRepository: (
-      username: string,
-      slug: string,
+      { username, slug, ...query }: GetRepositoryParams,
       params: RequestParams = {},
     ) =>
       this.request<GetRepositoryData, any>({
@@ -64170,7 +67681,10 @@ export class Api<
      * @name GetUserByName
      * @request GET:/2.0/users/{username}
      */
-    getUserByName: (username: string, params: RequestParams = {}) =>
+    getUserByName: (
+      { username, ...query }: GetUserByNameParams,
+      params: RequestParams = {},
+    ) =>
       this.request<GetUserByNameData, any>({
         path: \`/2.0/users/\${username}\`,
         method: "GET",
@@ -64185,9 +67699,7 @@ export class Api<
      * @request POST:/2.0/repositories/{username}/{slug}/pullrequests/{pid}/merge
      */
     mergePullRequest: (
-      username: string,
-      slug: string,
-      pid: string,
+      { username, slug, pid, ...query }: MergePullRequestParams,
       params: RequestParams = {},
     ) =>
       this.request<MergePullRequestData, any>({
@@ -65210,7 +68722,15 @@ export type AuthUserType = OmitIdUserType;
 
 export type DeleteJobData = any;
 
+export interface DeleteJobParams {
+  id: string;
+}
+
 export type DeleteProjectData = any;
+
+export interface DeleteProjectParams {
+  id: string;
+}
 
 export type ExtractedProjectType = OmitProjectTypeJob & {
   /** Information about job */
@@ -65238,6 +68758,10 @@ export interface FooBaz {
 }
 
 export type GetJobData = JobType;
+
+export interface GetJobParams {
+  id: string;
+}
 
 export type GetJobsData = JobType[];
 
@@ -65412,7 +68936,15 @@ export type TestOneOfDc = (FooBarBaz | FooBar) & {
 
 export type UpdateJobData = JobType;
 
+export interface UpdateJobParams {
+  id: string;
+}
+
 export type UpdateProjectData = ProjectType;
+
+export interface UpdateProjectParams {
+  id: string;
+}
 
 export namespace Auth {
   /**
@@ -65918,7 +69450,10 @@ export class Api<
      * @request DELETE:/jobs/{id}
      * @secure
      */
-    deleteJob: (id: string, params: RequestParams = {}) =>
+    deleteJob: (
+      { id, ...query }: DeleteJobParams,
+      params: RequestParams = {},
+    ) =>
       this.request<DeleteJobData, any>({
         path: \`/jobs/\${id}\`,
         method: "DELETE",
@@ -65935,7 +69470,7 @@ export class Api<
      * @request GET:/jobs/{id}
      * @secure
      */
-    getJob: (id: string, params: RequestParams = {}) =>
+    getJob: ({ id, ...query }: GetJobParams, params: RequestParams = {}) =>
       this.request<GetJobData, void>({
         path: \`/jobs/\${id}\`,
         method: "GET",
@@ -65970,7 +69505,7 @@ export class Api<
      * @secure
      */
     updateJob: (
-      id: string,
+      { id, ...query }: UpdateJobParams,
       params: JobUpdateType,
       requestParams: RequestParams = {},
     ) =>
@@ -66011,7 +69546,10 @@ export class Api<
      * @name DeleteProject
      * @request DELETE:/projects/{id}
      */
-    deleteProject: (id: string, params: RequestParams = {}) =>
+    deleteProject: (
+      { id, ...query }: DeleteProjectParams,
+      params: RequestParams = {},
+    ) =>
       this.request<DeleteProjectData, any>({
         path: \`/projects/\${id}\`,
         method: "DELETE",
@@ -66043,7 +69581,7 @@ export class Api<
      * @secure
      */
     updateProject: (
-      id: string,
+      { id, ...query }: UpdateProjectParams,
       data: ProjectUpdateType,
       params: RequestParams = {},
     ) =>
@@ -66108,6 +69646,11 @@ export type Pets = Pet[];
 export type ShowPetByIdData = Pet;
 
 export type ShowPetByIdError = Error;
+
+export interface ShowPetByIdParams {
+  /** The id of the pet to retrieve */
+  petId: string;
+}
 
 export type StringNullable = string | null;
 
@@ -66471,7 +70014,10 @@ export class Api<
      * @summary Info for a specific pet
      * @request GET:/pets/{petId}
      */
-    showPetById: (petId: string, params: RequestParams = {}) =>
+    showPetById: (
+      { petId, ...query }: ShowPetByIdParams,
+      params: RequestParams = {},
+    ) =>
       this.request<ShowPetByIdData, ShowPetByIdError>({
         path: \`/pets/\${petId}\`,
         method: "GET",
@@ -66530,6 +70076,11 @@ export type Pets = Pet[];
 export type ShowPetByIdData = Pets;
 
 export type ShowPetByIdError = Error;
+
+export interface ShowPetByIdParams {
+  /** The id of the pet to retrieve */
+  petId: string;
+}
 
 export namespace Pets {
   /**
@@ -66891,7 +70442,10 @@ export class Api<
      * @summary Info for a specific pet
      * @request GET:/pets/{petId}
      */
-    showPetById: (petId: string, params: RequestParams = {}) =>
+    showPetById: (
+      { petId, ...query }: ShowPetByIdParams,
+      params: RequestParams = {},
+    ) =>
       this.request<ShowPetByIdData, ShowPetByIdError>({
         path: \`/pets/\${petId}\`,
         method: "GET",
@@ -66924,6 +70478,14 @@ export type DeletePetData = any;
 
 export type DeletePetError = Error;
 
+export interface DeletePetParams {
+  /**
+   * ID of pet to delete
+   * @format int64
+   */
+  id: number;
+}
+
 export interface Error {
   /** @format int32 */
   code: number;
@@ -66933,6 +70495,14 @@ export interface Error {
 export type FindPetByIdData = Pet;
 
 export type FindPetByIdError = Error;
+
+export interface FindPetByIdParams {
+  /**
+   * ID of pet to fetch
+   * @format int64
+   */
+  id: number;
+}
 
 export type FindPetsData = Pet[];
 
@@ -67322,7 +70892,10 @@ export class Api<
      * @name DeletePet
      * @request DELETE:/pets/{id}
      */
-    deletePet: (id: number, params: RequestParams = {}) =>
+    deletePet: (
+      { id, ...query }: DeletePetParams,
+      params: RequestParams = {},
+    ) =>
       this.request<DeletePetData, DeletePetError>({
         path: \`/pets/\${id}\`,
         method: "DELETE",
@@ -67335,7 +70908,10 @@ export class Api<
      * @name FindPetById
      * @request GET:/pets/{id}
      */
-    findPetById: (id: number, params: RequestParams = {}) =>
+    findPetById: (
+      { id, ...query }: FindPetByIdParams,
+      params: RequestParams = {},
+    ) =>
       this.request<FindPetByIdData, FindPetByIdError>({
         path: \`/pets/\${id}\`,
         method: "GET",
@@ -67383,6 +70959,14 @@ export type DeletePetData = any;
 
 export type DeletePetError = Error;
 
+export interface DeletePetParams {
+  /**
+   * ID of pet to delete
+   * @format int64
+   */
+  id: number;
+}
+
 export interface Error {
   /** @format int32 */
   code: number;
@@ -67392,6 +70976,14 @@ export interface Error {
 export type FindPetByIdData = Pet;
 
 export type FindPetByIdError = Error;
+
+export interface FindPetByIdParams {
+  /**
+   * ID of pet to fetch
+   * @format int64
+   */
+  id: number;
+}
 
 export type FindPetsData = Pet[];
 
@@ -67430,6 +71022,13 @@ export interface PageTemplateResponseDto {
   totalElements?: number;
   /** @format int32 */
   totalPages?: number;
+}
+
+export interface PathParamFooBarBazListParams {
+  /** foo bar baz */
+  fooBarBaz: string;
+  /** path-param */
+  pathParam: string;
 }
 
 export type Pet = NewPet & {
@@ -67806,8 +71405,7 @@ export class Api<
      * @request GET:/path-params/{path-param}/{foo-bar-baz}
      */
     pathParamFooBarBazList: (
-      pathParam: string,
-      fooBarBaz: string,
+      { pathParam, fooBarBaz, ...query }: PathParamFooBarBazListParams,
       params: RequestParams = {},
     ) =>
       this.request<any, void>({
@@ -67839,7 +71437,10 @@ export class Api<
      * @name DeletePet
      * @request DELETE:/pets/{id}
      */
-    deletePet: (id: number, params: RequestParams = {}) =>
+    deletePet: (
+      { id, ...query }: DeletePetParams,
+      params: RequestParams = {},
+    ) =>
       this.request<DeletePetData, DeletePetError>({
         path: \`/pets/\${id}\`,
         method: "DELETE",
@@ -67852,7 +71453,10 @@ export class Api<
      * @name FindPetById
      * @request GET:/pets/{id}
      */
-    findPetById: (id: number, params: RequestParams = {}) =>
+    findPetById: (
+      { id, ...query }: FindPetByIdParams,
+      params: RequestParams = {},
+    ) =>
       this.request<FindPetByIdData, FindPetByIdError>({
         path: \`/pets/\${id}\`,
         method: "GET",
@@ -68224,6 +71828,14 @@ export type DeletePetData = any;
 
 export type DeletePetError = ErrorModel;
 
+export interface DeletePetParams {
+  /**
+   * ID of pet to delete
+   * @format int64
+   */
+  id: number;
+}
+
 export interface ErrorModel {
   /** @format int32 */
   code: number;
@@ -68233,6 +71845,14 @@ export interface ErrorModel {
 export type FindPetByIdData = Pet;
 
 export type FindPetByIdError = ErrorModel;
+
+export interface FindPetByIdParams {
+  /**
+   * ID of pet to fetch
+   * @format int64
+   */
+  id: number;
+}
 
 export type FindPetsData = Pet[];
 
@@ -68630,7 +72250,10 @@ export class Api<
      * @name DeletePet
      * @request DELETE:/pets/{id}
      */
-    deletePet: (id: number, params: RequestParams = {}) =>
+    deletePet: (
+      { id, ...query }: DeletePetParams,
+      params: RequestParams = {},
+    ) =>
       this.request<DeletePetData, DeletePetError>({
         path: \`/pets/\${id}\`,
         method: "DELETE",
@@ -68643,7 +72266,10 @@ export class Api<
      * @name FindPetById
      * @request GET:/pets/{id}
      */
-    findPetById: (id: number, params: RequestParams = {}) =>
+    findPetById: (
+      { id, ...query }: FindPetByIdParams,
+      params: RequestParams = {},
+    ) =>
       this.request<FindPetByIdData, FindPetByIdError>({
         path: \`/pets/\${id}\`,
         method: "GET",
@@ -68702,6 +72328,28 @@ export type CreateUsersWithArrayInputPayload = User[];
 /** List of user object */
 export type CreateUsersWithListInputPayload = User[];
 
+export interface DeleteOrderParams {
+  /**
+   * ID of the order that needs to be deleted
+   * @format int64
+   * @min 1
+   */
+  orderId: number;
+}
+
+export interface DeletePetParams {
+  /**
+   * Pet id to delete
+   * @format int64
+   */
+  petId: number;
+}
+
+export interface DeleteUserParams {
+  /** The name that needs to be deleted */
+  username: string;
+}
+
 export type FindPetsByStatusData = Pet[];
 
 export interface FindPetsByStatusParams {
@@ -68727,9 +72375,32 @@ export type GetInventoryData = Record<string, number>;
 
 export type GetOrderByIdData = Order;
 
+export interface GetOrderByIdParams {
+  /**
+   * ID of pet that needs to be fetched
+   * @format int64
+   * @min 1
+   * @max 10
+   */
+  orderId: number;
+}
+
 export type GetPetByIdData = Pet;
 
+export interface GetPetByIdParams {
+  /**
+   * ID of pet to return
+   * @format int64
+   */
+  petId: number;
+}
+
 export type GetUserByNameData = User;
+
+export interface GetUserByNameParams {
+  /** The name that needs to be fetched. Use user1 for testing.  */
+  username: string;
+}
 
 export type LoginUserData = string;
 
@@ -68795,6 +72466,14 @@ export interface Tag {
   name?: string;
 }
 
+export interface UpdatePetWithFormParams {
+  /**
+   * ID of pet that needs to be updated
+   * @format int64
+   */
+  petId: number;
+}
+
 export interface UpdatePetWithFormPayload {
   /** Updated name of the pet */
   name?: string;
@@ -68802,7 +72481,20 @@ export interface UpdatePetWithFormPayload {
   status?: string;
 }
 
+export interface UpdateUserParams {
+  /** name that need to be updated */
+  username: string;
+}
+
 export type UploadFileData = ApiResponse;
+
+export interface UploadFileParams {
+  /**
+   * ID of pet to update
+   * @format int64
+   */
+  petId: number;
+}
 
 export interface UploadFilePayload {
   /** Additional data to pass to server */
@@ -69501,7 +73193,10 @@ export class Api<
      * @request DELETE:/pet/{petId}
      * @secure
      */
-    deletePet: (petId: number, params: RequestParams = {}) =>
+    deletePet: (
+      { petId, ...query }: DeletePetParams,
+      params: RequestParams = {},
+    ) =>
       this.request<any, void>({
         path: \`/pet/\${petId}\`,
         method: "DELETE",
@@ -69560,7 +73255,10 @@ export class Api<
      * @request GET:/pet/{petId}
      * @secure
      */
-    getPetById: (petId: number, params: RequestParams = {}) =>
+    getPetById: (
+      { petId, ...query }: GetPetByIdParams,
+      params: RequestParams = {},
+    ) =>
       this.request<GetPetByIdData, void>({
         path: \`/pet/\${petId}\`,
         method: "GET",
@@ -69598,7 +73296,7 @@ export class Api<
      * @secure
      */
     updatePetWithForm: (
-      petId: number,
+      { petId, ...query }: UpdatePetWithFormParams,
       data: UpdatePetWithFormPayload,
       params: RequestParams = {},
     ) =>
@@ -69621,7 +73319,7 @@ export class Api<
      * @secure
      */
     uploadFile: (
-      petId: number,
+      { petId, ...query }: UploadFileParams,
       data: UploadFilePayload,
       params: RequestParams = {},
     ) =>
@@ -69644,7 +73342,10 @@ export class Api<
      * @summary Delete purchase order by ID
      * @request DELETE:/store/order/{orderId}
      */
-    deleteOrder: (orderId: number, params: RequestParams = {}) =>
+    deleteOrder: (
+      { orderId, ...query }: DeleteOrderParams,
+      params: RequestParams = {},
+    ) =>
       this.request<any, void>({
         path: \`/store/order/\${orderId}\`,
         method: "DELETE",
@@ -69677,7 +73378,10 @@ export class Api<
      * @summary Find purchase order by ID
      * @request GET:/store/order/{orderId}
      */
-    getOrderById: (orderId: number, params: RequestParams = {}) =>
+    getOrderById: (
+      { orderId, ...query }: GetOrderByIdParams,
+      params: RequestParams = {},
+    ) =>
       this.request<GetOrderByIdData, void>({
         path: \`/store/order/\${orderId}\`,
         method: "GET",
@@ -69769,7 +73473,10 @@ export class Api<
      * @summary Delete user
      * @request DELETE:/user/{username}
      */
-    deleteUser: (username: string, params: RequestParams = {}) =>
+    deleteUser: (
+      { username, ...query }: DeleteUserParams,
+      params: RequestParams = {},
+    ) =>
       this.request<any, void>({
         path: \`/user/\${username}\`,
         method: "DELETE",
@@ -69784,7 +73491,10 @@ export class Api<
      * @summary Get user by user name
      * @request GET:/user/{username}
      */
-    getUserByName: (username: string, params: RequestParams = {}) =>
+    getUserByName: (
+      { username, ...query }: GetUserByNameParams,
+      params: RequestParams = {},
+    ) =>
       this.request<GetUserByNameData, void>({
         path: \`/user/\${username}\`,
         method: "GET",
@@ -69832,7 +73542,11 @@ export class Api<
      * @summary Updated user
      * @request PUT:/user/{username}
      */
-    updateUser: (username: string, body: User, params: RequestParams = {}) =>
+    updateUser: (
+      { username, ...query }: UpdateUserParams,
+      body: User,
+      params: RequestParams = {},
+    ) =>
       this.request<any, void>({
         path: \`/user/\${username}\`,
         method: "PUT",
@@ -69866,6 +73580,14 @@ export type DeletePetData = any;
 
 export type DeletePetError = ErrorModel;
 
+export interface DeletePetParams {
+  /**
+   * ID of pet to delete
+   * @format int64
+   */
+  id: number;
+}
+
 export interface ErrorModel {
   /** @format int32 */
   code: number;
@@ -69875,6 +73597,14 @@ export interface ErrorModel {
 export type FindPetByIdData = Pet;
 
 export type FindPetByIdError = ErrorModel;
+
+export interface FindPetByIdParams {
+  /**
+   * ID of pet to fetch
+   * @format int64
+   */
+  id: number;
+}
 
 export type FindPetsData = Pet[];
 
@@ -70265,7 +73995,10 @@ export class Api<
      * @name DeletePet
      * @request DELETE:/pets/{id}
      */
-    deletePet: (id: number, params: RequestParams = {}) =>
+    deletePet: (
+      { id, ...query }: DeletePetParams,
+      params: RequestParams = {},
+    ) =>
       this.request<DeletePetData, DeletePetError>({
         path: \`/pets/\${id}\`,
         method: "DELETE",
@@ -70278,7 +74011,10 @@ export class Api<
      * @name FindPetById
      * @request GET:/pets/{id}
      */
-    findPetById: (id: number, params: RequestParams = {}) =>
+    findPetById: (
+      { id, ...query }: FindPetByIdParams,
+      params: RequestParams = {},
+    ) =>
       this.request<FindPetByIdData, FindPetByIdError>({
         path: \`/pets/\${id}\`,
         method: "GET",
@@ -71630,9 +75366,21 @@ export interface AuthUser {
 
 export type DeleteJobData = any;
 
+export interface DeleteJobParams {
+  id: string;
+}
+
 export type DeleteUserData = any;
 
+export interface DeleteUserParams {
+  id: string;
+}
+
 export type GetJobData = Job;
+
+export interface GetJobParams {
+  id: string;
+}
 
 export type GetJobsData = Job[];
 
@@ -71729,9 +75477,21 @@ export type RefreshData = string;
 
 export type UpdateJobData = UpdatedJob;
 
+export interface UpdateJobParams {
+  id: string;
+}
+
 export type UpdateProjectData = UpdatedProject;
 
+export interface UpdateProjectParams {
+  id: string;
+}
+
 export type UpdateUserData = User;
+
+export interface UpdateUserParams {
+  id: string;
+}
 
 export type UpdatedJob = Job;
 
@@ -72344,7 +76104,10 @@ export class Api<
      * @request DELETE:/jobs/{id}
      * @secure
      */
-    deleteJob: (id: string, params: RequestParams = {}) =>
+    deleteJob: (
+      { id, ...query }: DeleteJobParams,
+      params: RequestParams = {},
+    ) =>
       this.request<DeleteJobData, any>({
         path: \`/jobs/\${id}\`,
         method: "DELETE",
@@ -72361,7 +76124,7 @@ export class Api<
      * @request GET:/jobs/{id}
      * @secure
      */
-    getJob: (id: string, params: RequestParams = {}) =>
+    getJob: ({ id, ...query }: GetJobParams, params: RequestParams = {}) =>
       this.request<GetJobData, void>({
         path: \`/jobs/\${id}\`,
         method: "GET",
@@ -72395,7 +76158,11 @@ export class Api<
      * @request PATCH:/jobs/{id}
      * @secure
      */
-    updateJob: (id: string, data: JobUpdate, params: RequestParams = {}) =>
+    updateJob: (
+      { id, ...query }: UpdateJobParams,
+      data: JobUpdate,
+      params: RequestParams = {},
+    ) =>
       this.request<UpdateJobData, any>({
         path: \`/jobs/\${id}\`,
         method: "PATCH",
@@ -72487,7 +76254,7 @@ export class Api<
      * @secure
      */
     updateProject: (
-      id: string,
+      { id, ...query }: UpdateProjectParams,
       data: ProjectUpdate,
       params: RequestParams = {},
     ) =>
@@ -72529,7 +76296,10 @@ export class Api<
      * @request DELETE:/users/{id}
      * @secure
      */
-    deleteUser: (id: string, params: RequestParams = {}) =>
+    deleteUser: (
+      { id, ...query }: DeleteUserParams,
+      params: RequestParams = {},
+    ) =>
       this.request<DeleteUserData, any>({
         path: \`/users/\${id}\`,
         method: "DELETE",
@@ -72563,7 +76333,11 @@ export class Api<
      * @request PATCH:/users/{id}
      * @secure
      */
-    updateUser: (id: string, data: UserUpdate, params: RequestParams = {}) =>
+    updateUser: (
+      { id, ...query }: UpdateUserParams,
+      data: UserUpdate,
+      params: RequestParams = {},
+    ) =>
       this.request<UpdateUserData, any>({
         path: \`/users/\${id}\`,
         method: "PATCH",
@@ -73322,6 +77096,14 @@ export enum AccountTypeEnum {
 
 export type AccountsDetailData = GetAccountResponse;
 
+export interface AccountsDetailParams {
+  /**
+   * The unique identifier for the account.
+   * @example "9842e43e-a1f9-4460-a252-364c86df2d3e"
+   */
+  id: string;
+}
+
 export type AccountsListData = ListAccountsResponse;
 
 export interface AccountsListParams {
@@ -73344,6 +77126,14 @@ export interface CashbackObject {
 }
 
 export type CategoriesDetailData = GetCategoryResponse;
+
+export interface CategoriesDetailParams {
+  /**
+   * The unique identifier for the category.
+   * @example "restaurants-and-cafes"
+   */
+  id: string;
+}
 
 export type CategoriesListData = ListCategoriesResponse;
 
@@ -73658,6 +77448,14 @@ export interface MoneyObject {
 
 export type PingCreateData = WebhookEventCallback;
 
+export interface PingCreateParams {
+  /**
+   * The unique identifier for the webhook.
+   * @example "6ef4bb23-53f1-4a3d-aa5c-a6e9121c5da3"
+   */
+  webhookId: string;
+}
+
 export type PingListData = PingResponse;
 
 export type PingListError = ErrorResponse;
@@ -73674,7 +77472,23 @@ export interface PingResponse {
 
 export type RelationshipsTagsCreateData = any;
 
+export interface RelationshipsTagsCreateParams {
+  /**
+   * The unique identifier for the transaction.
+   * @example "d024c1b8-bc6a-4785-afc6-cd332d2a2efb"
+   */
+  transactionId: string;
+}
+
 export type RelationshipsTagsDeleteData = any;
+
+export interface RelationshipsTagsDeleteParams {
+  /**
+   * The unique identifier for the transaction.
+   * @example "d8c190d6-be35-4d64-b2c4-e1aa0c09a0e0"
+   */
+  transactionId: string;
+}
 
 /**
  * Provides information about how a Round Up was applied, such as whether or
@@ -73877,6 +77691,14 @@ export enum TransactionStatusEnum {
 }
 
 export type TransactionsDetailData = GetTransactionResponse;
+
+export interface TransactionsDetailParams {
+  /**
+   * The unique identifier for the transaction.
+   * @example "8e1da97e-6490-42eb-9c18-d8fdd94cfddc"
+   */
+  id: string;
+}
 
 export type TransactionsListData = ListTransactionsResponse;
 
@@ -74187,7 +78009,23 @@ export type WebhooksCreateData = CreateWebhookResponse;
 
 export type WebhooksDeleteData = any;
 
+export interface WebhooksDeleteParams {
+  /**
+   * The unique identifier for the webhook.
+   * @example "81f485ae-0e10-493d-95f3-a9c1dd4b6b6a"
+   */
+  id: string;
+}
+
 export type WebhooksDetailData = GetWebhookResponse;
+
+export interface WebhooksDetailParams {
+  /**
+   * The unique identifier for the webhook.
+   * @example "bc11e3ed-362e-43ab-b141-ef4f6251faa5"
+   */
+  id: string;
+}
 
 export type WebhooksListData = ListWebhooksResponse;
 
@@ -74943,7 +78781,10 @@ export class Api<
      * @request GET:/accounts/{id}
      * @secure
      */
-    accountsDetail: (id: string, params: RequestParams = {}) =>
+    accountsDetail: (
+      { id, ...query }: AccountsDetailParams,
+      params: RequestParams = {},
+    ) =>
       this.request<AccountsDetailData, any>({
         path: \`/accounts/\${id}\`,
         method: "GET",
@@ -75003,7 +78844,10 @@ export class Api<
      * @request GET:/categories/{id}
      * @secure
      */
-    categoriesDetail: (id: string, params: RequestParams = {}) =>
+    categoriesDetail: (
+      { id, ...query }: CategoriesDetailParams,
+      params: RequestParams = {},
+    ) =>
       this.request<CategoriesDetailData, any>({
         path: \`/categories/\${id}\`,
         method: "GET",
@@ -75081,7 +78925,7 @@ export class Api<
      * @secure
      */
     relationshipsTagsCreate: (
-      transactionId: string,
+      { transactionId, ...query }: RelationshipsTagsCreateParams,
       data: UpdateTransactionTagsRequest,
       params: RequestParams = {},
     ) =>
@@ -75104,7 +78948,7 @@ export class Api<
      * @secure
      */
     relationshipsTagsDelete: (
-      transactionId: string,
+      { transactionId, ...query }: RelationshipsTagsDeleteParams,
       data: UpdateTransactionTagsRequest,
       params: RequestParams = {},
     ) =>
@@ -75126,7 +78970,10 @@ export class Api<
      * @request GET:/transactions/{id}
      * @secure
      */
-    transactionsDetail: (id: string, params: RequestParams = {}) =>
+    transactionsDetail: (
+      { id, ...query }: TransactionsDetailParams,
+      params: RequestParams = {},
+    ) =>
       this.request<TransactionsDetailData, any>({
         path: \`/transactions/\${id}\`,
         method: "GET",
@@ -75189,7 +79036,10 @@ export class Api<
      * @request POST:/webhooks/{webhookId}/ping
      * @secure
      */
-    pingCreate: (webhookId: string, params: RequestParams = {}) =>
+    pingCreate: (
+      { webhookId, ...query }: PingCreateParams,
+      params: RequestParams = {},
+    ) =>
       this.request<PingCreateData, any>({
         path: \`/webhooks/\${webhookId}/ping\`,
         method: "POST",
@@ -75227,7 +79077,10 @@ export class Api<
      * @request DELETE:/webhooks/{id}
      * @secure
      */
-    webhooksDelete: (id: string, params: RequestParams = {}) =>
+    webhooksDelete: (
+      { id, ...query }: WebhooksDeleteParams,
+      params: RequestParams = {},
+    ) =>
       this.request<WebhooksDeleteData, any>({
         path: \`/webhooks/\${id}\`,
         method: "DELETE",
@@ -75244,7 +79097,10 @@ export class Api<
      * @request GET:/webhooks/{id}
      * @secure
      */
-    webhooksDetail: (id: string, params: RequestParams = {}) =>
+    webhooksDetail: (
+      { id, ...query }: WebhooksDetailParams,
+      params: RequestParams = {},
+    ) =>
       this.request<WebhooksDetailData, any>({
         path: \`/webhooks/\${id}\`,
         method: "GET",
@@ -75315,7 +79171,33 @@ export type ListSearchableFieldsData = string;
 
 export type ListSearchableFieldsError = string;
 
+export interface ListSearchableFieldsParams {
+  /**
+   * Name of the dataset.
+   * @example "oa_citations"
+   */
+  dataset: string;
+  /**
+   * Version of the dataset.
+   * @example "v1"
+   */
+  version: string;
+}
+
 export type PerformSearchData = Record<string, object>[];
+
+export interface PerformSearchParams {
+  /**
+   * Name of the dataset. In this case, the default value is oa_citations
+   * @default "oa_citations"
+   */
+  dataset: string;
+  /**
+   * Version of the dataset.
+   * @default "v1"
+   */
+  version: string;
+}
 
 export interface PerformSearchPayload {
   /**
@@ -75692,8 +79574,7 @@ export class Api<
      * @request GET:/{dataset}/{version}/fields
      */
     listSearchableFields: (
-      dataset: string,
-      version: string,
+      { dataset, version, ...query }: ListSearchableFieldsParams,
       params: RequestParams = {},
     ) =>
       this.request<ListSearchableFieldsData, ListSearchableFieldsError>({
@@ -75712,8 +79593,7 @@ export class Api<
      * @request POST:/{dataset}/{version}/records
      */
     performSearch: (
-      version: string,
-      dataset: string,
+      { version, dataset, ...query }: PerformSearchParams,
       data: PerformSearchPayload,
       params: RequestParams = {},
     ) =>
@@ -76038,6 +79918,12 @@ export type DF = string;
 
 export type GetPullRequestsByIdData = Type404;
 
+export interface GetPullRequestsByIdParams {
+  pid: string;
+  slug: string;
+  username: string;
+}
+
 export type GetPullRequestsByRepositoryData = any[];
 
 export interface GetPullRequestsByRepositoryParams {
@@ -76054,11 +79940,30 @@ export enum GetPullRequestsByRepositoryParams1StateEnum {
 
 export type GetRepositoriesByOwnerData = any[];
 
+export interface GetRepositoriesByOwnerParams {
+  username: string;
+}
+
 export type GetRepositoryData = any;
+
+export interface GetRepositoryParams {
+  slug: string;
+  username: string;
+}
 
 export type GetUserByNameData = any;
 
+export interface GetUserByNameParams {
+  username: string;
+}
+
 export type MergePullRequestData = any;
+
+export interface MergePullRequestParams {
+  pid: string;
+  slug: string;
+  username: string;
+}
 
 export enum StateEnum {
   Open = "open",
@@ -76453,9 +80358,7 @@ export class Api<
      * @request GET:/2.0/repositories/{username}/{slug}/pullrequests/{pid}
      */
     getPullRequestsById: (
-      username: string,
-      slug: string,
-      pid: string,
+      { username, slug, pid, ...query }: GetPullRequestsByIdParams,
       params: RequestParams = {},
     ) =>
       this.request<GetPullRequestsByIdData, any>({
@@ -76489,7 +80392,10 @@ export class Api<
      * @name GetRepositoriesByOwner
      * @request GET:/2.0/repositories/{username}
      */
-    getRepositoriesByOwner: (username: string, params: RequestParams = {}) =>
+    getRepositoriesByOwner: (
+      { username, ...query }: GetRepositoriesByOwnerParams,
+      params: RequestParams = {},
+    ) =>
       this.request<GetRepositoriesByOwnerData, any>({
         path: \`/2.0/repositories/\${username}\`,
         method: "GET",
@@ -76504,8 +80410,7 @@ export class Api<
      * @request GET:/2.0/repositories/{username}/{slug}
      */
     getRepository: (
-      username: string,
-      slug: string,
+      { username, slug, ...query }: GetRepositoryParams,
       params: RequestParams = {},
     ) =>
       this.request<GetRepositoryData, any>({
@@ -76521,7 +80426,10 @@ export class Api<
      * @name GetUserByName
      * @request GET:/2.0/users/{username}
      */
-    getUserByName: (username: string, params: RequestParams = {}) =>
+    getUserByName: (
+      { username, ...query }: GetUserByNameParams,
+      params: RequestParams = {},
+    ) =>
       this.request<GetUserByNameData, any>({
         path: \`/2.0/users/\${username}\`,
         method: "GET",
@@ -76536,9 +80444,7 @@ export class Api<
      * @request POST:/2.0/repositories/{username}/{slug}/pullrequests/{pid}/merge
      */
     mergePullRequest: (
-      username: string,
-      slug: string,
-      pid: string,
+      { username, slug, pid, ...query }: MergePullRequestParams,
       params: RequestParams = {},
     ) =>
       this.request<MergePullRequestData, any>({

--- a/tests/spec/extractRequestParams/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/extractRequestParams/__snapshots__/basic.test.ts.snap
@@ -78,6 +78,36 @@ export interface KeyRevoke2Params {
   pk: string;
 }
 
+export interface GetKeyParams {
+  /** Public Signing Key - Authentiq ID (43 chars) */
+  pk: string;
+}
+
+export interface HeadKeyParams {
+  /** Public Signing Key - Authentiq ID (43 chars) */
+  pk: string;
+}
+
+export interface KeyUpdateParams {
+  /** Public Signing Key - Authentiq ID (43 chars) */
+  pk: string;
+}
+
+export interface KeyBindParams {
+  /** Public Signing Key - Authentiq ID (43 chars) */
+  pk: string;
+}
+
+export interface IKeyDetailParams {
+  /** Public Signing Key - Authentiq ID (43 chars) */
+  iPk: string;
+}
+
+export interface UnderlinesDetailParams {
+  /** Variable with double __ in it. */
+  iUk: string;
+}
+
 export interface PushLoginRequestParams {
   /** URI App will connect to */
   callback: string;
@@ -86,6 +116,31 @@ export interface PushLoginRequestParams {
 export interface SignRequestParams {
   /** test only mode, using test issuer */
   test?: number;
+}
+
+export interface SignDeleteParams {
+  /** Job ID (20 chars) */
+  job: string;
+}
+
+export interface SignRetrieveParams {
+  /** Job ID (20 chars) */
+  job: string;
+}
+
+export interface SignRetrieveHeadParams {
+  /** Job ID (20 chars) */
+  job: string;
+}
+
+export interface SignConfirmParams {
+  /** Job ID (20 chars) */
+  job: string;
+}
+
+export interface SignUpdateParams {
+  /** Job ID (20 chars) */
+  job: string;
 }
 
 export type QueryParamsType = Record<string | number, any>;
@@ -456,7 +511,7 @@ export class Api<
      * @name GetKey
      * @request GET:/key/{PK}
      */
-    getKey: (pk: string, params: RequestParams = {}) =>
+    getKey: ({ pk, ...query }: GetKeyParams, params: RequestParams = {}) =>
       this.request<
         {
           /** @format date-time */
@@ -480,7 +535,7 @@ export class Api<
      * @name HeadKey
      * @request HEAD:/key/{PK}
      */
-    headKey: (pk: string, params: RequestParams = {}) =>
+    headKey: ({ pk, ...query }: HeadKeyParams, params: RequestParams = {}) =>
       this.request<void, Error>({
         path: \`/key/\${pk}\`,
         method: "HEAD",
@@ -494,7 +549,11 @@ export class Api<
      * @name KeyUpdate
      * @request POST:/key/{PK}
      */
-    keyUpdate: (pk: string, body: AuthentiqID, params: RequestParams = {}) =>
+    keyUpdate: (
+      { pk, ...query }: KeyUpdateParams,
+      body: AuthentiqID,
+      params: RequestParams = {},
+    ) =>
       this.request<
         {
           /** confirmed */
@@ -516,7 +575,11 @@ export class Api<
      * @name KeyBind
      * @request PUT:/key/{PK}
      */
-    keyBind: (pk: string, body: AuthentiqID, params: RequestParams = {}) =>
+    keyBind: (
+      { pk, ...query }: KeyBindParams,
+      body: AuthentiqID,
+      params: RequestParams = {},
+    ) =>
       this.request<
         {
           /** confirmed */
@@ -539,7 +602,10 @@ export class Api<
      * @name IKeyDetail
      * @request GET:/i_key/{i_PK}
      */
-    iKeyDetail: (iPk: string, params: RequestParams = {}) =>
+    iKeyDetail: (
+      { iPk, ...query }: IKeyDetailParams,
+      params: RequestParams = {},
+    ) =>
       this.request<
         {
           /** @format date-time */
@@ -563,7 +629,10 @@ export class Api<
      * @name UnderlinesDetail
      * @request GET:/i_key/underlines/{i__UK}
      */
-    underlinesDetail: (iUk: string, params: RequestParams = {}) =>
+    underlinesDetail: (
+      { iUk, ...query }: UnderlinesDetailParams,
+      params: RequestParams = {},
+    ) =>
       this.request<
         {
           /** base64safe encoded public signing key */
@@ -642,7 +711,10 @@ export class Api<
      * @name SignDelete
      * @request DELETE:/scope/{job}
      */
-    signDelete: (job: string, params: RequestParams = {}) =>
+    signDelete: (
+      { job, ...query }: SignDeleteParams,
+      params: RequestParams = {},
+    ) =>
       this.request<
         {
           /** done */
@@ -663,7 +735,10 @@ export class Api<
      * @name SignRetrieve
      * @request GET:/scope/{job}
      */
-    signRetrieve: (job: string, params: RequestParams = {}) =>
+    signRetrieve: (
+      { job, ...query }: SignRetrieveParams,
+      params: RequestParams = {},
+    ) =>
       this.request<
         {
           exp?: number;
@@ -686,7 +761,10 @@ export class Api<
      * @name SignRetrieveHead
      * @request HEAD:/scope/{job}
      */
-    signRetrieveHead: (job: string, params: RequestParams = {}) =>
+    signRetrieveHead: (
+      { job, ...query }: SignRetrieveHeadParams,
+      params: RequestParams = {},
+    ) =>
       this.request<void, Error>({
         path: \`/scope/\${job}\`,
         method: "HEAD",
@@ -700,7 +778,10 @@ export class Api<
      * @name SignConfirm
      * @request POST:/scope/{job}
      */
-    signConfirm: (job: string, params: RequestParams = {}) =>
+    signConfirm: (
+      { job, ...query }: SignConfirmParams,
+      params: RequestParams = {},
+    ) =>
       this.request<
         {
           /** confirmed */
@@ -722,7 +803,10 @@ export class Api<
      * @name SignUpdate
      * @request PUT:/scope/{job}
      */
-    signUpdate: (job: string, params: RequestParams = {}) =>
+    signUpdate: (
+      { job, ...query }: SignUpdateParams,
+      params: RequestParams = {},
+    ) =>
       this.request<
         {
           /** result is JWT or JSON?? */


### PR DESCRIPTION
## Summary
- support extracting request parameters when an operation only defines path parameters
- update snapshots accordingly

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68b008db0c308327b6a1e19eff065502