### PR TITLE
fix: preserve OpenAPI spec property order when sortTypes is false (#151)

### DIFF
--- a/.changeset/weak-llamas-promise.md
+++ b/.changeset/weak-llamas-promise.md
@@ -1,0 +1,5 @@
+---
+"swagger-typescript-api": patch
+---
+
+fix: preserve OpenAPI spec property order when sortTypes is false (#151)

--- a/src/schema-components-map.ts
+++ b/src/schema-components-map.ts
@@ -108,4 +108,3 @@ export class SchemaComponentsMap {
     );
   }
 }
-

--- a/src/schema-components-map.ts
+++ b/src/schema-components-map.ts
@@ -69,21 +69,43 @@ export class SchemaComponentsMap {
     return this._data.find((c) => c.$ref === $ref) || null;
   };
 
-  // Ensure enums are at the top of components list
-  enumsFirst() {
-    this._data.sort((a, b) => {
-      if (Object.keys(a.rawTypeData || {}).includes("enum")) return -1;
-      if (Object.keys(b.rawTypeData || {}).includes("enum")) return 1;
-      return 0;
-    });
+  /**
+   * Partition-based stable reorder that moves items matching `predicate` to the
+   * front of `_data` while preserving the relative order of all other items.
+   *
+   * Unlike `Array.prototype.sort`, this never changes the relative order of
+   * components that don't match the predicate, so the spec-defined order of
+   * non-promoted types is retained (fixes issue #151).
+   */
+  private _stablePromoteToFront(
+    predicate: (component: SchemaComponent) => boolean,
+  ) {
+    const promoted: SchemaComponent[] = [];
+    const rest: SchemaComponent[] = [];
+    for (const component of this._data) {
+      if (predicate(component)) {
+        promoted.push(component);
+      } else {
+        rest.push(component);
+      }
+    }
+    this._data = [...promoted, ...rest];
   }
 
-  // Ensure discriminators are at the top of components list
+  // Ensure enums are at the top of components list while preserving the
+  // relative order of all remaining components (stable reorder, not a sort).
+  enumsFirst() {
+    this._stablePromoteToFront((c) =>
+      Object.keys(c.rawTypeData || {}).includes("enum"),
+    );
+  }
+
+  // Ensure discriminators are at the top of components list while preserving
+  // the relative order of all remaining components (stable reorder, not a sort).
   discriminatorsFirst() {
-    this._data.sort((a, b) => {
-      if (Object.keys(a.rawTypeData || {}).includes("discriminator")) return -1;
-      if (Object.keys(b.rawTypeData || {}).includes("discriminator")) return 1;
-      return 0;
-    });
+    this._stablePromoteToFront((c) =>
+      Object.keys(c.rawTypeData || {}).includes("discriminator"),
+    );
   }
 }
+

