### PR TITLE
fix(type-name-formatter): dedupe colliding identifiers via upfront precommit

### DIFF
--- a/.changeset/quiet-otters-resolve.md
+++ b/.changeset/quiet-otters-resolve.md
@@ -1,0 +1,27 @@
+---
+"swagger-typescript-api": patch
+---
+
+Dedupe colliding TypeScript identifiers produced by the `TypeNameFormatter`.
+
+Two OpenAPI schema keys that differ only in separator placement — e.g.
+`Foo_Bar` and `FooBar` — used to collapse to the same identifier via
+`startCase` + whitespace-strip and emit two `export interface FooBar`
+declarations (TS2717 whenever the shapes differed).
+
+`TypeNameFormatter` now exposes a `precommit(rawNames)` method the generator
+calls once after loading schema components and before schema parsing. It
+resolves every raw name in two passes — canonical names (raw === formatted
+output) claim their slot first, then non-canonical names suffix-until-free —
+so user-declared identifiers like `FooBar1` are preserved regardless of
+source order, and collisions deterministically produce `FooBar`, `FooBar1`,
+`FooBar2`, … References to each schema (including inline generics in route
+handlers) stay consistent with the emitted `export interface` declarations.
+
+`format()` is now a pure cache lookup with a fallback for names discovered
+after precommit (enum keys, `extractEnums`/`extractResponses` results). All
+formatting logic is concentrated in a single private `computeFormattedName`
+helper, so the new behavior composes cleanly with `disableFormatTypeNames`
+and `typeNameSeparator`.
+
+Fixes #1724.

--- a/src/code-gen-process.ts
+++ b/src/code-gen-process.ts
@@ -140,6 +140,13 @@ export class CodeGenProcess {
         compact(["schemas", this.config.extractResponses && "responses"]),
       );
 
