### PR TITLE
Set discriminators types before other types than enums

### DIFF
--- a/.changeset/slow-vans-win.md
+++ b/.changeset/slow-vans-win.md
@@ -1,0 +1,5 @@
+---
+"swagger-typescript-api": patch
+---
+
+Ensure discriminators are just after enums in components list to avoid cyclic errors

--- a/src/code-gen-process.ts
+++ b/src/code-gen-process.ts
@@ -127,6 +127,9 @@ export class CodeGenProcess {
       }),
     );
 
+    //set all discriminators at the top
+    this.schemaComponentsMap.discriminatorsFirst();
+    // put all enums at the top (before discriminators)
     this.schemaComponentsMap.enumsFirst();
 
     const componentsToParse: SchemaComponent[] =

--- a/src/code-gen-process.ts
+++ b/src/code-gen-process.ts
@@ -127,9 +127,9 @@ export class CodeGenProcess {
       }),
     );
 
-    //set all discriminators at the top
+    // Set all discriminators at the top
     this.schemaComponentsMap.discriminatorsFirst();
-    // put all enums at the top (before discriminators)
+    // Put all enums at the top (before discriminators)
     this.schemaComponentsMap.enumsFirst();
 
     const componentsToParse: SchemaComponent[] =

--- a/src/schema-components-map.ts
+++ b/src/schema-components-map.ts
@@ -77,4 +77,13 @@ export class SchemaComponentsMap {
       return 0;
     });
   }
+
+  // Ensure discriminators are at the top of components list
+  discriminatorsFirst() {
+    this._data.sort((a, b) => {
+      if (Object.keys(a.rawTypeData || {}).includes("discriminator")) return -1;
+      if (Object.keys(b.rawTypeData || {}).includes("discriminator")) return 1;
+      return 0;
+    });
+  }
 }

--- a/tests/spec/discriminator/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/discriminator/__snapshots__/basic.test.ts.snap
@@ -25,106 +25,6 @@ export enum BlockDTOEnum {
   Kek = "kek",
 }
 