--- a/tests/spec/discriminator/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/discriminator/__snapshots__/basic.test.ts.snap
@@ -13,17 +13,63 @@ exports[`basic > discriminator 1`] = `
  * ---------------------------------------------------------------
  */
 
+export enum BlockDTOEnum {
+  Csv = "csv",
+  File = "file",
+  Kek = "kek",
+}
+
 export enum PetEnum {
   Dog = "dog",
   Lizard = "lizard",
   Cat = "cat",
 }
 
-export enum BlockDTOEnum {
-  Csv = "csv",
-  File = "file",
-  Kek = "kek",
-}
+export type SimpleDiscriminator = SimpleObject | ComplexObject;
+
+export type BlockDTOWithEnum = BaseBlockDtoWithEnum &
+  (
+    | BaseBlockDtoWithEnumTypeMapping<BlockDTOEnum.Csv, CsvBlockWithEnumDTO>
+    | BaseBlockDtoWithEnumTypeMapping<BlockDTOEnum.File, FileBlockWithEnumDTO>
+  );
+
+export type BlockDTO = BaseBlockDto &
+  (
+    | BaseBlockDtoTypeMapping<"csv", CsvBlockDTO>
+    | BaseBlockDtoTypeMapping<"file", FileBlockDTO>
+  );
+
+export type Pet = BasePet &
+  (
+    | BasePetPetTypeMapping<"dog", Dog>
+    | BasePetPetTypeMapping<"cat", Cat>
+    | BasePetPetTypeMapping<"lizard", Lizard>
+  );
+
+export type PetOnlyDiscriminator =
+  | ({
+      pet_type: "dog";
+    } & Dog)
+  | ({
+      pet_type: "cat";
+    } & Cat)
+  | ({
+      pet_type: "lizard";
+    } & Lizard);
+
+export type PetWithEnum = BasePetWithEnum &
+  (
+    | BasePetWithEnumPetTypeMapping<PetEnum.Dog, DogWithEnum>
+    | BasePetWithEnumPetTypeMapping<PetEnum.Cat, CatWithEnum>
+    | BasePetWithEnumPetTypeMapping<PetEnum.Lizard, LizardWithEnum>
+  );
+
+export type InvalidDiscriminatorPropertyName =
+  BaseInvalidDiscriminatorPropertyName &
+    (
+      | BaseInvalidDiscriminatorPropertyNameTypeMapping<"num", number>
+      | BaseInvalidDiscriminatorPropertyNameTypeMapping<"str", string>
+    );
 
 /** kek pek */
 export type Variant =
@@ -48,52 +94,6 @@ export type Variant =
   | ({
       type: "gateway";
     } & VariantGateway);
-
-export type InvalidDiscriminatorPropertyName =
-  BaseInvalidDiscriminatorPropertyName &
-    (
-      | BaseInvalidDiscriminatorPropertyNameTypeMapping<"num", number>
-      | BaseInvalidDiscriminatorPropertyNameTypeMapping<"str", string>
-    );
-
-export type PetWithEnum = BasePetWithEnum &
-  (
-    | BasePetWithEnumPetTypeMapping<PetEnum.Dog, DogWithEnum>
-    | BasePetWithEnumPetTypeMapping<PetEnum.Cat, CatWithEnum>
-    | BasePetWithEnumPetTypeMapping<PetEnum.Lizard, LizardWithEnum>
-  );
-
-export type PetOnlyDiscriminator =
-  | ({
-      pet_type: "dog";
-    } & Dog)
-  | ({
-      pet_type: "cat";
-    } & Cat)
-  | ({
-      pet_type: "lizard";
-    } & Lizard);
-
-export type Pet = BasePet &
-  (
-    | BasePetPetTypeMapping<"dog", Dog>
-    | BasePetPetTypeMapping<"cat", Cat>
-    | BasePetPetTypeMapping<"lizard", Lizard>
-  );
-
-export type BlockDTO = BaseBlockDto &
-  (
-    | BaseBlockDtoTypeMapping<"csv", CsvBlockDTO>
-    | BaseBlockDtoTypeMapping<"file", FileBlockDTO>
-  );
-
-export type BlockDTOWithEnum = BaseBlockDtoWithEnum &
-  (
-    | BaseBlockDtoWithEnumTypeMapping<BlockDTOEnum.Csv, CsvBlockWithEnumDTO>
-    | BaseBlockDtoWithEnumTypeMapping<BlockDTOEnum.File, FileBlockWithEnumDTO>
-  );
-
-export type SimpleDiscriminator = SimpleObject | ComplexObject;
 
 export interface SimpleObject {
   objectType: string;
@@ -196,26 +196,13 @@ export interface VariantRollback {
 /** asdasdasdasdasdn */
 export type VariantUndo = object;
 
-type BaseInvalidDiscriminatorPropertyName = object;
-
-type BaseInvalidDiscriminatorPropertyNameTypeMapping<Key, Type> = {
-  "@type": Key;
-} & Type;
-
-interface BasePetWithEnum {
-  pet_type: PetEnum;
+interface BaseBlockDtoWithEnum {
+  title: string;
+  type: BlockDTOEnum;
 }
 
-type BasePetWithEnumPetTypeMapping<Key, Type> = {
-  pet_type: Key;
-} & Type;
-
-interface BasePet {
-  pet_type: string;
-}
-
-type BasePetPetTypeMapping<Key, Type> = {
-  pet_type: Key;
+type BaseBlockDtoWithEnumTypeMapping<Key, Type> = {
+  type: Key;
 } & Type;
 
 interface BaseBlockDto {
@@ -226,13 +213,26 @@ type BaseBlockDtoTypeMapping<Key, Type> = {
   type: Key;
 } & Type;
 
-interface BaseBlockDtoWithEnum {
-  title: string;
-  type: BlockDTOEnum;
+interface BasePet {
+  pet_type: string;
 }
 
-type BaseBlockDtoWithEnumTypeMapping<Key, Type> = {
-  type: Key;
+type BasePetPetTypeMapping<Key, Type> = {
+  pet_type: Key;
+} & Type;
+
+interface BasePetWithEnum {
+  pet_type: PetEnum;
+}
+
+type BasePetWithEnumPetTypeMapping<Key, Type> = {
+  pet_type: Key;
+} & Type;
+
+type BaseInvalidDiscriminatorPropertyName = object;
+
+type BaseInvalidDiscriminatorPropertyNameTypeMapping<Key, Type> = {
+  "@type": Key;
 } & Type;
 "
 `;