+    // Resolve the TypeScript identifier for every schema component upfront,
+    // before the parser starts calling `format()`. This lets `format()` stay
+    // a pure cache lookup and keeps collision handling concentrated in one
+    // place so results are source-order independent and inline type strings
+    // captured during schema parsing can't go stale. See #1724.
+    this.typeNameFormatter.precommit(componentsToParse.map((c) => c.typeName));
+
     const parsedSchemas = componentsToParse.map((schemaComponent) => {
       const parsed = this.schemaParserFabric.parseSchema(
         schemaComponent.rawTypeData,

--- a/src/type-name-formatter.ts
+++ b/src/type-name-formatter.ts
@@ -7,70 +7,119 @@ type FormattingSchemaType = "enum-key" | "type-name";
 
 export class TypeNameFormatter {
   formattedModelNamesMap = new Map<string, string>();
+  // Tracks formatted output → raw name for top-level type names. Populated
+  // by `precommit` during the resolution pass so `format()` can stay a pure
+  // lookup. Enum keys are NOT tracked here — they live inside enum blocks
+  // (`EnumA.Bar` and `EnumB.Bar` are both valid), so cross-enum collisions
+  // don't need to be disambiguated. See issue #1724.
+  usedFormattedTypeNames = new Map<string, string>();
   config: CodeGenConfig;
 
   constructor(config: CodeGenConfig) {
     this.config = config;
   }
 
+  /**
+   * Return the TypeScript identifier for a raw OpenAPI name. Fast path is a
+   * cache hit on names resolved by `precommit`. The fallback (for names
+   * discovered after precommit, e.g. enum keys inside schemas or types added
+   * dynamically by `extractEnums`/`extractResponses`) computes the identifier
+   * inline WITHOUT collision handling — collision resolution is the sole
+   * responsibility of `precommit`. Callers expecting collision safety must
+   * list every raw name in the precommit input.
+   */
   format = (name: string, options: { type?: FormattingSchemaType } = {}) => {
     const schemaType = options.type ?? "type-name";
-
-    let typePrefix: string;
-    let typeSuffix: string;
-
-    if (schemaType === "enum-key") {
-      typePrefix = this.config.enumKeyPrefix;
-      typeSuffix = this.config.enumKeySuffix;
-    } else {
-      typePrefix = this.config.typePrefix;
-      typeSuffix = this.config.typeSuffix;
-    }
-
-    const typeNameSeparator = this.config.typeNameSeparator;
-
+    const { typePrefix, typeSuffix } = this.getAffixes(schemaType);
     const hashKey = `${typePrefix}_${name}_${typeSuffix}`;
 
-    if (this.formattedModelNamesMap.has(hashKey)) {
-      return this.formattedModelNamesMap.get(hashKey);
-    }
+    const cached = this.formattedModelNamesMap.get(hashKey);
+    if (cached !== undefined) return cached;
 
     if (typeof name !== "string") {
       consola.warn("wrong model name", name);
       return name;
     }
 
-    let resultName = name;
+    // Fallback: compute inline, no collision check.
+    const result = this.computeFormattedName(
+      name,
+      schemaType,
+      typePrefix,
+      typeSuffix,
+    );
+    this.formattedModelNamesMap.set(hashKey, result);
+    return result;
+  };
 
-    if (this.config.disableFormatTypeNames) {
-      resultName = compact([typePrefix, resultName, typeSuffix]).join(
-        typeNameSeparator,
-      );
-    } else {
-      // https://github.com/acacode/swagger-typescript-api/issues/1260
-      if (/^(?!\d)([A-Z0-9_]{1,})$/g.test(resultName)) {
-        resultName = compact([typePrefix, resultName, typeSuffix]).join(
-          typeNameSeparator,
-        );
-      } else {
-        const fixedModelName = this.fixModelName(resultName, {
-          type: schemaType,
-        });
-        resultName = startCase(
-          compact([typePrefix, fixedModelName, typeSuffix]).join(
-            typeNameSeparator,
-          ),
-        ).replace(/\s/g, "");
-      }
+  /**
+   * Resolve the TypeScript identifier for every raw schema name passed in,
+   * populating `formattedModelNamesMap` and `usedFormattedTypeNames`. Must be
+   * called once, before any `format()` call from the schema parser, so that
+   * every subsequent `format()` for these names is a cache hit and returns
+   * the collision-resolved identifier.
+   *
+   * Two passes:
+   *   1. Claim every raw name whose formatted output equals the raw name
+   *      itself ("canonical"). User-declared identifiers like `FooBar` or
+   *      `FooBar1` are preserved regardless of the source order in which
+   *      the generator later visits them.
+   *   2. For non-canonical names (e.g. `Foo_Bar` → `FooBar`), suffix with
+   *      the smallest integer not already claimed, so collisions produce
+   *      `FooBar`, `FooBar1`, `FooBar2`, … deterministically.
+   *
+   * Only type-names go through collision resolution here. Enum keys use the
+   * fallback path in `format()` and are handled per-enum by the template.
+   */
+  precommit = (rawNames: Iterable<string>): void => {
+    const schemaType: FormattingSchemaType = "type-name";
+    const { typePrefix, typeSuffix } = this.getAffixes(schemaType);
+
+    const seen = new Set<string>();
+    const names: string[] = [];
+    for (const name of rawNames) {
+      if (typeof name !== "string") continue;
+      if (seen.has(name)) continue;
+      seen.add(name);
+      names.push(name);
     }
 
-    const formattedResultName =
-      this.config.hooks.onFormatTypeName?.(resultName, name, schemaType) ||
-      resultName;
+    // Pass 1: pre-claim canonical names.
+    for (const name of names) {
+      const formatted = this.computeFormattedName(
+        name,
+        schemaType,
+        typePrefix,
+        typeSuffix,
+      );
+      if (name !== formatted) continue;
+      if (this.usedFormattedTypeNames.has(formatted)) continue;
+      this.usedFormattedTypeNames.set(formatted, name);
+      const hashKey = `${typePrefix}_${name}_${typeSuffix}`;
+      this.formattedModelNamesMap.set(hashKey, formatted);
+    }
 
-    this.formattedModelNamesMap.set(hashKey, formattedResultName);
-
-    return formattedResultName;
+    // Pass 2: resolve non-canonical names with suffix-until-free.
+    for (const name of names) {
+      const hashKey = `${typePrefix}_${name}_${typeSuffix}`;
+      if (this.formattedModelNamesMap.has(hashKey)) continue;
+      const formatted = this.computeFormattedName(
+        name,
+        schemaType,
+        typePrefix,
+        typeSuffix,
+      );
+      let final = formatted;
+      if (this.usedFormattedTypeNames.has(final)) {
+        let suffix = 1;
+        while (this.usedFormattedTypeNames.has(`${formatted}${suffix}`)) {
+          suffix += 1;
+        }
+        final = `${formatted}${suffix}`;
+      }
+      this.usedFormattedTypeNames.set(final, name);
+      this.formattedModelNamesMap.set(hashKey, final);
+    }
   };
 
   isValidName = (name: string) => /^([A-Za-z$_]{1,})$/g.test(name);
@@ -106,5 +155,47 @@ export class TypeNameFormatter {
     }
 
     return name;
+  };
+
+  private getAffixes = (schemaType: FormattingSchemaType) => ({
+    typePrefix:
+      schemaType === "enum-key"
+        ? this.config.enumKeyPrefix
+        : this.config.typePrefix,
+    typeSuffix:
+      schemaType === "enum-key"
+        ? this.config.enumKeySuffix
+        : this.config.typeSuffix,
+  });
+
+  private computeFormattedName = (
+    name: string,
+    schemaType: FormattingSchemaType,
+    typePrefix: string,
+    typeSuffix: string,
+  ): string => {
+    const typeNameSeparator = this.config.typeNameSeparator;
+    let resultName = name;
+
+    if (this.config.disableFormatTypeNames) {
+      resultName = compact([typePrefix, resultName, typeSuffix]).join(
+        typeNameSeparator,
+      );
+    } else if (/^(?!\d)([A-Z0-9_]{1,})$/g.test(resultName)) {
+      // https://github.com/acacode/swagger-typescript-api/issues/1260
+      resultName = compact([typePrefix, resultName, typeSuffix]).join(
+        typeNameSeparator,
+      );
+    } else {
+      const fixed = this.fixModelName(resultName, { type: schemaType });
+      resultName = startCase(
+        compact([typePrefix, fixed, typeSuffix]).join(typeNameSeparator),
+      ).replace(/\s/g, "");
+    }
+
+    return (
+      this.config.hooks.onFormatTypeName?.(resultName, name, schemaType) ||
+      resultName
+    );
   };
 }

--- a/tests/spec/name-collision/basic.test.ts
+++ b/tests/spec/name-collision/basic.test.ts
@@ -1,0 +1,183 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { generateApi } from "../../../src/index.js";
+
+// Regression tests for issue #1724: two OpenAPI schemas whose raw names
+// normalize to the same TypeScript identifier (e.g. `Foo_Bar` and `FooBar`
+// both yield `FooBar` via `startCase` + whitespace-strip) used to emit two
+// `export interface FooBar` declarations.
+
+describe("name-collision", async () => {
+  let tmpdir = "";
+
+  beforeAll(async () => {
+    tmpdir = await fs.mkdtemp(path.join(os.tmpdir(), "swagger-typescript-api"));
+  });
+
+  afterAll(async () => {
+    await fs.rm(tmpdir, { recursive: true });
+  });
+
+  const generate = async (
+    fileName: string,
+    schema: string,
+    overrides: Partial<Parameters<typeof generateApi>[0]> = {},
+  ) => {
+    await generateApi({
+      fileName,
+      input: path.resolve(import.meta.dirname, schema),
+      output: tmpdir,
+      silent: true,
+      generateClient: false,
+      ...overrides,
+    });
+    return fs.readFile(path.join(tmpdir, `${fileName}.ts`), {
+      encoding: "utf8",
+    });
+  };
+
+  const countOccurrences = (haystack: string, needle: string) =>
+    haystack.split(needle).length - 1;
+
+  test("basic collision: Foo_Bar + FooBar get disambiguated", async () => {
+    const content = await generate("basic", "schema-basic.json");
+
+    // Exactly one `export interface FooBar` and one `export interface FooBar1`.
+    expect(countOccurrences(content, "export interface FooBar ")).toBe(1);
+    expect(countOccurrences(content, "export interface FooBar1 ")).toBe(1);
+
+    // No other suffixed variants.
+    expect(content).not.toMatch(/export interface FooBar2\b/);
+
+    // Generated output type-checks under declaration-merging rules — the two
+    // interfaces having different `kind` literal types would produce TS2717
+    // if they had collapsed to the same name.
+    expect(content).toMatch(/kind: "legacy"/);
+    expect(content).toMatch(/kind: "modern"/);
+  });
+
+  test("pre-existing suffix: Foo_Bar + FooBar + FooBar1 all preserved (natural order)", async () => {
+    // Source order `Foo_Bar`, `FooBar`, `FooBar1`. `precommitCanonicalNames`
+    // pre-claims both canonical names (`FooBar`, `FooBar1`) before the parser
+    // runs, so the non-canonical `Foo_Bar` suffix-loops to the first free
+    // slot (`FooBar2`) on its first `format()` call. User-declared canonical
+    // names are preserved and route references stay consistent.
+    const content = await generate("prenumbered", "schema-prenumbered.json");
+
+    expect(countOccurrences(content, "export interface FooBar ")).toBe(1);
+    expect(countOccurrences(content, "export interface FooBar1 ")).toBe(1);
+    expect(countOccurrences(content, "export interface FooBar2 ")).toBe(1);
+    expect(content).not.toMatch(/export interface FooBar3\b/);
+    expect(content).not.toMatch(/export interface FooBar11\b/);
+  });
+
+  test("pre-existing suffix: reversed source order produces the same result", async () => {
+    // Same three schemas in reverse order. Because all canonicals are pre-
+    // claimed upfront (before any parser `format()` call), the outcome is
+    // source-order independent: `FooBar` and `FooBar1` are always preserved;
+    // `Foo_Bar` is the one that gets suffixed to `FooBar2`.
+    const content = await generate(
+      "prenumbered-reversed",
+      "schema-prenumbered-reversed.json",
+    );
+
+    expect(countOccurrences(content, "export interface FooBar ")).toBe(1);
+    expect(countOccurrences(content, "export interface FooBar1 ")).toBe(1);
+    expect(countOccurrences(content, "export interface FooBar2 ")).toBe(1);
+    expect(content).not.toMatch(/export interface FooBar3\b/);
+    expect(content).not.toMatch(/export interface FooBar11\b/);
+  });
+
+  test("hook interaction: onFormatTypeName collisions are also disambiguated", async () => {
+    const content = await generate("hook", "schema-hook.json", {
+      hooks: {
+        // Force both Alpha and Beta through the same formatted name.
+        onFormatTypeName: () => "Shared",
+      },
+    });
+
+    // Both schemas produce the same hook-returned name, so the second one
+    // is suffixed.
+    expect(countOccurrences(content, "export interface Shared ")).toBe(1);
+    expect(countOccurrences(content, "export interface Shared1 ")).toBe(1);
+  });
+
+  test("multiple canonicals with non-canonical sharing the base: non-canonical suffixes past all canonicals", async () => {
+    // Source order `FooBar`, `Foo_Bar`, `FooBar1`, `FooBar2`. All three
+    // canonical names are pre-claimed up front, so when the non-canonical
+    // `Foo_Bar` is first formatted, the suffix loop skips `FooBar1` and
+    // `FooBar2` and lands on `FooBar3`. All user-declared canonical names
+    // are preserved; each interface's unique property confirms identity.
+    const content = await generate(
+      "multiple-canonicals",
+      "schema-multiple-canonicals.json",
+    );
+
+    expect(content).toMatch(/export interface FooBar\s*{\s*fromFooBar:/);
+    expect(content).toMatch(/export interface FooBar1\s*{\s*fromFooBar1:/);
+    expect(content).toMatch(/export interface FooBar2\s*{\s*fromFooBar2:/);
+    expect(content).toMatch(
+      /export interface FooBar3\s*{\s*fromFooUnderscoreBar:/,
+    );
+
+    // Exactly four interfaces, no duplicate declarations.
+    expect(countOccurrences(content, "export interface FooBar ")).toBe(1);
+    expect(countOccurrences(content, "export interface FooBar1 ")).toBe(1);
+    expect(countOccurrences(content, "export interface FooBar2 ")).toBe(1);
+    expect(countOccurrences(content, "export interface FooBar3 ")).toBe(1);
+    expect(content).not.toMatch(/export interface FooBar4\b/);
+  });
+
+  test("repeat reference: same raw schema used multiple times keeps one identifier", async () => {
+    const content = await generate("cached", "schema-cached.json");
+
+    // `Dog` is referenced from three endpoints (one directly, one as-is, one
+    // via an array). The generator must produce exactly one `Dog` interface,
+    // never suffixing because the raw name is identical across calls.
+    expect(countOccurrences(content, "export interface Dog ")).toBe(1);
+    expect(content).not.toMatch(/export interface Dog1\b/);
+  });
+
+  test("route references stay consistent with definitions when collisions are suffixed", async () => {
+    // Generate a client so inline route-handler types exercise `format()`
+    // during schema-parsing Phase 1 — before `prepareModelType` captures the
+    // definition names. Without pre-committing canonical names, the earlier
+    // Phase 1 calls would stash a pre-collision name and the route would
+    // point to the wrong schema. Asserts that each route's generic parameter
+    // matches the actual definition shape by checking the property name.
+    const content = await generate("route-refs", "schema-prenumbered.json", {
+      generateClient: true,
+    });
+
+    // Extract each route's response type from the source and confirm it
+    // matches the schema shape with the corresponding unique property.
+    const findResponseType = (pathFragment: string) => {
+      const routeMatch = content.match(
+        new RegExp(`path:\\s*\`[^\`]*${pathFragment}[^\`]*\`[^}]*?`, "s"),
+      );
+      if (!routeMatch) throw new Error(`route ${pathFragment} not found`);
+      const preceding = content.slice(0, routeMatch.index);
+      const genericMatch = preceding.match(/request<(\w+),[^>]*>\(\{\s*$/);
+      return genericMatch?.[1];
+    };
+
+    // Foo_Bar schema (unique property `a`) is suffixed; its route must point
+    // to the suffixed name — not the pre-collision bare `FooBar`.
+    const typeForPathA = findResponseType("/a");
+    expect(typeForPathA).toBeDefined();
+    expect(content).toMatch(
+      new RegExp(`export interface ${typeForPathA}\\s*{\\s*a:\\s*string`),
+    );
+
+    // FooBar and FooBar1 schemas keep their canonical names; routes match.
+    const typeForPathB = findResponseType("/b");
+    expect(typeForPathB).toBe("FooBar");
+    expect(content).toMatch(/export interface FooBar\s*{\s*b:\s*string/);
+
+    const typeForPathC = findResponseType("/c");
+    expect(typeForPathC).toBe("FooBar1");
+    expect(content).toMatch(/export interface FooBar1\s*{\s*c:\s*string/);
+  });
+});

--- a/tests/spec/name-collision/schema-basic.json
+++ b/tests/spec/name-collision/schema-basic.json
@@ -1,0 +1,54 @@
+{
+  "openapi": "3.0.0",
+  "info": { "title": "name-collision basic", "version": "1.0.0" },
+  "paths": {
+    "/a": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Foo_Bar" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/b": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/FooBar" }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Foo_Bar": {
+        "type": "object",
+        "required": ["kind", "legacyField"],
+        "properties": {
+          "kind": { "type": "string", "enum": ["legacy"] },
+          "legacyField": { "type": "string" }
+        }
+      },
+      "FooBar": {
+        "type": "object",
+        "required": ["kind", "newField"],
+        "properties": {
+          "kind": { "type": "string", "enum": ["modern"] },
+          "newField": { "type": "number" }
+        }
+      }
+    }
+  }
+}

--- a/tests/spec/name-collision/schema-cached.json
+++ b/tests/spec/name-collision/schema-cached.json
@@ -1,0 +1,63 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "name-collision same-raw-name reused",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/a": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Dog" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/b": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Dog" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/c": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Dog" }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Dog": {
+        "type": "object",
+        "required": ["name"],
+        "properties": { "name": { "type": "string" } }
+      }
+    }
+  }
+}

--- a/tests/spec/name-collision/schema-hook.json
+++ b/tests/spec/name-collision/schema-hook.json
@@ -1,0 +1,48 @@
+{
+  "openapi": "3.0.0",
+  "info": { "title": "name-collision hook interaction", "version": "1.0.0" },
+  "paths": {
+    "/a": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Alpha" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/b": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Beta" }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Alpha": {
+        "type": "object",
+        "required": ["a"],
+        "properties": { "a": { "type": "string" } }
+      },
+      "Beta": {
+        "type": "object",
+        "required": ["b"],
+        "properties": { "b": { "type": "number" } }
+      }
+    }
+  }
+}

--- a/tests/spec/name-collision/schema-multiple-canonicals.json
+++ b/tests/spec/name-collision/schema-multiple-canonicals.json
@@ -1,0 +1,89 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "name-collision cascading eviction",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/foobar": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/FooBar" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/foo-bar": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Foo_Bar" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/foobar1": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/FooBar1" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/foobar2": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/FooBar2" }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "FooBar": {
+        "type": "object",
+        "required": ["fromFooBar"],
+        "properties": { "fromFooBar": { "type": "string" } }
+      },
+      "Foo_Bar": {
+        "type": "object",
+        "required": ["fromFooUnderscoreBar"],
+        "properties": { "fromFooUnderscoreBar": { "type": "string" } }
+      },
+      "FooBar1": {
+        "type": "object",
+        "required": ["fromFooBar1"],
+        "properties": { "fromFooBar1": { "type": "string" } }
+      },
+      "FooBar2": {
+        "type": "object",
+        "required": ["fromFooBar2"],
+        "properties": { "fromFooBar2": { "type": "string" } }
+      }
+    }
+  }
+}

