### PR TITLE
Add type annotations to schema parser chain

### DIFF
--- a/src/schema-parser/base-schema-parsers/enum.ts
+++ b/src/schema-parser/base-schema-parsers/enum.ts
@@ -6,8 +6,7 @@ import { EnumKeyResolver } from "../util/enum-key-resolver.js";
 export class EnumSchemaParser extends MonoSchemaParser {
   enumKeyResolver: EnumKeyResolver;
 
-  constructor(...args) {
-    // @ts-expect-error TS(2556) FIXME: A spread argument must either have a tuple type or... Remove this comment to see the full error message
+  constructor(...args: ConstructorParameters<typeof MonoSchemaParser>) {
     super(...args);
     this.enumKeyResolver = new EnumKeyResolver(this.config, []);
   }
@@ -129,7 +128,6 @@ export class EnumSchemaParser extends MonoSchemaParser {
     } else {
       content = this.schema.enum.map((value, index) => {
         return {
-          // @ts-expect-error TS(2345) FIXME: Argument of type '{ value: any; }' is not assignab... Remove this comment to see the full error message
           key: this.formatEnumKey({ value }),
           type: keyType,
           value: formatValue(value),
@@ -157,7 +155,7 @@ export class EnumSchemaParser extends MonoSchemaParser {
     };
   }
 
-  formatEnumKey = ({ key, value }) => {
+  formatEnumKey = ({ key, value }: { key?: string; value: unknown }) => {
     let formatted: string | undefined;
 
     if (key) {

--- a/src/schema-parser/base-schema-parsers/object.ts
+++ b/src/schema-parser/base-schema-parsers/object.ts
@@ -91,7 +91,7 @@ export class ObjectSchemaParser extends MonoSchemaParser {
     if (additionalProperties) {
       const propertyNamesSchema =
         this.schemaUtils.getSchemaPropertyNamesSchema(schema);
-      let interfaceKeysContent: any;
+      let interfaceKeysContent: string;
 
       if (propertyNamesSchema) {
         interfaceKeysContent = this.schemaParserFabric

--- a/src/schema-parser/base-schema-parsers/primitive.ts
+++ b/src/schema-parser/base-schema-parsers/primitive.ts
@@ -12,8 +12,8 @@ export class PrimitiveSchemaParser extends MonoSchemaParser {
         this.schema,
       );
 
-      let recordKeysContent: any;
-      let recordValuesContent: any;
+      let recordKeysContent: string;
+      let recordValuesContent: string;
 
       if (propertyNamesSchema) {
         recordKeysContent = this.schemaParserFabric

--- a/src/schema-parser/mono-schema-parser.ts
+++ b/src/schema-parser/mono-schema-parser.ts
@@ -6,10 +6,18 @@ import type { SchemaParser } from "./schema-parser.js";
 import type { SchemaParserFabric } from "./schema-parser-fabric.js";
 import type { SchemaUtils } from "./schema-utils.js";
 
+export interface SchemaParserConfig {
+  typeName?: string | null;
+  // biome-ignore lint/suspicious/noExplicitAny: TODO: narrow to OpenAPI schema type
+  schema?: any;
+  schemaPath?: string[];
+}
+
 export class MonoSchemaParser {
-  schema;
-  typeName;
-  schemaPath;
+  // biome-ignore lint/suspicious/noExplicitAny: TODO: narrow to OpenAPI schema type
+  schema: any;
+  typeName: string | null;
+  schemaPath: string[];
 
   schemaParser: SchemaParser;
   schemaParserFabric: SchemaParserFabric;
@@ -21,9 +29,9 @@ export class MonoSchemaParser {
 
   constructor(
     schemaParser: SchemaParser,
-    schema,
-    typeName = null,
-    schemaPath = [],
+    schema: unknown,
+    typeName: string | null = null,
+    schemaPath: string[] = [],
   ) {
     this.schemaParser = schemaParser;
     this.schemaParserFabric = schemaParser.schemaParserFabric;

--- a/src/schema-parser/schema-parser-fabric.ts
+++ b/src/schema-parser/schema-parser-fabric.ts
@@ -10,6 +10,7 @@ import type { SchemaComponentsMap } from "../schema-components-map.js";
 import type { SchemaWalker } from "../schema-walker.js";
 import type { TemplatesWorker } from "../templates-worker.js";
 import type { TypeNameFormatter } from "../type-name-formatter.js";
+import type { SchemaParserConfig } from "./mono-schema-parser.js";
 import { SchemaFormatters } from "./schema-formatters.js";
 import { SchemaParser } from "./schema-parser.js";
 import { SchemaUtils } from "./schema-utils.js";
@@ -39,7 +40,11 @@ export class SchemaParserFabric {
     this.schemaFormatters = new SchemaFormatters(this);
   }
 
-  createSchemaParser = ({ schema, typeName, schemaPath }) => {
+  createSchemaParser = ({
+    schema,
+    typeName,
+    schemaPath,
+  }: SchemaParserConfig) => {
     return new SchemaParser(this, { schema, typeName, schemaPath });
   };
 
@@ -49,8 +54,13 @@ export class SchemaParserFabric {
     linkedComponent,
     schemaPath,
     ...otherSchemaProps
+  }: {
+    content: unknown;
+    linkedSchema?: Record<string, unknown>;
+    linkedComponent?: SchemaComponent;
+    schemaPath?: string[];
+    [key: string]: unknown;
   }) => {
-    // @ts-expect-error TS(2345) FIXME: Argument of type '{ schema: any; schemaPath: any; ... Remove this comment to see the full error message
     const parser = this.createSchemaParser({
       schema: linkedComponent || linkedSchema,
       schemaPath,
@@ -68,7 +78,7 @@ export class SchemaParserFabric {
     typeName,
     schema,
     schemaPath,
-  }): SchemaComponent => {
+  }: Required<SchemaParserConfig> & { typeName: string }): SchemaComponent => {
     const schemaCopy = structuredClone(schema);
     const customComponent = this.schemaComponentsMap.createComponent(
       this.schemaComponentsMap.createRef(["components", "schemas", typeName]),
@@ -83,7 +93,7 @@ export class SchemaParserFabric {
   };
 
   parseSchema = (
-    schema: string,
+    schema: SchemaParserConfig["schema"],
     typeName: string | null = null,
     schemaPath: string[] = [],
   ): ParsedSchema<
@@ -98,19 +108,21 @@ export class SchemaParserFabric {
   };
 
   getInlineParseContent = (
-    schema: string,
+    schema: SchemaParserConfig["schema"],
     typeName: string | null,
     schemaPath: string[],
-  ): Record<string, any> => {
+  ): // biome-ignore lint/suspicious/noExplicitAny: TODO: narrow return type
+  Record<string, any> => {
     const parser = this.createSchemaParser({ schema, typeName, schemaPath });
     return parser.getInlineParseContent();
   };
 
   getParseContent = (
-    schema: string,
+    schema: SchemaParserConfig["schema"],
     typeName: string | null,
     schemaPath: string[],
-  ): Record<string, any> => {
+  ): // biome-ignore lint/suspicious/noExplicitAny: TODO: narrow return type
+  Record<string, any> => {
     const parser = this.createSchemaParser({ schema, typeName, schemaPath });
     return parser.getParseContent();
   };

--- a/src/schema-parser/schema-parser.ts
+++ b/src/schema-parser/schema-parser.ts
@@ -32,12 +32,24 @@ export class SchemaParser {
   templatesWorker: TemplatesWorker;
   schemaWalker: SchemaWalker;
 
-  typeName;
-  schema;
-  schemaPath = [];
+  typeName: string | null;
+  // biome-ignore lint/suspicious/noExplicitAny: TODO: narrow to OpenAPI schema type
+  schema: any;
+  schemaPath: string[];
 
-  // @ts-expect-error TS(2525) FIXME: Initializer provides no value for this binding ele... Remove this comment to see the full error message
-  constructor(schemaParserFabric, { typeName, schema, schemaPath } = {}) {
+  constructor(
+    schemaParserFabric: SchemaParserFabric,
+    {
+      typeName,
+      schema,
+      schemaPath,
+    }: {
+      typeName?: string | null;
+      // biome-ignore lint/suspicious/noExplicitAny: TODO: narrow to OpenAPI schema type
+      schema?: any;
+      schemaPath?: string[];
+    } = {},
+  ) {
     this.schemaParserFabric = schemaParserFabric;
     this.config = schemaParserFabric.config;
     this.templatesWorker = schemaParserFabric.templatesWorker;


### PR DESCRIPTION
## Problem

The schema parser chain (`MonoSchemaParser`, `SchemaParser`, `SchemaParserFabric`, and their subclasses) had several typing gaps:

- Properties like `typeName`, `schemaPath`, and constructor parameters lacked type annotations, resulting in implicit `any` under the `@tsconfig/strictest` configuration
- Four `@ts-expect-error` directives suppressed type errors that could be resolved with proper annotations
- `SchemaParserFabric.parseSchema`, `getInlineParseContent`, and `getParseContent` incorrectly typed the `schema` parameter as `string` when it accepts objects, components, and other schema structures
- Local variables like `recordKeysContent`, `recordValuesContent`, and `interfaceKeysContent` used `any` when their actual type is always `string`

## Solution

Add incremental type annotations across the schema parser chain:

- **`MonoSchemaParser`**: Define and export `SchemaParserConfig` interface (placed in `src/` rather than `types/index.ts` to support eventual removal of the latter). Annotate `typeName: string | null`, `schemaPath: string[]`, and constructor parameters.
- **`SchemaParser`**: Type constructor parameters with an options object type, removing the `@ts-expect-error TS(2525)` for the default `= {}` value.
- **`SchemaParserFabric`**: Type `createSchemaParser` with `SchemaParserConfig`, type `createSchema` parameters to remove its `@ts-expect-error TS(2345)`, type `createParsedComponent`, and fix the incorrect `schema: string` to `SchemaParserConfig["schema"]` on three methods.
- **`EnumSchemaParser`**: Use `ConstructorParameters<typeof MonoSchemaParser>` for the spread constructor (removing `@ts-expect-error TS(2556)`). Type `formatEnumKey` with `{ key?: string; value: unknown }` (removing `@ts-expect-error TS(2345)`).
- **`PrimitiveSchemaParser`** / **`ObjectSchemaParser`**: Narrow `recordKeysContent`, `recordValuesContent`, and `interfaceKeysContent` from `any` to `string`.

The `schema` property itself remains typed as `any` (with `biome-ignore` TODO markers) because narrowing it would cascade across the entire parser tree. This is intentionally left for a future iteration.

## Verification

- `bun run build` succeeds
- All 134 tests pass across 47 test files
- No type errors reported by vitest's type checking

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only refactors that mainly improve TypeScript safety; runtime behavior should be unchanged aside from stricter compile-time checks.
> 
> **Overview**
> Tightens TypeScript typings across the schema parser pipeline (`MonoSchemaParser`, `SchemaParser`, and `SchemaParserFabric`) by explicitly typing `schema`, `typeName`, `schemaPath`, and constructor/options shapes via a new exported `SchemaParserConfig`.
> 
> Removes several `@ts-expect-error` suppressions by fixing spread/option typing, corrects `SchemaParserFabric` method signatures that incorrectly treated `schema` as `string`, and narrows a few internal locals (e.g., record/interface key/value content) from `any` to `string`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c12b169212987dc26c998d5585a90a3ffef221fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->