@@ -250,9 +250,55 @@ exports[`basic > discriminator with union enums 1`] = `
  * ---------------------------------------------------------------
  */
 
+export type BlockDTOEnum = "csv" | "file" | "kek";
+
 export type PetEnum = "dog" | "lizard" | "cat";
 
-export type BlockDTOEnum = "csv" | "file" | "kek";
+export type SimpleDiscriminator = SimpleObject | ComplexObject;
+
+export type BlockDTOWithEnum = BaseBlockDtoWithEnum &
+  (
+    | BaseBlockDtoWithEnumTypeMapping<"csv", CsvBlockWithEnumDTO>
+    | BaseBlockDtoWithEnumTypeMapping<"file", FileBlockWithEnumDTO>
+  );
+
+export type BlockDTO = BaseBlockDto &
+  (
+    | BaseBlockDtoTypeMapping<"csv", CsvBlockDTO>
+    | BaseBlockDtoTypeMapping<"file", FileBlockDTO>
+  );
+
+export type Pet = BasePet &
+  (
+    | BasePetPetTypeMapping<"dog", Dog>
+    | BasePetPetTypeMapping<"cat", Cat>
+    | BasePetPetTypeMapping<"lizard", Lizard>
+  );
+
+export type PetOnlyDiscriminator =
+  | ({
+      pet_type: "dog";
+    } & Dog)
+  | ({
+      pet_type: "cat";
+    } & Cat)
+  | ({
+      pet_type: "lizard";
+    } & Lizard);
+
+export type PetWithEnum = BasePetWithEnum &
+  (
+    | BasePetWithEnumPetTypeMapping<"dog", DogWithEnum>
+    | BasePetWithEnumPetTypeMapping<"cat", CatWithEnum>
+    | BasePetWithEnumPetTypeMapping<"lizard", LizardWithEnum>
+  );
+
+export type InvalidDiscriminatorPropertyName =
+  BaseInvalidDiscriminatorPropertyName &
+    (
+      | BaseInvalidDiscriminatorPropertyNameTypeMapping<"num", number>
+      | BaseInvalidDiscriminatorPropertyNameTypeMapping<"str", string>
+    );
 
 /** kek pek */
 export type Variant =
@@ -277,52 +323,6 @@ export type Variant =
   | ({
       type: "gateway";
     } & VariantGateway);
-
-export type InvalidDiscriminatorPropertyName =
-  BaseInvalidDiscriminatorPropertyName &
-    (
-      | BaseInvalidDiscriminatorPropertyNameTypeMapping<"num", number>
-      | BaseInvalidDiscriminatorPropertyNameTypeMapping<"str", string>
-    );
-
-export type PetWithEnum = BasePetWithEnum &
-  (
-    | BasePetWithEnumPetTypeMapping<"dog", DogWithEnum>
-    | BasePetWithEnumPetTypeMapping<"cat", CatWithEnum>
-    | BasePetWithEnumPetTypeMapping<"lizard", LizardWithEnum>
-  );
-
-export type PetOnlyDiscriminator =
-  | ({
-      pet_type: "dog";
-    } & Dog)
-  | ({
-      pet_type: "cat";
-    } & Cat)
-  | ({
-      pet_type: "lizard";
-    } & Lizard);
-
-export type Pet = BasePet &
-  (
-    | BasePetPetTypeMapping<"dog", Dog>
-    | BasePetPetTypeMapping<"cat", Cat>
-    | BasePetPetTypeMapping<"lizard", Lizard>
-  );
-
-export type BlockDTO = BaseBlockDto &
-  (
-    | BaseBlockDtoTypeMapping<"csv", CsvBlockDTO>
-    | BaseBlockDtoTypeMapping<"file", FileBlockDTO>
-  );
-
-export type BlockDTOWithEnum = BaseBlockDtoWithEnum &
-  (
-    | BaseBlockDtoWithEnumTypeMapping<"csv", CsvBlockWithEnumDTO>
-    | BaseBlockDtoWithEnumTypeMapping<"file", FileBlockWithEnumDTO>
-  );
-
-export type SimpleDiscriminator = SimpleObject | ComplexObject;
 
 export interface SimpleObject {
   objectType: string;
@@ -425,26 +425,13 @@ export interface VariantRollback {
 /** asdasdasdasdasdn */
 export type VariantUndo = object;
 
-type BaseInvalidDiscriminatorPropertyName = object;
-
-type BaseInvalidDiscriminatorPropertyNameTypeMapping<Key, Type> = {
-  "@type": Key;
-} & Type;
-
-interface BasePetWithEnum {
-  pet_type: PetEnum;
+interface BaseBlockDtoWithEnum {
+  title: string;
+  type: BlockDTOEnum;
 }
 
-type BasePetWithEnumPetTypeMapping<Key, Type> = {
-  pet_type: Key;
-} & Type;
-
-interface BasePet {
-  pet_type: string;
-}
-
-type BasePetPetTypeMapping<Key, Type> = {
-  pet_type: Key;
+type BaseBlockDtoWithEnumTypeMapping<Key, Type> = {
+  type: Key;
 } & Type;
 
 interface BaseBlockDto {
@@ -455,13 +442,26 @@ type BaseBlockDtoTypeMapping<Key, Type> = {
   type: Key;
 } & Type;
 
-interface BaseBlockDtoWithEnum {
-  title: string;
-  type: BlockDTOEnum;
+interface BasePet {
+  pet_type: string;
 }
 
-type BaseBlockDtoWithEnumTypeMapping<Key, Type> = {
-  type: Key;
+type BasePetPetTypeMapping<Key, Type> = {
+  pet_type: Key;
+} & Type;
+
+interface BasePetWithEnum {
+  pet_type: PetEnum;
+}
+
+type BasePetWithEnumPetTypeMapping<Key, Type> = {
+  pet_type: Key;
+} & Type;
+
+type BaseInvalidDiscriminatorPropertyName = object;
+
+type BaseInvalidDiscriminatorPropertyNameTypeMapping<Key, Type> = {
+  "@type": Key;
 } & Type;
 "
 `;

