### PR TITLE
Automatically extract enums when using enum names as values

### DIFF
--- a/.changeset/four-pears-watch.md
+++ b/.changeset/four-pears-watch.md
@@ -1,0 +1,5 @@
+---
+"swagger-typescript-api": patch
+---
+
+Automatically extract enums when using enum names as values.

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -441,5 +441,8 @@ export class CodeGenConfig {
 
   update = (update: Partial<GenerateApiConfiguration["config"]>) => {
     objectAssign(this, update);
+    if (this.enumNamesAsValues) {
+      this.extractEnums = true;
+    }
   };
 }

--- a/tests/spec/enumNamesAsValues/__snapshots__/inline.test.ts.snap
+++ b/tests/spec/enumNamesAsValues/__snapshots__/inline.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`basic > jsonapi-media-type 1`] = `
+exports[`inline enum > --enum-names-as-values with inline enum 1`] = `
 "/* eslint-disable */
 /* tslint:disable */
 // @ts-nocheck
@@ -14,25 +14,11 @@ exports[`basic > jsonapi-media-type 1`] = `
  */
 
 export interface Pet {
-  /** @format uuid */
-  id?: string;
-  type: PetTypeEnum;
-  attributes: {
-    name: string;
-    status?: PetStatusEnum;
-    photoUrls: string[];
-  };
+  /** pet status in the store */
+  status?: PetStatusEnum;
 }
 
-export interface Error {
-  status?: string;
-  detail?: string;
-}
-
-export enum PetTypeEnum {
-  Pet = "pet",
-}
-
+/** pet status in the store */
 export enum PetStatusEnum {
   Available = "available",
   Pending = "pending",
@@ -92,7 +78,7 @@ export enum ContentType {
 }
 
 export class HttpClient<SecurityDataType = unknown> {
-  public baseUrl: string = "https://api.petstore.localhost";
+  public baseUrl: string = "";
   private securityData: SecurityDataType | null = null;
   private securityWorker?: ApiConfig<SecurityDataType>["securityWorker"];
   private abortControllers = new Map<CancelToken, AbortController>();
@@ -294,73 +280,11 @@ export class HttpClient<SecurityDataType = unknown> {
 }
 
 /**
- * @title JSON:API Swagger Petstore
- * @version 1.1
- * @baseUrl https://api.petstore.localhost
+ * @title Inline enum example
+ * @version 1.0.0
  */
 export class Api<
   SecurityDataType extends unknown,
-> extends HttpClient<SecurityDataType> {
-  pets = {
-    /**
-     * @description Add a new pet to the store.
-     *
-     * @tags pet
-     * @name AddPet
-     * @summary Add a new pet to the store.
-     * @request POST:/pets
-     */
-    addPet: (
-      data: {
-        data: Pet;
-      },
-      params: RequestParams = {},
-    ) =>
-      this.request<
-        {
-          data: Pet;
-        },
-        {
-          errors: Error[];
-        }
-      >({
-        path: \`/pets\`,
-        method: "POST",
-        body: data,
-        type: ContentType.JsonApi,
-        ...params,
-      }),
-
-    /**
-     * @description Update an existing pet by Id.
-     *
-     * @tags pet
-     * @name UpdatePet
-     * @summary Update an existing pet.
-     * @request PATCH:/pets/{petId}
-     */
-    updatePet: (
-      petId: string,
-      data: {
-        data: Pet;
-      },
-      params: RequestParams = {},
-    ) =>
-      this.request<
-        {
-          data: Pet;
-        },
-        {
-          errors: Error[];
-        }
-      >({
-        path: \`/pets/\${petId}\`,
-        method: "PATCH",
-        body: data,
-        type: ContentType.JsonApi,
-        ...params,
-      }),
-  };
-}
+> extends HttpClient<SecurityDataType> {}
 "
 `;

--- a/tests/spec/enumNamesAsValues/inline-schema.json
+++ b/tests/spec/enumNamesAsValues/inline-schema.json
@@ -1,0 +1,19 @@
+{
+  "openapi": "3.0.0",
+  "info": { "title": "Inline enum example", "version": "1.0.0" },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "Pet": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "description": "pet status in the store",
+            "enum": ["available", "pending", "sold"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/spec/enumNamesAsValues/inline.test.ts
+++ b/tests/spec/enumNamesAsValues/inline.test.ts
@@ -1,0 +1,33 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { generateApi } from "../../../src/index.js";
+
+describe("inline enum", async () => {
+  let tmpdir = "";
+
+  beforeAll(async () => {
+    tmpdir = await fs.mkdtemp(path.join(os.tmpdir(), "swagger-typescript-api"));
+  });
+
+  afterAll(async () => {
+    await fs.rm(tmpdir, { recursive: true });
+  });
+
+  test("--enum-names-as-values with inline enum", async () => {
+    await generateApi({
+      fileName: "schema",
+      input: path.resolve(import.meta.dirname, "inline-schema.json"),
+      output: tmpdir,
+      silent: true,
+      enumNamesAsValues: true,
+    });
+
+    const content = await fs.readFile(path.join(tmpdir, "schema.ts"), {
+      encoding: "utf8",
+    });
+
+    expect(content).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
## Summary
- automatically extract inline enums when enum names are used as values
- add coverage for enum names-as-values on inline enums

## Testing
- `yarn lint src/configuration.ts tests/spec/enumNamesAsValues/inline.test.ts tests/spec/enumNamesAsValues/inline-schema.json`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68b018077bc88327b794bb5ce355a6b1