### PR TITLE
Fix for Useless conditional

### DIFF
--- a/src/schema-routes/schema-routes.ts
+++ b/src/schema-routes/schema-routes.ts
@@ -241,9 +241,7 @@ export class SchemaRoutes {
         routeParam.name = lodash.camelCase(routeParam.name);
       }
 
-      if (routeParam) {
-        routeParams[routeParam.in].push(routeParam);
-      }
+      routeParams[routeParam.in].push(routeParam);
     });
 
     // used in case when path parameters is not declared in requestInfo.parameters ("in": "path")


### PR DESCRIPTION
To fix the flagged issue, we should remove the redundant `if (routeParam)` condition. The push to the appropriate array should happen directly, as we know that, for all code paths that reach this point, `routeParam` is assigned a non-null object. Remove the `if (routeParam)` guard and directly push `routeParam` to its array. Only one code region needs editing: lines 244–246 (inside the lodash.each callback).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Always push `routeParam` into `routeParams[routeParam.in]` in `getRouteParams`, removing the unnecessary `if (routeParam)` guard.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 859da6a2dc2ba7529806a3a2d7a6b2cd698580d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->