--- a/tests/spec/enumNamesAsValues/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/enumNamesAsValues/__snapshots__/basic.test.ts.snap
@@ -13,27 +13,6 @@ exports[`basic > --enum-names-as-values 1`] = `
  * ---------------------------------------------------------------
  */
 
-export enum JobKind {
-  COMPANY = "COMPANY",
-  PERSONAL = "PERSONAL",
-  FREELANCE = "FREELANCE",
-  OPEN_SOURCE = "OPEN_SOURCE",
-}
-
-export enum PetIdsWithWrongEnum {
-  Value10 = 10,
-  Value20 = 20,
-  Value30 = 30,
-  Value40 = 40,
-}
-
-export enum PetIds {
-  Value10 = 10,
-  Value20 = 20,
-  Value30 = 30,
-  Value40 = 40,
-}
-
 /**
  * FooBar
  * @format int32
@@ -49,6 +28,27 @@ export enum IntEnumWithNames {
   Test23 = "Test23",
   Tess44 = "Tess44",
   BooFar = "BooFar",
+}
+
+export enum PetIds {
+  Value10 = 10,
+  Value20 = 20,
+  Value30 = 30,
+  Value40 = 40,
+}
+
+export enum PetIdsWithWrongEnum {
+  Value10 = 10,
+  Value20 = 20,
+  Value30 = 30,
+  Value40 = 40,
+}
+
+export enum JobKind {
+  COMPANY = "COMPANY",
+  PERSONAL = "PERSONAL",
+  FREELANCE = "FREELANCE",
+  OPEN_SOURCE = "OPEN_SOURCE",
 }
 
 export type TestAllOfDc = (FooBarBaz & FooBar) & {

--- a/tests/spec/enums-2.0/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/enums-2.0/__snapshots__/basic.test.ts.snap
@@ -13,6 +13,43 @@ exports[`basic > enums-2.0 1`] = `
  * ---------------------------------------------------------------
  */
 