-export type SimpleDiscriminator = SimpleObject | ComplexObject;
-
-export interface SimpleObject {
-  objectType: string;
-}
-
-export interface ComplexObject {
-  objectType: string;
-}
-
-export type BlockDTOWithEnum = BaseBlockDtoWithEnum &
-  (
-    | BaseBlockDtoWithEnumTypeMapping<BlockDTOEnum.Csv, CsvBlockWithEnumDTO>
-    | BaseBlockDtoWithEnumTypeMapping<BlockDTOEnum.File, FileBlockWithEnumDTO>
-  );
-
-export type CsvBlockWithEnumDTO = BaseBlockDtoWithEnum & {
-  type: BlockDTOEnum.Csv;
-  text: string;
-};
-
-export type FileBlockWithEnumDTO = BaseBlockDtoWithEnum & {
-  type: BlockDTOEnum.File;
-  fileId: string;
-};
-
-export type BlockDTO = BaseBlockDto &
-  (
-    | BaseBlockDtoTypeMapping<"csv", CsvBlockDTO>
-    | BaseBlockDtoTypeMapping<"file", FileBlockDTO>
-  );
-
-export type CsvBlockDTO = BaseBlockDto & {
-  /** @default "csv" */
-  type: "csv";
-  text: string;
-};
-
-export type FileBlockDTO = BaseBlockDto & {
-  /** @default "file" */
-  type: "file";
-  fileId: string;
-};
-
-export type Pet = BasePet &
-  (
-    | BasePetPetTypeMapping<"dog", Dog>
-    | BasePetPetTypeMapping<"cat", Cat>
-    | BasePetPetTypeMapping<"lizard", Lizard>
-  );
-
-export type PetOnlyDiscriminator =
-  | ({
-      pet_type: "dog";
-    } & Dog)
-  | ({
-      pet_type: "cat";
-    } & Cat)
-  | ({
-      pet_type: "lizard";
-    } & Lizard);
-
-export type Cat = BasePet & {
-  name?: string;
-};
-
-export type Dog = BasePet & {
-  bark?: string;
-};
-
-export type Lizard = BasePet & {
-  lovesRocks?: boolean;
-};
-
-export type PetWithEnum = BasePetWithEnum &
-  (
-    | BasePetWithEnumPetTypeMapping<PetEnum.Dog, DogWithEnum>
-    | BasePetWithEnumPetTypeMapping<PetEnum.Cat, CatWithEnum>
-    | BasePetWithEnumPetTypeMapping<PetEnum.Lizard, LizardWithEnum>
-  );
-
-export type CatWithEnum = BasePetWithEnum & {
-  name?: string;
-};
-
-export type DogWithEnum = BasePetWithEnum & {
-  bark?: string;
-};
-
-export type LizardWithEnum = BasePetWithEnum & {
-  lovesRocks?: boolean;
-};
-
-export type InvalidDiscriminatorPropertyName =
-  BaseInvalidDiscriminatorPropertyName &
-    (
-      | BaseInvalidDiscriminatorPropertyNameTypeMapping<"num", number>
-      | BaseInvalidDiscriminatorPropertyNameTypeMapping<"str", string>
-    );
-
 /** kek pek */
 export type Variant =
   | ({
@@ -148,6 +48,106 @@ export type Variant =
   | ({
       type: "gateway";
     } & VariantGateway);
+
+export type InvalidDiscriminatorPropertyName =
+  BaseInvalidDiscriminatorPropertyName &
+    (
+      | BaseInvalidDiscriminatorPropertyNameTypeMapping<"num", number>
+      | BaseInvalidDiscriminatorPropertyNameTypeMapping<"str", string>
+    );
+
+export type PetWithEnum = BasePetWithEnum &
+  (
+    | BasePetWithEnumPetTypeMapping<PetEnum.Dog, DogWithEnum>
+    | BasePetWithEnumPetTypeMapping<PetEnum.Cat, CatWithEnum>
+    | BasePetWithEnumPetTypeMapping<PetEnum.Lizard, LizardWithEnum>
+  );
+
+export type PetOnlyDiscriminator =
+  | ({
+      pet_type: "dog";
+    } & Dog)
+  | ({
+      pet_type: "cat";
+    } & Cat)
+  | ({
+      pet_type: "lizard";
+    } & Lizard);
+
+export type Pet = BasePet &
+  (
+    | BasePetPetTypeMapping<"dog", Dog>
+    | BasePetPetTypeMapping<"cat", Cat>
+    | BasePetPetTypeMapping<"lizard", Lizard>
+  );
+
+export type BlockDTO = BaseBlockDto &
+  (
+    | BaseBlockDtoTypeMapping<"csv", CsvBlockDTO>
+    | BaseBlockDtoTypeMapping<"file", FileBlockDTO>
+  );
+
+export type BlockDTOWithEnum = BaseBlockDtoWithEnum &
+  (
+    | BaseBlockDtoWithEnumTypeMapping<BlockDTOEnum.Csv, CsvBlockWithEnumDTO>
+    | BaseBlockDtoWithEnumTypeMapping<BlockDTOEnum.File, FileBlockWithEnumDTO>
+  );
+
+export type SimpleDiscriminator = SimpleObject | ComplexObject;
+
+export interface SimpleObject {
+  objectType: string;
+}
+
+export interface ComplexObject {
+  objectType: string;
+}
+
+export type CsvBlockWithEnumDTO = BaseBlockDtoWithEnum & {
+  type: BlockDTOEnum.Csv;
+  text: string;
+};
+
+export type FileBlockWithEnumDTO = BaseBlockDtoWithEnum & {
+  type: BlockDTOEnum.File;
+  fileId: string;
+};
+
+export type CsvBlockDTO = BaseBlockDto & {
+  /** @default "csv" */
+  type: "csv";
+  text: string;
+};
+
+export type FileBlockDTO = BaseBlockDto & {
+  /** @default "file" */
+  type: "file";
+  fileId: string;
+};
+
+export type Cat = BasePet & {
+  name?: string;
+};
+
+export type Dog = BasePet & {
+  bark?: string;
+};
+
+export type Lizard = BasePet & {
+  lovesRocks?: boolean;
+};
+
+export type CatWithEnum = BasePetWithEnum & {
+  name?: string;
+};
+
+export type DogWithEnum = BasePetWithEnum & {
+  bark?: string;
+};
+
+export type LizardWithEnum = BasePetWithEnum & {
+  lovesRocks?: boolean;
+};
 
 /** Proposal to change firewall rules for deployment. */
 export interface VariantFirewall {
@@ -196,29 +196,10 @@ export interface VariantRollback {
 /** asdasdasdasdasdn */
 export type VariantUndo = object;
 
-interface BaseBlockDtoWithEnum {
-  title: string;
-  type: BlockDTOEnum;
-}
+type BaseInvalidDiscriminatorPropertyName = object;
 
-type BaseBlockDtoWithEnumTypeMapping<Key, Type> = {
-  type: Key;
-} & Type;
-
-interface BaseBlockDto {
-  title: string;
-}
-
-type BaseBlockDtoTypeMapping<Key, Type> = {
-  type: Key;
-} & Type;
-
-interface BasePet {
-  pet_type: string;
-}
-
-type BasePetPetTypeMapping<Key, Type> = {
-  pet_type: Key;
+type BaseInvalidDiscriminatorPropertyNameTypeMapping<Key, Type> = {
+  "@type": Key;
 } & Type;
 
 interface BasePetWithEnum {
@@ -229,10 +210,29 @@ type BasePetWithEnumPetTypeMapping<Key, Type> = {
   pet_type: Key;
 } & Type;
 
-type BaseInvalidDiscriminatorPropertyName = object;
+interface BasePet {
+  pet_type: string;
+}
 
-type BaseInvalidDiscriminatorPropertyNameTypeMapping<Key, Type> = {
-  "@type": Key;
+type BasePetPetTypeMapping<Key, Type> = {
+  pet_type: Key;
+} & Type;
+
+interface BaseBlockDto {
+  title: string;
+}
+
+type BaseBlockDtoTypeMapping<Key, Type> = {
+  type: Key;
+} & Type;
+
+interface BaseBlockDtoWithEnum {
+  title: string;
+  type: BlockDTOEnum;
+}
+
+type BaseBlockDtoWithEnumTypeMapping<Key, Type> = {
+  type: Key;
 } & Type;
 "
 `;

--- a/tests/spec/enumNotFirstInComponents/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/enumNotFirstInComponents/__snapshots__/basic.test.ts.snap
@@ -18,6 +18,12 @@ export enum ExampleEnum {
   Example2 = "Example2",
 }
 
+export type ExampleObject = BaseExampleObject &
+  (
+    | BaseExampleObjectTypeMapping<ExampleEnum.Example1, DtoExample1>
+    | BaseExampleObjectTypeMapping<ExampleEnum.Example2, DtoExample2>
+  );
+
 export interface DtoExample1 {
   name: string;
   age: number;
@@ -28,12 +34,6 @@ export interface DtoExample2 {
   title: string;
   description: string;
 }
-
-export type ExampleObject = BaseExampleObject &
-  (
-    | BaseExampleObjectTypeMapping<ExampleEnum.Example1, DtoExample1>
-    | BaseExampleObjectTypeMapping<ExampleEnum.Example2, DtoExample2>
-  );
 
 interface BaseExampleObject {
   type?: ExampleEnum;


### PR DESCRIPTION
The goal of this merge request is to ensure discriminators are at the (not so) very first place in generation, just after enums.
If they're not, that will cause cyclic errors in typescript. 