### PR TITLE
fix: SchemaComponentsMap bindings

### DIFF
--- a/.changeset/itchy-owls-beg.md
+++ b/.changeset/itchy-owls-beg.md
@@ -1,0 +1,5 @@
+---
+"swagger-typescript-api": patch
+---
+
+Fix being able to call getComponentByRef from templates

--- a/src/schema-components-map.ts
+++ b/src/schema-components-map.ts
@@ -65,7 +65,7 @@ export class SchemaComponentsMap {
     );
   }
 
-  get($ref: string) {
+  get = ($ref: string) => {
     return this._data.find((c) => c.$ref === $ref) || null;
   }
 

--- a/src/schema-components-map.ts
+++ b/src/schema-components-map.ts
@@ -67,7 +67,7 @@ export class SchemaComponentsMap {
 
   get = ($ref: string) => {
     return this._data.find((c) => c.$ref === $ref) || null;
-  }
+  };
 
   // Ensure enums are at the top of components list
   enumsFirst() {


### PR DESCRIPTION
Inside of an `ejs`, when using
```js
const { getComponentByRef } = utils;

getComponentByRef('XXX')
```

You'll get
```
Cannot read properties of undefined (reading '_data')
```