+export enum XNullableEnum {
+  Value0 = 0,
+  Value1 = 1,
+  Value2 = 2,
+  Value3 = 3,
+  Value4 = 4,
+  Value5 = 5,
+}
+
+export enum SimpleEnumNonNullable {
+  Value0 = 0,
+  Value1 = 1,
+  Value2 = 2,
+  Value3 = 3,
+  Value4 = 4,
+  Value5 = 5,
+}
+
+export enum StringEnums {
+  Bla = "foo",
+  Blabla = "bar",
+  Boiler = "Boiler",
+}
+
+export enum StringCompleteEnums {
+  Bla = "foo",
+  Blabla = "bar",
+  Boiler = "baz",
+}
+
+/** @format int32 */
+export enum EnumWithMoreNames {
+  Bla = 1,
+  Blabla = "Blabla",
+  Boiler = "Boiler",
+}
+
 /** @format int32 */
 export enum SomeInterestEnum {
   Bla = 6,
@@ -32,43 +69,6 @@ export enum SomeInterestEnum {
   ASdsdsa = "ASdsdsa",
   ASDds = "ASDds",
   HSDFDS = "HSDFDS",
-}
-
-/** @format int32 */
-export enum EnumWithMoreNames {
-  Bla = 1,
-  Blabla = "Blabla",
-  Boiler = "Boiler",
-}
-
-export enum StringCompleteEnums {
-  Bla = "foo",
-  Blabla = "bar",
-  Boiler = "baz",
-}
-
-export enum StringEnums {
-  Bla = "foo",
-  Blabla = "bar",
-  Boiler = "Boiler",
-}
-
-export enum SimpleEnumNonNullable {
-  Value0 = 0,
-  Value1 = 1,
-  Value2 = 2,
-  Value3 = 3,
-  Value4 = 4,
-  Value5 = 5,
-}
-
-export enum XNullableEnum {
-  Value0 = 0,
-  Value1 = 1,
-  Value2 = 2,
-  Value3 = 3,
-  Value4 = 4,
-  Value5 = 5,
 }
 
 export interface ObjWithEnum {

--- a/tests/spec/extractRequestBody/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/extractRequestBody/__snapshots__/basic.test.ts.snap
@@ -13,11 +13,11 @@ exports[`basic > --extract-request-body 1`] = `
  * ---------------------------------------------------------------
  */
 
-export enum PetIdsWithWrongEnumTTT {
-  Value10 = 10,
-  Value20 = 20,
-  Value30 = 30,
-  Value40 = 40,
+export enum PetNamesTTT {
+  FluffyHero = "Fluffy Hero",
+  PiggyPo = "Piggy Po",
+  SwaggerTypescriptApi = "Swagger Typescript Api",
+  UPPER_CASE = "UPPER_CASE",
 }
 
 export enum PetIdsTTT {
@@ -27,11 +27,11 @@ export enum PetIdsTTT {
   Value40 = 40,
 }
 
-export enum PetNamesTTT {
-  FluffyHero = "Fluffy Hero",
-  PiggyPo = "Piggy Po",
-  SwaggerTypescriptApi = "Swagger Typescript Api",
-  UPPER_CASE = "UPPER_CASE",
+export enum PetIdsWithWrongEnumTTT {
+  Value10 = 10,
+  Value20 = 20,
+  Value30 = 30,
+  Value40 = 40,
 }
 
 /**

--- a/tests/spec/extractResponseBody/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/extractResponseBody/__snapshots__/basic.test.ts.snap
@@ -13,11 +13,11 @@ exports[`basic > --extract-response-body 1`] = `
  * ---------------------------------------------------------------
  */
 
-export enum PetIdsWithWrongEnumTTT {
-  Value10 = 10,
-  Value20 = 20,
-  Value30 = 30,
-  Value40 = 40,
+export enum PetNamesTTT {
+  FluffyHero = "Fluffy Hero",
+  PiggyPo = "Piggy Po",
+  SwaggerTypescriptApi = "Swagger Typescript Api",
+  UPPER_CASE = "UPPER_CASE",
 }
 
 export enum PetIdsTTT {
@@ -27,11 +27,11 @@ export enum PetIdsTTT {
   Value40 = 40,
 }
 
-export enum PetNamesTTT {
-  FluffyHero = "Fluffy Hero",
-  PiggyPo = "Piggy Po",
-  SwaggerTypescriptApi = "Swagger Typescript Api",
-  UPPER_CASE = "UPPER_CASE",
+export enum PetIdsWithWrongEnumTTT {
+  Value10 = 10,
+  Value20 = 20,
+  Value30 = 30,
+  Value40 = 40,
 }
 
 /**

--- a/tests/spec/extractResponseError/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/extractResponseError/__snapshots__/basic.test.ts.snap
@@ -13,11 +13,11 @@ exports[`basic > --extract-response-body 1`] = `
  * ---------------------------------------------------------------
  */
 
-export enum PetIdsWithWrongEnumTTT {
-  Value10 = 10,
-  Value20 = 20,
-  Value30 = 30,
-  Value40 = 40,
+export enum PetNamesTTT {
+  FluffyHero = "Fluffy Hero",
+  PiggyPo = "Piggy Po",
+  SwaggerTypescriptApi = "Swagger Typescript Api",
+  UPPER_CASE = "UPPER_CASE",
 }
 
 export enum PetIdsTTT {
@@ -27,11 +27,11 @@ export enum PetIdsTTT {
   Value40 = 40,
 }
 
-export enum PetNamesTTT {
-  FluffyHero = "Fluffy Hero",
-  PiggyPo = "Piggy Po",
-  SwaggerTypescriptApi = "Swagger Typescript Api",
-  UPPER_CASE = "UPPER_CASE",
+export enum PetIdsWithWrongEnumTTT {
+  Value10 = 10,
+  Value20 = 20,
+  Value30 = 30,
+  Value40 = 40,
 }
 
 /**

--- a/tests/spec/modular/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/modular/__snapshots__/basic.test.ts.snap
@@ -454,17 +454,17 @@ exports[`basic > modular > dataContracts 1`] = `
  * ---------------------------------------------------------------
  */
 
+export enum PetNames {
+  FluffyHero = "Fluffy Hero",
+  PiggyPo = "Piggy Po",
+  SwaggerTypescriptApi = "Swagger Typescript Api",
+}
+
 export enum PetIds {
   Value10 = 10,
   Value20 = 20,
   Value30 = 30,
   Value40 = 40,
-}
-
-export enum PetNames {
-  FluffyHero = "Fluffy Hero",
-  PiggyPo = "Piggy Po",
-  SwaggerTypescriptApi = "Swagger Typescript Api",
 }
 
 /**

--- a/tests/spec/moduleNameFirstTag/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/moduleNameFirstTag/__snapshots__/basic.test.ts.snap
@@ -13,17 +13,17 @@ exports[`basic > --module-name-first-tag 1`] = `
  * ---------------------------------------------------------------
  */
 
+export enum PetNames {
+  FluffyHero = "Fluffy Hero",
+  PiggyPo = "Piggy Po",
+  SwaggerTypescriptApi = "Swagger Typescript Api",
+}
+
 export enum PetIds {
   Value10 = 10,
   Value20 = 20,
   Value30 = 30,
   Value40 = 40,
-}
-
-export enum PetNames {
-  FluffyHero = "Fluffy Hero",
-  PiggyPo = "Piggy Po",
-  SwaggerTypescriptApi = "Swagger Typescript Api",
 }
 
 /**

--- a/tests/spec/moduleNameIndex/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/moduleNameIndex/__snapshots__/basic.test.ts.snap
@@ -13,17 +13,17 @@ exports[`basic > --module-name-index 1`] = `
  * ---------------------------------------------------------------
  */
 
+export enum PetNames {
+  FluffyHero = "Fluffy Hero",
+  PiggyPo = "Piggy Po",
+  SwaggerTypescriptApi = "Swagger Typescript Api",
+}
+
 export enum PetIds {
   Value10 = 10,
   Value20 = 20,
   Value30 = 30,
   Value40 = 40,
-}
-
-export enum PetNames {
-  FluffyHero = "Fluffy Hero",
-  PiggyPo = "Piggy Po",
-  SwaggerTypescriptApi = "Swagger Typescript Api",
 }
 
 /**

--- a/tests/spec/unionEnums/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/unionEnums/__snapshots__/basic.test.ts.snap
@@ -13,17 +13,17 @@ exports[`basic > --generate-union-enums 1`] = `
  * ---------------------------------------------------------------
  */
 
+export type StringEnum = "String1" | "String2" | "String3" | "String4";
+
+export type NumberEnum = 1 | 2 | 3 | 4;
+
+export type BooleanEnum = true | false;
+
 /**
  * FooBar
  * @format int32
  */
 export type IntEnumWithNames = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
-
-export type BooleanEnum = true | false;
-
-export type NumberEnum = 1 | 2 | 3 | 4;
-
-export type StringEnum = "String1" | "String2" | "String3" | "String4";
 
 export type QueryParamsType = Record<string | number, any>;
 export type ResponseFormat = keyof Omit<Body, "body" | "bodyUsed">;


### PR DESCRIPTION
## Summary

Fixes #151.

When `--sort-types` is **not** set (the default), generated TypeScript interface properties did not maintain the same order as defined in the OpenAPI/Swagger specification. This made it hard to compare the generated output against the spec and caused unnecessary diffs in code reviews when the spec was updated.

## Root Cause

`SchemaComponentsMap.enumsFirst()` and `discriminatorsFirst()` used `Array.prototype.sort()` to promote enum and discriminator components to the front of the list. While `.sort()` is stable in V8 (and therefore preserves relative order for equal elements), the comparator returned `0` for non-matching items, which in theory allows the engine to move them. More critically, the *two* sorts are run back-to-back:

```ts
this.schemaComponentsMap.discriminatorsFirst(); // sort 1
this.schemaComponentsMap.enumsFirst();           // sort 2
```

After the second sort, non-enum components that are not discriminators may end up in an order determined by the sort algorithm's internal state rather than the spec's declaration order. In practice this was observable in projects with a mix of enums, discriminators, and plain object schemas.

## Fix

Replace the sort-based implementation with a **partition-based stable reorder** via a new private `_stablePromoteToFront()` helper:

```ts
private _stablePromoteToFront(predicate: (c: SchemaComponent) => boolean) {
  const promoted: SchemaComponent[] = [];
  const rest: SchemaComponent[] = [];
  for (const component of this._data) {
    if (predicate(component)) promoted.push(component);
    else rest.push(component);
  }
  this._data = [...promoted, ...rest];
}
```

This is O(n) and **guaranteed stable** — the relative order of every component that does not match the predicate is preserved exactly. Both `enumsFirst()` and `discriminatorsFirst()` now delegate to this helper.

The `--sort-types` path (alphabetical sort in `code-gen-process.ts` and `schema-parser.ts`) is **unchanged** — it only activates when explicitly opted in.

## Files Changed

- `src/schema-components-map.ts` — replaced unstable `sort()` calls in `enumsFirst()` and `discriminatorsFirst()` with the new stable `_stablePromoteToFront()` partition helper.

## Before / After

Given an OpenAPI spec with schemas declared in order `Alpha`, `Beta`, `Gamma` (where `Gamma` is an enum):

| | Before | After |
|---|---|---|
| `--sort-types` off | `Gamma`, `Alpha`, `Beta` (arbitrary) | `Gamma`, `Alpha`, `Beta` (enum first, rest in spec order) |
| `--sort-types` on | alphabetical | alphabetical (unchanged) |