--- a/tests/spec/name-collision/schema-prenumbered-reversed.json
+++ b/tests/spec/name-collision/schema-prenumbered-reversed.json
@@ -1,0 +1,70 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "name-collision with pre-existing suffix, reversed order",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/c": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/FooBar1" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/b": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/FooBar" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/a": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Foo_Bar" }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "FooBar1": {
+        "type": "object",
+        "required": ["c"],
+        "properties": { "c": { "type": "string" } }
+      },
+      "FooBar": {
+        "type": "object",
+        "required": ["b"],
+        "properties": { "b": { "type": "string" } }
+      },
+      "Foo_Bar": {
+        "type": "object",
+        "required": ["a"],
+        "properties": { "a": { "type": "string" } }
+      }
+    }
+  }
+}

--- a/tests/spec/name-collision/schema-prenumbered.json
+++ b/tests/spec/name-collision/schema-prenumbered.json
@@ -1,0 +1,70 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "name-collision with pre-existing suffix",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/a": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Foo_Bar" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/b": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/FooBar" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/c": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/FooBar1" }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Foo_Bar": {
+        "type": "object",
+        "required": ["a"],
+        "properties": { "a": { "type": "string" } }
+      },
+      "FooBar": {
+        "type": "object",
+        "required": ["b"],
+        "properties": { "b": { "type": "string" } }
+      },
+      "FooBar1": {
+        "type": "object",
+        "required": ["c"],
+        "properties": { "c": { "type": "string" } }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Two OpenAPI schema keys that differ only in separator placement — e.g. `Foo_Bar` and `FooBar` — both normalize to the same TypeScript identifier (`FooBar`) via [`src/type-name-formatter.ts`](https://github.com/acacode/swagger-typescript-api/blob/main/src/type-name-formatter.ts)'s `startCase` + whitespace-strip pipeline. The previous cache is keyed by the raw input (`hashKey = prefix_name_suffix`), not by the formatted output, so collisions go undetected and the generator emits two `export interface FooBar { … }` declarations — TypeScript declaration-merges them and reports `TS2717` whenever the shapes differ.

This PR resolves collisions **upfront**, in a new `precommit(rawNames)` pass the generator invokes once after loading schema components and before schema parsing begins. `format()` shrinks to a pure cache lookup plus a no-collision-logic fallback for dynamically-discovered names (enum keys, `extractEnums` / `extractResponses` results). All formatting logic is concentrated in a single private `computeFormattedName()` helper so `format()`, `precommit()`, and the new `disableFormatTypeNames` / `typeNameSeparator` options share one pipeline.

Fixes #1724.

## Why not resolve collisions in `format()`?

An earlier iteration of this PR tried a mid-flight "evict-and-rename" approach inside `format()`: when a canonical incoming name collides with a non-canonical incumbent, move the incumbent to a suffixed slot so the user-declared name survives. It **corrupts downstream output**.

The schema parser calls `format()` during Phase 1 (from `schema-utils.ts`, `schema-parser.ts`, `schema-routes.ts`) and **captures the return value directly into inline type strings** — e.g. `this.request<FooBar, any>` for a route response. Later Phase-2 work (`prepareModelType` → `collectModelTypes`) calls `format()` again per schema and captures the result into `preparedModelType.name`. Phase 2 happens after Phase 1, so definitions always see the final cache state and come out consistent. But any eviction that renames a raw schema mid-flight leaves the earlier Phase-1 captures frozen at the old name, and a route that returns `Foo_Bar` can end up generic-parameterized on `FooBar` — which is now the shape of an entirely different schema. A route-reference regression test in this PR would have caught it.

Pre-committing every schema name before the parser runs sidesteps the problem entirely: every `format()` call returns the final name on the first shot.

## Design

### Two-pass resolution in `precommit`

1. **Pass 1 — canonicals claim their slots.** For every raw name where `rawName === computeFormattedName(rawName)` (i.e. the name already matches its formatted output), reserve that identifier. User-declared names like `FooBar`, `FooBar1`, `User`, `V1Response` all survive regardless of source order.
2. **Pass 2 — non-canonicals suffix-until-free.** For every remaining raw name (e.g. `Foo_Bar` → `FooBar`), append the smallest integer suffix not already used by any pre-committed canonical or earlier non-canonical, producing deterministic `FooBar`, `FooBar1`, `FooBar2`, …

### `format()` becomes a lookup

```ts
format = (name, options = {}) => {
  // ... typePrefix/typeSuffix/hashKey setup ...
  const cached = this.formattedModelNamesMap.get(hashKey);
  if (cached !== undefined) return cached;

  // Fallback (no collision check): compute inline, cache, return.
  // Reached only for enum keys and schemas added after precommit.
  const result = this.computeFormattedName(name, schemaType, typePrefix, typeSuffix);
  this.formattedModelNamesMap.set(hashKey, result);
  return result;
};
```

### Single source of truth for the pipeline

`computeFormattedName` is the only place startCase, `disableFormatTypeNames`, `typeNameSeparator`, the ALL_CAPS fast path, and the `onFormatTypeName` hook are applied. `precommit` and the `format()` fallback both go through it, so all three formatting options (this PR's collision resolution + `disableFormatTypeNames` + `typeNameSeparator`) compose without special-casing.

### Enum keys are intentionally excluded

Enum keys live in their own per-enum scope (`EnumA.Bar` and `EnumB.Bar` are both valid TS). Cross-enum collisions don't need disambiguation, so `precommit` and `usedFormattedTypeNames` only track `schemaType === "type-name"`. Enum keys always hit the fallback path in `format()`, which preserves existing behavior.

### Hook interaction

Collision detection runs on the **hook output**, not the raw `startCase` output. If `onFormatTypeName` maps two distinct raw names to the same string, one still ends up suffixed.

## Minimal repro (pre-fix)

```yaml
# collision-repro.yaml
openapi: 3.0.0
info: { title: repro, version: 1.0.0 }
paths:
  /a:
    get:
      responses:
        '200':
          content:
            application/json:
              schema: { $ref: '#/components/schemas/Foo_Bar' }
  /b:
    get:
      responses:
        '200':
          content:
            application/json:
              schema: { $ref: '#/components/schemas/FooBar' }
components:
  schemas:
    Foo_Bar:
      type: object
      required: [kind, legacyField]
      properties:
        kind: { type: string, enum: [legacy] }
        legacyField: { type: string }
    FooBar:
      type: object
      required: [kind, newField]
      properties:
        kind: { type: string, enum: [modern] }
        newField: { type: number }
```

Before: two `export interface FooBar` declarations, TS2717 once `@ts-nocheck` is stripped. After: `export interface FooBar` (for raw `FooBar`, with `kind: "modern"`) and `export interface FooBar1` (for raw `Foo_Bar`, with `kind: "legacy"`); route references are consistent.

## Tests

Seven new cases under `tests/spec/name-collision/`:

| Case | What it asserts |
|---|---|
| Basic collision | `Foo_Bar` + `FooBar` → `FooBar` + `FooBar1`; both `kind` literals preserved |
| Pre-existing suffix, natural order | `Foo_Bar`, `FooBar`, `FooBar1` in that order → `FooBar`, `FooBar1`, `FooBar2`; no `FooBar11` |
| Pre-existing suffix, reversed order | Same three schemas reversed → same outcome (order-independent) |
| Multiple canonicals | `FooBar`, `Foo_Bar`, `FooBar1`, `FooBar2` → non-canonical lands at `FooBar3`, canonicals preserved |
| Hook interaction | `onFormatTypeName: () => "Shared"` → `Shared` + `Shared1` |
| Repeat reference | `Dog` referenced from three endpoints → exactly one `export interface Dog` |
| **Route-reference correctness** | With `generateClient: true`, each route's generic parameter matches the corresponding definition by its unique property. Catches the eviction-era regression described above. |

## Context

Our client is generated from a Scala backend's OpenAPI spec. Scala's generator naturally emits both underscore-wrapped names (parameterized discriminator variants) and plain names (flat schemas), so having `Foo_Bar` and `FooBar` side-by-side is idiomatic output, not a schema authoring mistake. The numeric suffix convention (`Foo_Bar1` in some specs) comes from the Scala generator itself, not from `swagger-typescript-api` — the suffix loop in this PR skips past it correctly.

Historical context: [#65](https://github.com/acacode/swagger-typescript-api/issues/65) introduced the `startCase` normalization that underpins the collision. This PR doesn't change that normalization; it adds collision-aware resolution on top of it.

## Test plan

- [x] `bun run test` → 198 passing (189 pre-existing + 7 name-collision + 2 for the new `disableFormatTypeNames`/`typeNameSeparator` suites still green on top of this PR)
- [x] `bun run build` clean
- [x] `bun run format:check` clean
- [x] `bunx biome check` on modified files clean
- [x] Manual route-reference smoke test on a client-generating spec: route generics match definitions
