### PR TITLE
Replace generateUnionEnums with unified enumStyle option

### DIFF
--- a/.changeset/add-enum-style-option.md
+++ b/.changeset/add-enum-style-option.md
@@ -1,0 +1,5 @@
+---
+"swagger-typescript-api": minor
+---
+
+Add `enumStyle` option ("enum" | "union" | "const") to control enum output format. `"const"` generates `as const` objects with a companion type alias, including the built-in `ContentType` in the http-client. `generateUnionEnums` is deprecated in favor of `enumStyle: "union"`.

--- a/index.ts
+++ b/index.ts
@@ -183,8 +183,13 @@ const generateCommand = defineCommand({
     },
     "generate-union-enums": {
       type: "boolean",
-      description: 'generate all "enum" types as union types (T1 | T2 | TN)',
+      description: '(deprecated) generate all "enum" types as union types — use --enum-style=union instead',
       default: codeGenBaseConfig.generateUnionEnums,
+    },
+    "enum-style": {
+      type: "string",
+      description: 'enum output style: "enum" (default), "union" (T1 | T2 | TN), or "const" (as const object + type alias)',
+      default: codeGenBaseConfig.enumStyle,
     },
     "http-client": {
       type: "string",
@@ -323,6 +328,7 @@ const generateCommand = defineCommand({
       generateResponses: args.responses,
       generateRouteTypes: args["route-types"],
       generateUnionEnums: args["generate-union-enums"],
+      enumStyle: args["enum-style"] as "enum" | "union" | "const" | undefined,
       httpClientType:
         args["http-client"] || args.axios
           ? HTTP_CLIENT.AXIOS

--- a/index.ts
+++ b/index.ts
@@ -183,12 +183,14 @@ const generateCommand = defineCommand({
     },
     "generate-union-enums": {
       type: "boolean",
-      description: '(deprecated) generate all "enum" types as union types — use --enum-style=union instead',
+      description:
+        '(deprecated) generate all "enum" types as union types — use --enum-style=union instead',
       default: codeGenBaseConfig.generateUnionEnums,
     },
     "enum-style": {
       type: "string",
-      description: 'enum output style: "enum" (default), "union" (T1 | T2 | TN), or "const" (as const object + type alias)',
+      description:
+        'enum output style: "enum" (default), "union" (T1 | T2 | TN), or "const" (as const object + type alias)',
       default: codeGenBaseConfig.enumStyle,
     },
     "http-client": {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,3 +1,4 @@
+import { consola } from "consola";
 import { compact, merge, uniq } from "es-toolkit";
 import type { OpenAPI } from "openapi-types";
 import * as typescript from "typescript";
@@ -30,6 +31,7 @@ const TsKeyword = {
   Date: "Date",
   Type: "type",
   Enum: "enum",
+  Const: "const",
   Interface: "interface",
   Array: "Array",
   Record: "Record",
@@ -53,7 +55,9 @@ export class CodeGenConfig {
   generateRouteTypes = false;
   /** CLI flag */
   generateClient = true;
-  /** CLI flag */
+  /** CLI flag. Controls enum output format: "enum" (default), "union" (T1 | T2 | TN), or "const" (as const object + type alias). */
+  enumStyle: "enum" | "union" | "const" = "enum";
+  /** @deprecated Use enumStyle: "union" instead */
   generateUnionEnums = false;
   /** CLI flag */
   addReadonly = false;
@@ -459,6 +463,12 @@ export class CodeGenConfig {
     objectAssign(this, update);
     if (this.enumNamesAsValues) {
       this.extractEnums = true;
+    }
+    if (this.generateUnionEnums) {
+      consola.warn('`generateUnionEnums` is deprecated. Use `enumStyle: "union"` instead.');
+      if (this.enumStyle === "enum") {
+        this.enumStyle = "union";
+      }
     }
   };
 }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -465,7 +465,9 @@ export class CodeGenConfig {
       this.extractEnums = true;
     }
     if (this.generateUnionEnums) {
-      consola.warn('`generateUnionEnums` is deprecated. Use `enumStyle: "union"` instead.');
+      consola.warn(
+        '`generateUnionEnums` is deprecated. Use `enumStyle: "union"` instead.',
+      );
       if (this.enumStyle === "enum") {
         this.enumStyle = "union";
       }

--- a/src/schema-parser/base-schema-parsers/discriminator.ts
+++ b/src/schema-parser/base-schema-parsers/discriminator.ts
@@ -186,7 +186,7 @@ export class DiscriminatorSchemaParser extends MonoSchemaParser {
       ]);
       for (const [key, index] of enumEntries) {
         const enumContent = parsedEnum.content?.[index];
-        if (this.config.generateUnionEnums) {
+        if (this.config.enumStyle === "union" || this.config.enumStyle === "const") {
           const literalValue =
             enumContent?.value ??
             (key !== undefined ? ts.StringValue(key) : undefined);

--- a/src/schema-parser/base-schema-parsers/discriminator.ts
+++ b/src/schema-parser/base-schema-parsers/discriminator.ts
@@ -186,7 +186,10 @@ export class DiscriminatorSchemaParser extends MonoSchemaParser {
       ]);
       for (const [key, index] of enumEntries) {
         const enumContent = parsedEnum.content?.[index];
-        if (this.config.enumStyle === "union" || this.config.enumStyle === "const") {
+        if (
+          this.config.enumStyle === "union" ||
+          this.config.enumStyle === "const"
+        ) {
           const literalValue =
             enumContent?.value ??
             (key !== undefined ? ts.StringValue(key) : undefined);

--- a/src/schema-parser/base-schema-parsers/enum.ts
+++ b/src/schema-parser/base-schema-parsers/enum.ts
@@ -144,9 +144,12 @@ export class EnumSchemaParser extends MonoSchemaParser {
       schemaType: SCHEMA_TYPES.ENUM,
       type: SCHEMA_TYPES.ENUM,
       keyType: keyType,
-      typeIdentifier: this.config.generateUnionEnums
-        ? this.config.Ts.Keyword.Type
-        : this.config.Ts.Keyword.Enum,
+      typeIdentifier:
+        this.config.enumStyle === "const"
+          ? this.config.Ts.Keyword.Const
+          : this.config.enumStyle === "union"
+            ? this.config.Ts.Keyword.Type
+            : this.config.Ts.Keyword.Enum,
       name: this.typeName,
       description: this.schemaFormatters.formatDescription(
         this.schema.description,

--- a/src/schema-parser/schema-formatters.ts
+++ b/src/schema-parser/schema-formatters.ts
@@ -20,7 +20,17 @@ export class SchemaFormatters {
 
   base = {
     [SCHEMA_TYPES.ENUM]: (parsedSchema) => {
-      if (this.config.generateUnionEnums) {
+      if (this.config.enumStyle === "const") {
+        return {
+          ...parsedSchema,
+          $content: parsedSchema.content,
+          content: parsedSchema.content
+            .map(({ key, value }) => `  ${key}: ${value}`)
+            .join(",\n"),
+        };
+      }
+
+      if (this.config.enumStyle === "union") {
         return {
           ...parsedSchema,
           $content: parsedSchema.content,

--- a/templates/base/data-contracts.ejs
+++ b/templates/base/data-contracts.ejs
@@ -25,6 +25,15 @@ const dataContractTemplates = {
   type: (contract) => {
     return `type ${contract.name}${buildGenerics(contract)} = ${contract.content}`;
   },
+  const: (contract) => {
+    const entries = contract.$content
+      .map(({ key, value }) => `  ${key}: ${value}`)
+      .join(',\n');
+    return (
+      `const ${contract.name} = {\n${entries},\n} as const\n` +
+      `export type ${contract.name} = (typeof ${contract.name})[keyof typeof ${contract.name}]`
+    );
+  },
 }
 %>
 

--- a/templates/base/data-contracts.ejs
+++ b/templates/base/data-contracts.ejs
@@ -29,9 +29,10 @@ const dataContractTemplates = {
     const entries = contract.$content
       .map(({ key, value }) => `  ${key}: ${value}`)
       .join(',\n');
+    const typeExport = contract.internal ? '' : 'export ';
     return (
       `const ${contract.name} = {\n${entries},\n} as const\n` +
-      `export type ${contract.name} = (typeof ${contract.name})[keyof typeof ${contract.name}]`
+      `${typeExport}type ${contract.name} = (typeof ${contract.name})[keyof typeof ${contract.name}]`
     );
   },
 }

--- a/templates/base/enum-data-contract.ejs
+++ b/templates/base/enum-data-contract.ejs
@@ -3,7 +3,12 @@ const { contract, utils, config } = it;
 const { formatDescription, require, _ } = utils;
 const { name, $content } = contract;
 %>
-<% if (config.generateUnionEnums) { %>
+<% if (config.enumStyle === "const") { %>
+  export const <%~ name %> = {
+    <%~ _.map($content, ({ key, value }) => `${key}: ${value}`).join(",\n    ") %>
+  } as const;
+  export type <%~ name %> = (typeof <%~ name %>)[keyof typeof <%~ name %>];
+<% } else if (config.enumStyle === "union") { %>
   export type <%~ name %> = <%~ _.map($content, ({ value }) => value).join(" | ") %>
 <% } else { %>
   export enum <%~ name %> {

--- a/templates/base/http-clients/axios-http-client.ejs
+++ b/templates/base/http-clients/axios-http-client.ejs
@@ -30,6 +30,16 @@ export interface ApiConfig<SecurityDataType = unknown> extends Omit<AxiosRequest
   format?: ResponseType;
 }
 
+<% if (config.enumStyle === "const") { %>
+export const ContentType = {
+  Json: "application/json",
+  JsonApi: "application/vnd.api+json",
+  FormData: "multipart/form-data",
+  UrlEncoded: "application/x-www-form-urlencoded",
+  Text: "text/plain",
+} as const;
+export type ContentType = (typeof ContentType)[keyof typeof ContentType];
+<% } else { %>
 export enum ContentType {
   Json = "application/json",
   JsonApi = "application/vnd.api+json",
@@ -37,6 +47,7 @@ export enum ContentType {
   UrlEncoded = "application/x-www-form-urlencoded",
   Text = "text/plain",
 }
+<% } %>
 
 export class HttpClient<SecurityDataType = unknown> {
     public instance: AxiosInstance;

--- a/templates/base/http-clients/fetch-http-client.ejs
+++ b/templates/base/http-clients/fetch-http-client.ejs
@@ -41,6 +41,16 @@ export interface HttpResponse<D extends unknown, E extends unknown = unknown> ex
 
 type CancelToken = Symbol | string | number;
 
+<% if (config.enumStyle === "const") { %>
+export const ContentType = {
+    Json: "application/json",
+    JsonApi: "application/vnd.api+json",
+    FormData: "multipart/form-data",
+    UrlEncoded: "application/x-www-form-urlencoded",
+    Text: "text/plain",
+} as const;
+export type ContentType = (typeof ContentType)[keyof typeof ContentType];
+<% } else { %>
 export enum ContentType {
     Json = "application/json",
     JsonApi = "application/vnd.api+json",
@@ -48,6 +58,7 @@ export enum ContentType {
     UrlEncoded = "application/x-www-form-urlencoded",
     Text = "text/plain",
 }
+<% } %>
 
 export class HttpClient<SecurityDataType = unknown> {
     public baseUrl: string = "<%~ apiConfig.baseUrl %>";

--- a/tests/spec/const-object-enums/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/const-object-enums/__snapshots__/basic.test.ts.snap
@@ -1,0 +1,339 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`basic > const-object-enums 1`] = `
+"/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+export const PetKind = {
+  Cat: 0,
+  Dog: 1,
+  Bird: 2,
+} as const;
+export type PetKind = (typeof PetKind)[keyof typeof PetKind];
+
+export const PetStatus = {
+  Available: "available",
+  Pending: "pending",
+  Sold: "sold",
+} as const;
+export type PetStatus = (typeof PetStatus)[keyof typeof PetStatus];
+
+export interface Pet {
+  id?: number;
+  name: string;
+  status: PetStatus;
+  kind?: PetKind;
+}
+
+export type QueryParamsType = Record<string | number, any>;
+export type ResponseFormat = keyof Omit<Body, "body" | "bodyUsed">;
+
+export interface FullRequestParams extends Omit<RequestInit, "body"> {
+  /** set parameter to \`true\` for call \`securityWorker\` for this request */
+  secure?: boolean;
+  /** request path */
+  path: string;
+  /** content type of request body */
+  type?: ContentType;
+  /** query params */
+  query?: QueryParamsType;
+  /** format of response (i.e. response.json() -> format: "json") */
+  format?: ResponseFormat;
+  /** request body */
+  body?: unknown;
+  /** base url */
+  baseUrl?: string;
+  /** request cancellation token */
+  cancelToken?: CancelToken;
+}
+
+export type RequestParams = Omit<
+  FullRequestParams,
+  "body" | "method" | "query" | "path"
+>;
+
+export interface ApiConfig<SecurityDataType = unknown> {
+  baseUrl?: string;
+  baseApiParams?: Omit<RequestParams, "baseUrl" | "cancelToken" | "signal">;
+  securityWorker?: (
+    securityData: SecurityDataType | null,
+  ) => Promise<RequestParams | void> | RequestParams | void;
+  customFetch?: typeof fetch;
+}
+
+export interface HttpResponse<D extends unknown, E extends unknown = unknown>
+  extends Response {
+  data: D;
+  error: E;
+}
+
+type CancelToken = Symbol | string | number;
+
+export const ContentType = {
+  Json: "application/json",
+  JsonApi: "application/vnd.api+json",
+  FormData: "multipart/form-data",
+  UrlEncoded: "application/x-www-form-urlencoded",
+  Text: "text/plain",
+} as const;
+export type ContentType = (typeof ContentType)[keyof typeof ContentType];
+
+export class HttpClient<SecurityDataType = unknown> {
+  public baseUrl: string = "";
+  private securityData: SecurityDataType | null = null;
+  private securityWorker?: ApiConfig<SecurityDataType>["securityWorker"];
+  private abortControllers = new Map<CancelToken, AbortController>();
+  private customFetch = (...fetchParams: Parameters<typeof fetch>) =>
+    fetch(...fetchParams);
+
+  private baseApiParams: RequestParams = {
+    credentials: "same-origin",
+    headers: {},
+    redirect: "follow",
+    referrerPolicy: "no-referrer",
+  };
+
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
+  }
+
+  public setSecurityData = (data: SecurityDataType | null) => {
+    this.securityData = data;
+  };
+
+  protected encodeQueryParam(key: string, value: any) {
+    const encodedKey = encodeURIComponent(key);
+    return \`\${encodedKey}=\${encodeURIComponent(typeof value === "number" ? value : \`\${value}\`)}\`;
+  }
+
+  protected addQueryParam(query: QueryParamsType, key: string) {
+    return this.encodeQueryParam(key, query[key]);
+  }
+
+  protected addArrayQueryParam(query: QueryParamsType, key: string) {
+    const value = query[key];
+    return value.map((v: any) => this.encodeQueryParam(key, v)).join("&");
+  }
+
+  protected toQueryString(rawQuery?: QueryParamsType): string {
+    const query = rawQuery || {};
+    const keys = Object.keys(query).filter(
+      (key) => "undefined" !== typeof query[key],
+    );
+    return keys
+      .map((key) =>
+        Array.isArray(query[key])
+          ? this.addArrayQueryParam(query, key)
+          : this.addQueryParam(query, key),
+      )
+      .join("&");
+  }
+
+  protected addQueryParams(rawQuery?: QueryParamsType): string {
+    const queryString = this.toQueryString(rawQuery);
+    return queryString ? \`?\${queryString}\` : "";
+  }
+
+  private contentFormatters: Record<ContentType, (input: any) => any> = {
+    [ContentType.Json]: (input: any) =>
+      input !== null && (typeof input === "object" || typeof input === "string")
+        ? JSON.stringify(input)
+        : input,
+    [ContentType.JsonApi]: (input: any) =>
+      input !== null && (typeof input === "object" || typeof input === "string")
+        ? JSON.stringify(input)
+        : input,
+    [ContentType.Text]: (input: any) =>
+      input !== null && typeof input !== "string"
+        ? JSON.stringify(input)
+        : input,
+    [ContentType.FormData]: (input: any) => {
+      if (input instanceof FormData) {
+        return input;
+      }
+
+      return Object.keys(input || {}).reduce((formData, key) => {
+        const property = input[key];
+        formData.append(
+          key,
+          property instanceof Blob
+            ? property
+            : typeof property === "object" && property !== null
+              ? JSON.stringify(property)
+              : \`\${property}\`,
+        );
+        return formData;
+      }, new FormData());
+    },
+    [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),
+  };
+
+  protected mergeRequestParams(
+    params1: RequestParams,
+    params2?: RequestParams,
+  ): RequestParams {
+    return {
+      ...this.baseApiParams,
+      ...params1,
+      ...(params2 || {}),
+      headers: {
+        ...(this.baseApiParams.headers || {}),
+        ...(params1.headers || {}),
+        ...((params2 && params2.headers) || {}),
+      },
+    };
+  }
+
+  protected createAbortSignal = (
+    cancelToken: CancelToken,
+  ): AbortSignal | undefined => {
+    if (this.abortControllers.has(cancelToken)) {
+      const abortController = this.abortControllers.get(cancelToken);
+      if (abortController) {
+        return abortController.signal;
+      }
+      return void 0;
+    }
+
+    const abortController = new AbortController();
+    this.abortControllers.set(cancelToken, abortController);
+    return abortController.signal;
+  };
+
+  public abortRequest = (cancelToken: CancelToken) => {
+    const abortController = this.abortControllers.get(cancelToken);
+
+    if (abortController) {
+      abortController.abort();
+      this.abortControllers.delete(cancelToken);
+    }
+  };
+
+  public request = async <T = any, E = any>({
+    body,
+    secure,
+    path,
+    type,
+    query,
+    format,
+    baseUrl,
+    cancelToken,
+    ...params
+  }: FullRequestParams): Promise<HttpResponse<T, E>> => {
+    const secureParams =
+      ((typeof secure === "boolean" ? secure : this.baseApiParams.secure) &&
+        this.securityWorker &&
+        (await this.securityWorker(this.securityData))) ||
+      {};
+    const requestParams = this.mergeRequestParams(params, secureParams);
+    const queryString = query && this.toQueryString(query);
+    const payloadFormatter = this.contentFormatters[type || ContentType.Json];
+    const responseFormat = format || requestParams.format;
+
+    return this.customFetch(
+      \`\${baseUrl || this.baseUrl || ""}\${path}\${queryString ? \`?\${queryString}\` : ""}\`,
+      {
+        ...requestParams,
+        headers: {
+          ...(requestParams.headers || {}),
+          ...(type && type !== ContentType.FormData
+            ? { "Content-Type": type }
+            : {}),
+        },
+        signal:
+          (cancelToken
+            ? this.createAbortSignal(cancelToken)
+            : requestParams.signal) || null,
+        body:
+          typeof body === "undefined" || body === null
+            ? null
+            : payloadFormatter(body),
+      },
+    ).then(async (response) => {
+      const r = response as HttpResponse<T, E>;
+      r.data = null as unknown as T;
+      r.error = null as unknown as E;
+
+      const responseToParse = responseFormat ? response.clone() : response;
+      const data = !responseFormat
+        ? r
+        : await responseToParse[responseFormat]()
+            .then((data) => {
+              if (r.ok) {
+                r.data = data;
+              } else {
+                r.error = data;
+              }
+              return r;
+            })
+            .catch((e) => {
+              r.error = e;
+              return r;
+            });
+
+      if (cancelToken) {
+        this.abortControllers.delete(cancelToken);
+      }
+
+      if (!response.ok) throw data;
+      return data;
+    });
+  };
+}
+
+/**
+ * @title Test
+ * @version 1.0.0
+ */
+export class Api<
+  SecurityDataType extends unknown,
+> extends HttpClient<SecurityDataType> {
+  pets = {
+    /**
+     * No description
+     *
+     * @name ListPets
+     * @request GET:/pets
+     */
+    listPets: (
+      query?: {
+        status?: PetStatus;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<Pet[], any>({
+        path: \`/pets\`,
+        method: "GET",
+        query: query,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @name CreatePet
+     * @request POST:/pets
+     */
+    createPet: (data: Pet, params: RequestParams = {}) =>
+      this.request<Pet, any>({
+        path: \`/pets\`,
+        method: "POST",
+        body: data,
+        type: ContentType.Json,
+        format: "json",
+        ...params,
+      }),
+  };
+}
+"
+`;

--- a/tests/spec/const-object-enums/basic.test.ts
+++ b/tests/spec/const-object-enums/basic.test.ts
@@ -1,0 +1,33 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { generateApi } from "../../../src/index.js";
+
+describe("basic", async () => {
+  let tmpdir = "";
+
+  beforeAll(async () => {
+    tmpdir = await fs.mkdtemp(path.join(os.tmpdir(), "swagger-typescript-api"));
+  });
+
+  afterAll(async () => {
+    await fs.rm(tmpdir, { recursive: true });
+  });
+
+  test("const-object-enums", async () => {
+    await generateApi({
+      fileName: "schema",
+      input: path.resolve(import.meta.dirname, "schema.json"),
+      output: tmpdir,
+      silent: true,
+      enumStyle: "const",
+    });
+
+    const content = await fs.readFile(path.join(tmpdir, "schema.ts"), {
+      encoding: "utf8",
+    });
+
+    expect(content).toMatchSnapshot();
+  });
+});

--- a/tests/spec/const-object-enums/schema.json
+++ b/tests/spec/const-object-enums/schema.json
@@ -1,0 +1,76 @@
+{
+  "openapi": "3.0.0",
+  "info": { "title": "Test", "version": "1.0.0" },
+  "paths": {
+    "/pets": {
+      "get": {
+        "operationId": "listPets",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "status",
+            "schema": { "$ref": "#/components/schemas/PetStatus" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Pet" }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "createPet",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/Pet" }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Pet" }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "PetStatus": {
+        "type": "string",
+        "enum": ["available", "pending", "sold"],
+        "x-enumNames": ["Available", "Pending", "Sold"]
+      },
+      "PetKind": {
+        "type": "integer",
+        "enum": [0, 1, 2],
+        "x-enumNames": ["Cat", "Dog", "Bird"]
+      },
+      "Pet": {
+        "type": "object",
+        "required": ["name", "status"],
+        "properties": {
+          "id": { "type": "integer" },
+          "name": { "type": "string" },
+          "status": { "$ref": "#/components/schemas/PetStatus" },
+          "kind": { "$ref": "#/components/schemas/PetKind" }
+        }
+      }
+    }
+  }
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -527,7 +527,9 @@ export interface GenerateApiConfiguration {
     generateRouteTypes: boolean;
     /** generate an API client */
     generateClient: boolean;
-    /** generate all "enum" types as union types (T1 | T2 | TN) */
+    /** enum output style: "enum" (default), "union" (T1 | T2 | TN), or "const" (as const object + type alias) */
+    enumStyle: "enum" | "union" | "const";
+    /** @deprecated Use enumStyle: "union" instead */
     generateUnionEnums: boolean;
     /** parsed swagger schema */
     swaggerSchema: OpenAPI.Document;


### PR DESCRIPTION
Closes https://github.com/acacode/swagger-typescript-api/issues/1040

## Problem

The library currently exposes `generateUnionEnums` as a boolean flag to switch enum output to union types. PR #1281 proposes adding a second boolean `generateConstObjectEnums` for `as const` object output. I think adding a second independent boolean is the wrong direction — two mutually exclusive flags that silently override each other is confusing API design, and it still leaves a gap: `ContentType` in the http-client is always emitted as a traditional `enum` regardless of what the user configures, making the output inconsistent.

## Proposal

I propose replacing both flags with a single unified `enumStyle` option:

```typescript
enumStyle?: "enum" | "union" | "const"
// default: "enum"
```

This makes the three output modes explicit and mutually exclusive by construction. `generateUnionEnums` is preserved as a deprecated alias — it still works and emits a runtime warning pointing users to the new option, so nothing breaks for existing consumers.

I also propose extending the `"const"` style to cover `ContentType` in the http-client templates. When `enumStyle: "const"` is set, `ContentType` is emitted as:

```typescript
export const ContentType = {
  Json: "application/json",
  ...
} as const;
export type ContentType = (typeof ContentType)[keyof typeof ContentType];
```

This makes the entire generated output consistent — schema enums and internal http-client constants follow the same pattern.

## Changes

- New `enumStyle: "enum" | "union" | "const"` config option and `--enum-style` CLI flag
- `generateUnionEnums: true` auto-promotes to `enumStyle: "union"` with a deprecation warning
- `"const"` style generates `as const` objects with a companion type alias for all schema enums
- `"const"` style also converts `ContentType` in both Axios and Fetch http-client templates
- `enum-data-contract.ejs` subtemplate updated to support all three styles
- `Ts.Keyword.Const` added for template authors who use `codeGenConstructs`
- Snapshot test added for `enumStyle: "const"`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces `generateUnionEnums` with a unified `enumStyle` option ("enum" | "union" | "const") to control enum output, and applies the `"const"` style to `ContentType` in Axios and Fetch clients. Adds a CLI flag, deprecates the old option with a warning, keeps the default as `"enum"`, and fixes an internal export leak for `const` enums.

- **New Features**
  - Added `enumStyle` ("enum" | "union" | "const") and `--enum-style` CLI flag; `generateUnionEnums` remains as a deprecated alias that auto-promotes to `enumStyle: "union"` with a warning.
  - `"const"` style emits `as const` objects with a companion type alias and updates `ContentType` in both clients; parsers/discriminator handling/templates updated; snapshot tests added.

- **Bug Fixes**
  - `const` handler now respects `internal` and does not export the type alias for internal contracts.

<sup>Written for commit cb32443ab8f8290d66f221f729989bede155c8b3. Summary will update on new commits. <a href="https://cubic.dev/pr/acacode/swagger-typescript-api/pull/1754?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

