### PR TITLE
Replace `js-yaml` with `yaml`

### DIFF
--- a/.changeset/switch-to-yaml-parser.md
+++ b/.changeset/switch-to-yaml-parser.md
@@ -1,0 +1,9 @@
+---
+"swagger-typescript-api": patch
+---
+
+Replace `js-yaml` with `yaml`
+
+Switch YAML parsing from `js-yaml` to `yaml`. Update the resolver to
+use `YAML.parse` when `JSON.parse` fails. Remove `js-yaml` and its types,
+add `yaml` as a runtime dependency. No public API changes.

--- a/package.json
+++ b/package.json
@@ -55,13 +55,13 @@
     "citty": "^0.1.6",
     "consola": "^3.4.2",
     "eta": "^4.0.1",
-    "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",
     "nanoid": "^5.1.5",
     "openapi-types": "^12.1.3",
     "swagger-schema-official": "2.0.0-bab6bed",
     "swagger2openapi": "^7.0.8",
-    "typescript": "~5.9.2"
+    "typescript": "~5.9.2",
+    "yaml": "^2.8.1"
   },
   "devDependencies": {
     "@biomejs/biome": "2.2.4",
@@ -69,7 +69,6 @@
     "@changesets/cli": "2.29.7",
     "@tsconfig/node20": "20.1.6",
     "@tsconfig/strictest": "2.0.5",
-    "@types/js-yaml": "4.0.9",
     "@types/node": "24.5.2",
     "@types/swagger2openapi": "7.0.4",
     "axios": "1.12.2",

--- a/src/swagger-schema-resolver.ts
+++ b/src/swagger-schema-resolver.ts
@@ -1,8 +1,8 @@
 import { consola } from "consola";
-import * as yaml from "js-yaml";
 import lodash from "lodash";
 import type { OpenAPI, OpenAPIV2 } from "openapi-types";
 import * as swagger2openapi from "swagger2openapi";
+import * as YAML from "yaml";
 import type { CodeGenConfig } from "./configuration.js";
 import type { FileSystem } from "./util/file-system.js";
 import { Request } from "./util/request.js";
@@ -114,8 +114,8 @@ export class SwaggerSchemaResolver {
 
     try {
       return JSON.parse(file);
-    } catch (e) {
-      return yaml.load(file);
+    } catch {
+      return YAML.parse(file);
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1196,13 +1196,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/js-yaml@npm:4.0.9":
-  version: 4.0.9
-  resolution: "@types/js-yaml@npm:4.0.9"
-  checksum: 10c0/24de857aa8d61526bbfbbaa383aa538283ad17363fcd5bb5148e2c7f604547db36646440e739d78241ed008702a8920665d1add5618687b6743858fae00da211
-  languageName: node
-  linkType: hard
-
 "@types/lodash@npm:^4.17.20":
   version: 4.17.20
   resolution: "@types/lodash@npm:4.17.20"
@@ -2531,17 +2524,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "js-yaml@npm:4.1.0"
-  dependencies:
-    argparse: "npm:^2.0.1"
-  bin:
-    js-yaml: bin/js-yaml.js
-  checksum: 10c0/184a24b4eaacfce40ad9074c64fd42ac83cf74d8c8cd137718d456ced75051229e5061b8633c3366b8aada17945a7a356b337828c19da92b51ae62126575018f
-  languageName: node
-  linkType: hard
-
 "jsesc@npm:^3.0.2":
   version: 3.1.0
   resolution: "jsesc@npm:3.1.0"
@@ -3296,15 +3278,15 @@ __metadata:
   linkType: hard
 
 "rolldown-plugin-dts@npm:^0.16.5":
-  version: 0.16.5
-  resolution: "rolldown-plugin-dts@npm:0.16.5"
+  version: 0.16.6
+  resolution: "rolldown-plugin-dts@npm:0.16.6"
   dependencies:
     "@babel/generator": "npm:^7.28.3"
     "@babel/parser": "npm:^7.28.4"
     "@babel/types": "npm:^7.28.4"
     ast-kit: "npm:^2.1.2"
     birpc: "npm:^2.5.0"
-    debug: "npm:^4.4.1"
+    debug: "npm:^4.4.3"
     dts-resolver: "npm:^2.1.2"
     get-tsconfig: "npm:^4.10.1"
     magic-string: "npm:^0.30.19"
@@ -3323,7 +3305,7 @@ __metadata:
       optional: true
     vue-tsc:
       optional: true
-  checksum: 10c0/f15ba5ef752cb56db9289d71d62f371a06a04159d266efd7d19f7ff4a961730f4a2367f4f80d59322fbf6d2f3d5c7b36a2f3412c36e2cc49101976f5720939c8
+  checksum: 10c0/e13005cc3e70f99755ec176ceed5657b20fa8872e66943a9d7284a371d7536adff9513192273910e95ca149bcc6921987e01f0970f85b848b5eb48f29e0c0965
   languageName: node
   linkType: hard
 
@@ -3728,7 +3710,6 @@ __metadata:
     "@changesets/cli": "npm:2.29.7"
     "@tsconfig/node20": "npm:20.1.6"
     "@tsconfig/strictest": "npm:2.0.5"
-    "@types/js-yaml": "npm:4.0.9"
     "@types/lodash": "npm:^4.17.20"
     "@types/node": "npm:24.5.2"
     "@types/swagger-schema-official": "npm:^2.0.25"
@@ -3738,7 +3719,6 @@ __metadata:
     citty: "npm:^0.1.6"
     consola: "npm:^3.4.2"
     eta: "npm:^4.0.1"
-    js-yaml: "npm:^4.1.0"
     lodash: "npm:^4.17.21"
     nanoid: "npm:^5.1.5"
     openapi-types: "npm:^12.1.3"
@@ -3748,6 +3728,7 @@ __metadata:
     typedoc: "npm:0.28.13"
     typescript: "npm:~5.9.2"
     vitest: "npm:3.2.4"
+    yaml: "npm:^2.8.1"
   bin:
     sta: ./dist/cli.js
     swagger-typescript-api: ./dist/cli.js
@@ -3844,9 +3825,9 @@ __metadata:
   linkType: hard
 
 "tinyspy@npm:^4.0.3":
-  version: 4.0.3
-  resolution: "tinyspy@npm:4.0.3"
-  checksum: 10c0/0a92a18b5350945cc8a1da3a22c9ad9f4e2945df80aaa0c43e1b3a3cfb64d8501e607ebf0305e048e3c3d3e0e7f8eb10cea27dc17c21effb73e66c4a3be36373
+  version: 4.0.4
+  resolution: "tinyspy@npm:4.0.4"
+  checksum: 10c0/a8020fc17799251e06a8398dcc352601d2770aa91c556b9531ecd7a12581161fd1c14e81cbdaff0c1306c93bfdde8ff6d1c1a3f9bbe6d91604f0fd4e01e2f1eb
   languageName: node
   linkType: hard
 
@@ -4027,8 +4008,8 @@ __metadata:
   linkType: hard
 
 "vite@npm:^5.0.0 || ^6.0.0 || ^7.0.0-0":
-  version: 7.1.5
-  resolution: "vite@npm:7.1.5"
+  version: 7.1.6
+  resolution: "vite@npm:7.1.6"
   dependencies:
     esbuild: "npm:^0.25.0"
     fdir: "npm:^6.5.0"
@@ -4077,7 +4058,7 @@ __metadata:
       optional: true
   bin:
     vite: bin/vite.js
-  checksum: 10c0/782d2f20c25541b26d1fb39bef5f194149caff39dc25b7836e25f049ca919f2e2ce186bddb21f3f20f6195354b3579ec637a8ca08d65b117f8b6f81e3e730a9c
+  checksum: 10c0/2cd8baec0054956dae61289dd1497109c762cfc27ec6f6b88f39a15d5ddc7e0cc4559b72fbdd701b296c739d2f734d051c28e365539462fb92f83b5e7908f9de
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Switch YAML parsing from `js-yaml` to `yaml`. Update the resolver to use `YAML.parse` when `JSON.parse` fails. Remove `js-yaml` and its types, add `yaml` as a runtime dependency. No public API changes.