### PR TITLE
fix(schema-parser): allOf intersection + nullable:true not generating | null union type

### DIFF
--- a/.changeset/heavy-moles-hammer.md
+++ b/.changeset/heavy-moles-hammer.md
@@ -1,0 +1,5 @@
+---
+"swagger-typescript-api": patch
+---
+
+Add: null to allOf intersection types with nullable(true)

--- a/src/schema-parser/base-schema-parsers/object.ts
+++ b/src/schema-parser/base-schema-parsers/object.ts
@@ -45,12 +45,15 @@ export class ObjectSchemaParser extends MonoSchemaParser {
       const fieldName = this.typeNameFormatter.isValidName(name)
         ? name
         : this.config.Ts.StringValue(name);
-      const fieldValue = this.schemaParserFabric
+      const rawFieldValue = this.schemaParserFabric
         .createSchemaParser({
           schema: property,
           schemaPath: [...this.schemaPath, name],
         })
         .getInlineParseContent();
+      const fieldValue = nullable
+        ? this.schemaUtils.safeAddNullToType(property, rawFieldValue)
+        : rawFieldValue;
       const readOnly = (property as Record<string, unknown>).readOnly;
 
       const complexType = this.schemaUtils.getComplexType(property);

--- a/src/schema-parser/schema-utils.ts
+++ b/src/schema-parser/schema-utils.ts
@@ -149,15 +149,37 @@ export class SchemaUtils {
     return isRequired;
   };
 
+  // isNullMissingInType = (schema, type) => {
+  //   const { nullable, type: schemaType } = schema || {};
+  //   return (
+  //     (nullable ||
+  //       !!get(schema, "x-nullable") ||
+  //       schemaType === this.config.Ts.Keyword.Null) &&
+  //     typeof type === "string" &&
+  //     !type.includes(` ${this.config.Ts.Keyword.Null}`) &&
+  //     !type.includes(`${this.config.Ts.Keyword.Null} `)
+  //   );
+  // };
+
   isNullMissingInType = (schema, type) => {
     const { nullable, type: schemaType } = schema || {};
-    return (
-      (nullable ||
+    if (
+      !(
+        nullable ||
         !!get(schema, "x-nullable") ||
-        schemaType === this.config.Ts.Keyword.Null) &&
-      typeof type === "string" &&
-      !type.includes(` ${this.config.Ts.Keyword.Null}`) &&
-      !type.includes(`${this.config.Ts.Keyword.Null} `)
+        schemaType === this.config.Ts.Keyword.Null
+      ) ||
+      typeof type !== "string"
+    ) {
+      return false;
+    }
+
+    const nullKeyword = this.config.Ts.Keyword.Null;
+    const lastLine = type.trimEnd().split("\n").pop() ?? type;
+
+    return (
+      !lastLine.includes(` ${nullKeyword}`) &&
+      !lastLine.includes(`${nullKeyword} `)
     );
   };
 

--- a/src/schema-parser/schema-utils.ts
+++ b/src/schema-parser/schema-utils.ts
@@ -149,18 +149,6 @@ export class SchemaUtils {
     return isRequired;
   };
 
-  // isNullMissingInType = (schema, type) => {
-  //   const { nullable, type: schemaType } = schema || {};
-  //   return (
-  //     (nullable ||
-  //       !!get(schema, "x-nullable") ||
-  //       schemaType === this.config.Ts.Keyword.Null) &&
-  //     typeof type === "string" &&
-  //     !type.includes(` ${this.config.Ts.Keyword.Null}`) &&
-  //     !type.includes(`${this.config.Ts.Keyword.Null} `)
-  //   );
-  // };
-
   isNullMissingInType = (schema, type) => {
     const { nullable, type: schemaType } = schema || {};
     if (

--- a/tests/__snapshots__/extended.test.ts.snap
+++ b/tests/__snapshots__/extended.test.ts.snap
@@ -5768,7 +5768,7 @@ export interface Order {
   /** @format date-time */
   shipDate?: string;
   /** Order Status */
-  status?: OrderStatusEnum;
+  status?: OrderStatusEnum | null;
 }
 
 /** Order Status */
@@ -14973,7 +14973,7 @@ export interface CheckRun {
    */
   completed_at: string | null;
   /** @example "neutral" */
-  conclusion: CheckRunConclusionEnum;
+  conclusion: CheckRunConclusionEnum | null;
   /** @example "https://example.com" */
   details_url: string | null;
   /** @example "42" */
@@ -15053,7 +15053,7 @@ export interface CheckSuite {
   before: string | null;
   check_runs_url: string;
   /** @example "neutral" */
-  conclusion: CheckSuiteConclusionEnum;
+  conclusion: CheckSuiteConclusionEnum | null;
   /** @format date-time */
   created_at: string | null;
   /** @example "master" */
@@ -15074,7 +15074,7 @@ export interface CheckSuite {
   /** Minimal Repository */
   repository: MinimalRepository;
   /** @example "completed" */
-  status: CheckSuiteStatusEnum;
+  status: CheckSuiteStatusEnum | null;
   /** @format date-time */
   updated_at: string | null;
   /** @example "https://api.github.com/repos/github/hello-world/check-suites/5" */
@@ -15777,17 +15777,19 @@ export enum CodeScanningAlertDismissedReasonEnum {
 /** Identifies the variable values associated with the environment in which the analysis that generated this alert instance was performed, such as the language that was analyzed. */
 export type CodeScanningAlertEnvironment = string;
 
-export type CodeScanningAlertInstances = {
-  /** Identifies the configuration under which the analysis was executed. For example, in GitHub Actions this includes the workflow filename and job name. */
-  analysis_key?: CodeScanningAnalysisAnalysisKey;
-  /** Identifies the variable values associated with the environment in which the analysis that generated this alert instance was performed, such as the language that was analyzed. */
-  environment?: CodeScanningAlertEnvironment;
-  matrix_vars?: string | null;
-  /** The full Git reference, formatted as \`refs/heads/<branch name>\`. */
-  ref?: CodeScanningAlertRef;
-  /** State of a code scanning alert. */
-  state?: CodeScanningAlertState;
-}[];
+export type CodeScanningAlertInstances =
+  | {
+      /** Identifies the configuration under which the analysis was executed. For example, in GitHub Actions this includes the workflow filename and job name. */
+      analysis_key?: CodeScanningAnalysisAnalysisKey;
+      /** Identifies the variable values associated with the environment in which the analysis that generated this alert instance was performed, such as the language that was analyzed. */
+      environment?: CodeScanningAlertEnvironment;
+      matrix_vars?: string | null;
+      /** The full Git reference, formatted as \`refs/heads/<branch name>\`. */
+      ref?: CodeScanningAlertRef;
+      /** State of a code scanning alert. */
+      state?: CodeScanningAlertState;
+    }[]
+  | null;
 
 /** The full Git reference, formatted as \`refs/heads/<branch name>\`. */
 export type CodeScanningAlertRef = string;
@@ -15798,7 +15800,7 @@ export interface CodeScanningAlertRule {
   /** A unique identifier for the rule used to detect the alert. */
   id?: string | null;
   /** The severity of the alert. */
-  severity?: CodeScanningAlertRuleSeverityEnum;
+  severity?: CodeScanningAlertRuleSeverityEnum | null;
 }
 
 /** The severity of the alert. */
@@ -18659,26 +18661,28 @@ export interface GistsUpdateParams {
   gistId: string;
 }
 
-export type GistsUpdatePayload = null & {
-  /**
-   * Description of the gist
-   * @example "Example Ruby script"
-   */
-  description?: string;
-  /**
-   * Names of files to be updated
-   * @example {"hello.rb":{"content":"blah","filename":"goodbye.rb"}}
-   */
-  files?: Record<
-    string,
-    (object | null) & {
-      /** The new content of the file */
-      content?: string;
-      /** The new filename for the file */
-      filename?: string | null;
-    }
-  >;
-};
+export type GistsUpdatePayload = null &
+  ({
+    /**
+     * Description of the gist
+     * @example "Example Ruby script"
+     */
+    description?: string;
+    /**
+     * Names of files to be updated
+     * @example {"hello.rb":{"content":"blah","filename":"goodbye.rb"}}
+     */
+    files?: Record<
+      string,
+      (object | null) &
+        ({
+          /** The new content of the file */
+          content?: string;
+          /** The new filename for the file */
+          filename?: string | null;
+        } | null)
+    >;
+  } | null);
 
 /**
  * Git Commit
@@ -21592,7 +21596,7 @@ export interface MarketplacePurchase {
     /** Marketplace Listing Plan */
     plan?: MarketplaceListingPlan;
     unit_count?: number | null;
-  };
+  } | null;
   marketplace_purchase: {
     billing_cycle?: string;
     free_trial_ends_on?: string | null;
@@ -23654,7 +23658,7 @@ export interface Page {
    * The status of the most recent build of the Page.
    * @example "built"
    */
-  status: PageStatusEnum;
+  status: PageStatusEnum | null;
   /**
    * The API address for accessing this Page resource.
    * @format uri
@@ -25041,7 +25045,7 @@ export interface PullRequest {
         spdx_id: string | null;
         /** @format uri */
         url: string | null;
-      };
+      } | null;
       master_branch?: string;
       /** @format uri */
       merges_url: string;
@@ -25464,7 +25468,7 @@ export interface PullRequestReviewComment {
    * The side of the first line of the range for a multi-line comment.
    * @default "RIGHT"
    */
-  start_side?: PullRequestReviewCommentStartSideEnum;
+  start_side?: PullRequestReviewCommentStartSideEnum | null;
   /**
    * @format date-time
    * @example "2011-04-14T16:00:49Z"
@@ -30139,7 +30143,7 @@ export interface ReviewComment {
    * The side of the first line of the range for a multi-line comment.
    * @default "RIGHT"
    */
-  start_side?: ReviewCommentStartSideEnum;
+  start_side?: ReviewCommentStartSideEnum | null;
   /**
    * @format date-time
    * @example "2011-04-14T16:00:49Z"
@@ -31241,7 +31245,7 @@ export type SimpleUser = {
    * @example "https://api.github.com/users/octocat"
    */
   url: string;
-};
+} | null;
 
 /**
  * What to sort results by. Can be either \`created\`, \`updated\`, \`comments\`.
@@ -32319,7 +32323,7 @@ export type TeamSimple = {
    * @example "https://api.github.com/organizations/1/team/1"
    */
   url: string;
-};
+} | null;
 
 export type TeamsAddMemberLegacyData = any;
 
@@ -69032,7 +69036,7 @@ export type LoginData = string;
 export interface NullableEnum {
   /** @format int64 */
   id?: number;
-  legalCategory?: NullableEnumLegalCategoryEnum;
+  legalCategory?: NullableEnumLegalCategoryEnum | null;
 }
 
 export enum NullableEnumLegalCategoryEnum {

--- a/tests/__snapshots__/simple.test.ts.snap
+++ b/tests/__snapshots__/simple.test.ts.snap
@@ -9534,17 +9534,19 @@ export type CodeScanningAlertDismissedReason =
 /** Identifies the variable values associated with the environment in which the analysis that generated this alert instance was performed, such as the language that was analyzed. */
 export type CodeScanningAlertEnvironment = string;
 
-export type CodeScanningAlertInstances = {
-  /** Identifies the configuration under which the analysis was executed. For example, in GitHub Actions this includes the workflow filename and job name. */
-  analysis_key?: CodeScanningAnalysisAnalysisKey;
-  /** Identifies the variable values associated with the environment in which the analysis that generated this alert instance was performed, such as the language that was analyzed. */
-  environment?: CodeScanningAlertEnvironment;
-  matrix_vars?: string | null;
-  /** The full Git reference, formatted as \`refs/heads/<branch name>\`. */
-  ref?: CodeScanningAlertRef;
-  /** State of a code scanning alert. */
-  state?: CodeScanningAlertState;
-}[];
+export type CodeScanningAlertInstances =
+  | {
+      /** Identifies the configuration under which the analysis was executed. For example, in GitHub Actions this includes the workflow filename and job name. */
+      analysis_key?: CodeScanningAnalysisAnalysisKey;
+      /** Identifies the variable values associated with the environment in which the analysis that generated this alert instance was performed, such as the language that was analyzed. */
+      environment?: CodeScanningAlertEnvironment;
+      matrix_vars?: string | null;
+      /** The full Git reference, formatted as \`refs/heads/<branch name>\`. */
+      ref?: CodeScanningAlertRef;
+      /** State of a code scanning alert. */
+      state?: CodeScanningAlertState;
+    }[]
+  | null;
 
 /** The full Git reference, formatted as \`refs/heads/<branch name>\`. */
 export type CodeScanningAlertRef = string;
@@ -12595,7 +12597,7 @@ export interface MarketplacePurchase {
     /** Marketplace Listing Plan */
     plan?: MarketplaceListingPlan;
     unit_count?: number | null;
-  };
+  } | null;
   marketplace_purchase: {
     billing_cycle?: string;
     free_trial_ends_on?: string | null;
@@ -14084,7 +14086,7 @@ export interface PullRequest {
         spdx_id: string | null;
         /** @format uri */
         url: string | null;
-      };
+      } | null;
       master_branch?: string;
       /** @format uri */
       merges_url: string;
@@ -16031,7 +16033,7 @@ export type SimpleUser = {
    * @example "https://api.github.com/users/octocat"
    */
   url: string;
-};
+} | null;
 
 /**
  * Stargazer
@@ -16739,7 +16741,7 @@ export type TeamSimple = {
    * @example "https://api.github.com/organizations/1/team/1"
    */
   url: string;
-};
+} | null;
 
 /**
  * Thread
@@ -19479,26 +19481,28 @@ export class Api<
      */
     gistsUpdate: (
       gistId: string,
-      data: null & {
-        /**
-         * Description of the gist
-         * @example "Example Ruby script"
-         */
-        description?: string;
-        /**
-         * Names of files to be updated
-         * @example {"hello.rb":{"content":"blah","filename":"goodbye.rb"}}
-         */
-        files?: Record<
-          string,
-          (object | null) & {
-            /** The new content of the file */
-            content?: string;
-            /** The new filename for the file */
-            filename?: string | null;
-          }
-        >;
-      },
+      data: null &
+        ({
+          /**
+           * Description of the gist
+           * @example "Example Ruby script"
+           */
+          description?: string;
+          /**
+           * Names of files to be updated
+           * @example {"hello.rb":{"content":"blah","filename":"goodbye.rb"}}
+           */
+          files?: Record<
+            string,
+            (object | null) &
+              ({
+                /** The new content of the file */
+                content?: string;
+                /** The new filename for the file */
+                filename?: string | null;
+              } | null)
+          >;
+        } | null),
       params: RequestParams = {},
     ) =>
       this.request<GistSimple, BasicError | ValidationError>({

--- a/tests/spec/additional-properties-2.0/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/additional-properties-2.0/__snapshots__/basic.test.ts.snap
@@ -33,7 +33,7 @@ export type MyObject4 = Record<
   {
     content?: string;
     filename?: string | null;
-  }
+  } | null
 >;
 "
 `;

--- a/tests/spec/axios/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/axios/__snapshots__/basic.test.ts.snap
@@ -1688,9 +1688,9 @@ export interface SearchCode {
 
 export interface SearchIssues {
   items?: {
-    assignee?: any;
+    assignee?: any | null;
     body?: string;
-    closed_at?: any;
+    closed_at?: any | null;
     comments?: number;
     comments_url?: string;
     created_at?: string;
@@ -1703,12 +1703,12 @@ export interface SearchIssues {
       url?: string;
     }[];
     labels_url?: string;
-    milestone?: any;
+    milestone?: any | null;
     number?: number;
     pull_request?: {
-      diff_url?: any;
-      html_url?: any;
-      patch_url?: any;
+      diff_url?: any | null;
+      html_url?: any | null;
+      patch_url?: any | null;
     };
     score?: number;
     state?: string;

--- a/tests/spec/axiosSingleHttpClient/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/axiosSingleHttpClient/__snapshots__/basic.test.ts.snap
@@ -1688,9 +1688,9 @@ export interface SearchCode {
 
 export interface SearchIssues {
   items?: {
-    assignee?: any;
+    assignee?: any | null;
     body?: string;
-    closed_at?: any;
+    closed_at?: any | null;
     comments?: number;
     comments_url?: string;
     created_at?: string;
@@ -1703,12 +1703,12 @@ export interface SearchIssues {
       url?: string;
     }[];
     labels_url?: string;
-    milestone?: any;
+    milestone?: any | null;
     number?: number;
     pull_request?: {
-      diff_url?: any;
-      html_url?: any;
-      patch_url?: any;
+      diff_url?: any | null;
+      html_url?: any | null;
+      patch_url?: any | null;
     };
     score?: number;
     state?: string;

--- a/tests/spec/noClient/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/noClient/__snapshots__/basic.test.ts.snap
@@ -1688,9 +1688,9 @@ export interface SearchCode {
 
 export interface SearchIssues {
   items?: {
-    assignee?: any;
+    assignee?: any | null;
     body?: string;
-    closed_at?: any;
+    closed_at?: any | null;
     comments?: number;
     comments_url?: string;
     created_at?: string;
@@ -1703,12 +1703,12 @@ export interface SearchIssues {
       url?: string;
     }[];
     labels_url?: string;
-    milestone?: any;
+    milestone?: any | null;
     number?: number;
     pull_request?: {
-      diff_url?: any;
-      html_url?: any;
-      patch_url?: any;
+      diff_url?: any | null;
+      html_url?: any | null;
+      patch_url?: any | null;
     };
     score?: number;
     state?: string;

--- a/tests/spec/nullable-3.0/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/nullable-3.0/__snapshots__/basic.test.ts.snap
@@ -28,6 +28,17 @@ export interface TestObject {
   otherObjectMaybeNullB: OtherObject | null;
   otherObjectMaybeNullC: OtherObject | null;
   otherObjectMaybeNullD: OtherObject | null;
+  objectMaybeNullAllOf: OtherObject | null;
+  inlineObjectMaybeNullAllOf: {
+    value?: string;
+  } | null;
+  intersectionMaybeNullAllOf:
+    | ({
+        a?: string | null;
+      } & {
+        b?: string;
+      })
+    | null;
 }
 
 export type OtherObject = object;

--- a/tests/spec/nullable-3.0/schema.json
+++ b/tests/spec/nullable-3.0/schema.json
@@ -77,6 +77,38 @@
                 "type": "null"
               }
             ]
+          },
+          "objectMaybeNullAllOf": {
+            "nullable": true,
+            "allOf": [{ "$ref": "#/components/schemas/OtherObject" }]
+          },
+          "inlineObjectMaybeNullAllOf": {
+            "nullable": true,
+            "allOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "value": { "type": "string" }
+                }
+              }
+            ]
+          },
+          "intersectionMaybeNullAllOf": {
+            "nullable": true,
+            "allOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "a": { "type": "string", "nullable": true }
+                }
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "b": { "type": "string" }
+                }
+              }
+            ]
           }
         },
         "required": [
@@ -85,7 +117,10 @@
           "otherObjectMaybeNullA",
           "otherObjectMaybeNullB",
           "otherObjectMaybeNullC",
-          "otherObjectMaybeNullD"
+          "otherObjectMaybeNullD",
+          "objectMaybeNullAllOf",
+          "inlineObjectMaybeNullAllOf",
+          "intersectionMaybeNullAllOf"
         ]
       },
       "OtherObject": {

--- a/tests/spec/patch/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/patch/__snapshots__/basic.test.ts.snap
@@ -1567,9 +1567,9 @@ export interface SearchCode {
 
 export interface SearchIssues {
   items?: {
-    assignee?: any;
+    assignee?: any | null;
     body?: string;
-    closed_at?: any;
+    closed_at?: any | null;
     comments?: number;
     comments_url?: string;
     created_at?: string;
@@ -1582,12 +1582,12 @@ export interface SearchIssues {
       url?: string;
     }[];
     labels_url?: string;
-    milestone?: any;
+    milestone?: any | null;
     number?: number;
     pull_request?: {
-      diff_url?: any;
-      html_url?: any;
-      patch_url?: any;
+      diff_url?: any | null;
+      html_url?: any | null;
+      patch_url?: any | null;
     };
     score?: number;
     state?: string;

--- a/tests/spec/routeTypes/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/routeTypes/__snapshots__/basic.test.ts.snap
@@ -1688,9 +1688,9 @@ export interface SearchCode {
 
 export interface SearchIssues {
   items?: {
-    assignee?: any;
+    assignee?: any | null;
     body?: string;
-    closed_at?: any;
+    closed_at?: any | null;
     comments?: number;
     comments_url?: string;
     created_at?: string;
@@ -1703,12 +1703,12 @@ export interface SearchIssues {
       url?: string;
     }[];
     labels_url?: string;
-    milestone?: any;
+    milestone?: any | null;
     number?: number;
     pull_request?: {
-      diff_url?: any;
-      html_url?: any;
-      patch_url?: any;
+      diff_url?: any | null;
+      html_url?: any | null;
+      patch_url?: any | null;
     };
     score?: number;
     state?: string;

--- a/tests/spec/sortTypes-false/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/sortTypes-false/__snapshots__/basic.test.ts.snap
@@ -1568,9 +1568,9 @@ export interface SearchCode {
 export interface SearchIssues {
   total_count?: number;
   items?: {
-    closed_at?: any;
+    closed_at?: any | null;
     body?: string;
-    assignee?: any;
+    assignee?: any | null;
     comments?: number;
     comments_url?: string;
     created_at?: string;
@@ -1583,12 +1583,12 @@ export interface SearchIssues {
       url?: string;
     }[];
     labels_url?: string;
-    milestone?: any;
+    milestone?: any | null;
     number?: number;
     pull_request?: {
-      diff_url?: any;
-      html_url?: any;
-      patch_url?: any;
+      diff_url?: any | null;
+      html_url?: any | null;
+      patch_url?: any | null;
     };
     score?: number;
     state?: string;

--- a/tests/spec/sortTypes/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/sortTypes/__snapshots__/basic.test.ts.snap
@@ -1567,9 +1567,9 @@ export interface SearchCode {
 
 export interface SearchIssues {
   items?: {
-    assignee?: any;
+    assignee?: any | null;
     body?: string;
-    closed_at?: any;
+    closed_at?: any | null;
     comments?: number;
     comments_url?: string;
     created_at?: string;
@@ -1582,12 +1582,12 @@ export interface SearchIssues {
       url?: string;
     }[];
     labels_url?: string;
-    milestone?: any;
+    milestone?: any | null;
     number?: number;
     pull_request?: {
-      diff_url?: any;
-      html_url?: any;
-      patch_url?: any;
+      diff_url?: any | null;
+      html_url?: any | null;
+      patch_url?: any | null;
     };
     score?: number;
     state?: string;

--- a/tests/spec/typeSuffixPrefix/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/typeSuffixPrefix/__snapshots__/basic.test.ts.snap
@@ -1575,9 +1575,9 @@ export interface SwaggerTypeSearchCodeGeneratedDataContract {
 
 export interface SwaggerTypeSearchIssuesGeneratedDataContract {
   items?: {
-    assignee?: any;
+    assignee?: any | null;
     body?: string;
-    closed_at?: any;
+    closed_at?: any | null;
     comments?: number;
     comments_url?: string;
     created_at?: string;
@@ -1590,12 +1590,12 @@ export interface SwaggerTypeSearchIssuesGeneratedDataContract {
       url?: string;
     }[];
     labels_url?: string;
-    milestone?: any;
+    milestone?: any | null;
     number?: number;
     pull_request?: {
-      diff_url?: any;
-      html_url?: any;
-      patch_url?: any;
+      diff_url?: any | null;
+      html_url?: any | null;
+      patch_url?: any | null;
     };
     score?: number;
     state?: string;


### PR DESCRIPTION
## Overview

First of all, I really enjoy using swagger-typescript-api in my project.
Thank you for maintaining such a great tool! 🙏

While using this library, I discovered a bug where `| null` was not being
appended to `allOf` intersection types even when `nullable: true` was specified.

---

## Problem

In OpenAPI 3.0, the correct pattern for a nullable `$ref` type is to wrap it
in `allOf` alongside `nullable: true`:

```json
"priorStudy": {
  "nullable": true,
  "allOf": [
    {
      "properties": {
        "patient": { ... }
      },
      "type": "object"
    },
    {
      "properties": {
        "studyIdInPacs": { "type": "string", "nullable": true },
        "category": {
          "allOf": [{ "$ref": "#/components/schemas/Category" }],
          "nullable": true
        }
      },
      "type": "object"
    }
  ]
}
```

**Expected output:**
```typescript
priorStudy:
  | ({
      patient: { ... };
    } & {
      studyIdInPacs: string | null;
      category: TCategory | null;
      ...
    })
  | null;  // ← should be here
```

**Actual output (before fix):**
```typescript
priorStudy: {
  patient: { ... };
} & {
  studyIdInPacs: string | null;
  category: TCategory | null;
  ...
};  // ← | null missing
```

---

## Root Cause

Two issues were found:

**1. `isNullMissingInType` in `schema-utils.ts`**

The function scanned the **entire multiline type string** for ` null`.
When inner fields contained `string | null` (e.g. `studyIdInPacs: string | null`),
it falsely concluded that `null` was already present at the top level,
and skipped adding `| null` to the intersection type.

```typescript
// Before (bug)
!type.includes(` ${this.config.Ts.Keyword.Null}`)  // ← matches inner fields too
```

**2. `$parsed` cache in `object.ts`**

Even after fixing `isNullMissingInType`, the `schema.$parsed` cache caused
the parser to skip re-evaluation on subsequent calls, so `safeAddNullToType`
was never reached for cached schemas.

---

## Fix

**`src/schema-parser/schema-utils.ts`**

Check only the **last line** of a multiline type string instead of the full string,
preventing false positives from inner field declarations.

```typescript
// After (fix)
const lastLine = type.trimEnd().split("\n").pop() ?? type;
return (
  !lastLine.includes(` ${nullKeyword}`) &&
  !lastLine.includes(`${nullKeyword} `)
);
```

**`src/schema-parser/base-schema-parsers/object.ts`**

Apply `safeAddNullToType` directly after `getInlineParseContent()` when
`nullable` is true, bypassing the `$parsed` cache issue.

```typescript
const rawFieldValue = this.schemaParserFabric
  .createSchemaParser({ schema: property, schemaPath: [...this.schemaPath, name] })
  .getInlineParseContent();

const fieldValue = nullable
  ? this.schemaUtils.safeAddNullToType(property, rawFieldValue)
  : rawFieldValue;
```

---

## Test

Added test cases to `tests/spec/nullable-3.0/schema.json`:

- `objectMaybeNullAllOf` — single `$ref` inside `allOf` + `nullable: true`
- `inlineObjectMaybeNullAllOf` — inline object inside `allOf` + `nullable: true`
- `intersectionMaybeNullAllOf` — **multiple objects in `allOf` + `nullable: true`**
  (the core bug case: inner fields contain `string | null`)

Ran `bun test:update` to update snapshots. Pre-existing snapshots that had
`nullable: true` but were missing `| null` were also corrected as a result
of this fix.

---

## Note

Pre-existing lint warnings exist in the codebase and are out of scope for this PR.

Two commits included:
- `fix`: source code changes (`schema-utils.ts`, `object.ts`)
- `test`: snapshot updates and new test cases