### PR TITLE
Fix: query params object incorrectly required when all fields are optional (extractRequestParams)

### DIFF
--- a/.changeset/fix-optional-query-params.md
+++ b/.changeset/fix-optional-query-params.md
@@ -1,0 +1,5 @@
+---
+"swagger-typescript-api": patch
+---
+
+Fix: combined query params object now correctly gets a default value of `{}` when all its fields are optional and no path params are present (extractRequestParams mode)

--- a/src/schema-routes/schema-routes.ts
+++ b/src/schema-routes/schema-routes.ts
@@ -1326,6 +1326,8 @@ export class SchemaRoutes {
         security: hasSecurity,
         method: method,
         requestParams: requestParamsSchema,
+        requestParamsOptional:
+          requestParamsSchema?.typeData?.allFieldsAreOptional ?? false,
 
         payload: specificArgs.body,
         query: specificArgs.query,

--- a/templates/default/procedure-call.ejs
+++ b/templates/default/procedure-call.ejs
@@ -31,8 +31,9 @@ const rawWrapperArgs = config.extractRequestParams ?
     _.compact([
         requestParams && {
           name: extractedRequestParamsName,
-          optional: false,
+          optional: route.request.requestParamsOptional,
           type: getInlineParseContent(requestParams),
+          defaultValue: route.request.requestParamsOptional ? '{}' : undefined,
         },
         ...(!requestParams ? pathParams : []),
         payload,

--- a/templates/modular/procedure-call.ejs
+++ b/templates/modular/procedure-call.ejs
@@ -31,8 +31,9 @@ const rawWrapperArgs = config.extractRequestParams ?
     _.compact([
         requestParams && {
           name: extractedRequestParamsName,
-          optional: false,
+          optional: route.request.requestParamsOptional,
           type: getInlineParseContent(requestParams),
+          defaultValue: route.request.requestParamsOptional ? '{}' : undefined,
         },
         ...(!requestParams ? pathParams : []),
         payload,

--- a/tests/__snapshots__/extended.test.ts.snap
+++ b/tests/__snapshots__/extended.test.ts.snap
@@ -9545,8 +9545,8 @@ export class Api<
      * @request POST:/scope
      */
     signRequest: (
-      query: SignRequestParams,
       body: Claims,
+      query: SignRequestParams = {},
       params: RequestParams = {},
     ) =>
       this.request<SignRequestData, SignRequestError>({
@@ -11682,7 +11682,7 @@ export class Api<
      * @name Gets
      * @request GET:/something/
      */
-    gets: (query: GetsParams, params: RequestParams = {}) =>
+    gets: (query: GetsParams = {}, params: RequestParams = {}) =>
       this.request<any, any>({
         path: \`/something/\`,
         method: "GET",
@@ -50549,7 +50549,7 @@ export class Api<
      * @request GET:/app/installations
      */
     appsListInstallations: (
-      query: AppsListInstallationsParams,
+      query: AppsListInstallationsParams = {},
       params: RequestParams = {},
     ) =>
       this.request<AppsListInstallationsData, any>({
@@ -50876,7 +50876,7 @@ export class Api<
      * @deprecated
      */
     oauthAuthorizationsListGrants: (
-      query: OauthAuthorizationsListGrantsParams,
+      query: OauthAuthorizationsListGrantsParams = {},
       params: RequestParams = {},
     ) =>
       this.request<OauthAuthorizationsListGrantsData, BasicError>({
@@ -51044,7 +51044,7 @@ export class Api<
      * @deprecated
      */
     oauthAuthorizationsListAuthorizations: (
-      query: OauthAuthorizationsListAuthorizationsParams,
+      query: OauthAuthorizationsListAuthorizationsParams = {},
       params: RequestParams = {},
     ) =>
       this.request<OauthAuthorizationsListAuthorizationsData, BasicError>({
@@ -51924,7 +51924,7 @@ export class Api<
      * @request GET:/events
      */
     activityListPublicEvents: (
-      query: ActivityListPublicEventsParams,
+      query: ActivityListPublicEventsParams = {},
       params: RequestParams = {},
     ) =>
       this.request<
@@ -52154,7 +52154,7 @@ export class Api<
      * @summary List gists for the authenticated user
      * @request GET:/gists
      */
-    gistsList: (query: GistsListParams, params: RequestParams = {}) =>
+    gistsList: (query: GistsListParams = {}, params: RequestParams = {}) =>
       this.request<GistsListData, BasicError>({
         path: \`/gists\`,
         method: "GET",
@@ -52232,7 +52232,7 @@ export class Api<
      * @request GET:/gists/public
      */
     gistsListPublic: (
-      query: GistsListPublicParams,
+      query: GistsListPublicParams = {},
       params: RequestParams = {},
     ) =>
       this.request<GistsListPublicData, BasicError | ValidationError>({
@@ -52252,7 +52252,7 @@ export class Api<
      * @request GET:/gists/starred
      */
     gistsListStarred: (
-      query: GistsListStarredParams,
+      query: GistsListStarredParams = {},
       params: RequestParams = {},
     ) =>
       this.request<GistsListStarredData, BasicError>({
@@ -52383,7 +52383,7 @@ export class Api<
      * @request GET:/installation/repositories
      */
     appsListReposAccessibleToInstallation: (
-      query: AppsListReposAccessibleToInstallationParams,
+      query: AppsListReposAccessibleToInstallationParams = {},
       params: RequestParams = {},
     ) =>
       this.request<AppsListReposAccessibleToInstallationData, BasicError>({
@@ -52418,7 +52418,7 @@ export class Api<
      * @summary List issues assigned to the authenticated user
      * @request GET:/issues
      */
-    issuesList: (query: IssuesListParams, params: RequestParams = {}) =>
+    issuesList: (query: IssuesListParams = {}, params: RequestParams = {}) =>
       this.request<IssuesListData, BasicError | ValidationError>({
         path: \`/issues\`,
         method: "GET",
@@ -52453,7 +52453,7 @@ export class Api<
      * @request GET:/licenses
      */
     licensesGetAllCommonlyUsed: (
-      query: LicensesGetAllCommonlyUsedParams,
+      query: LicensesGetAllCommonlyUsedParams = {},
       params: RequestParams = {},
     ) =>
       this.request<LicensesGetAllCommonlyUsedData, any>({
@@ -52595,7 +52595,10 @@ export class Api<
      * @summary List plans
      * @request GET:/marketplace_listing/plans
      */
-    appsListPlans: (query: AppsListPlansParams, params: RequestParams = {}) =>
+    appsListPlans: (
+      query: AppsListPlansParams = {},
+      params: RequestParams = {},
+    ) =>
       this.request<AppsListPlansData, BasicError>({
         path: \`/marketplace_listing/plans\`,
         method: "GET",
@@ -52613,7 +52616,7 @@ export class Api<
      * @request GET:/marketplace_listing/stubbed/plans
      */
     appsListPlansStubbed: (
-      query: AppsListPlansStubbedParams,
+      query: AppsListPlansStubbedParams = {},
       params: RequestParams = {},
     ) =>
       this.request<AppsListPlansStubbedData, BasicError>({
@@ -52731,7 +52734,7 @@ export class Api<
      * @request GET:/notifications
      */
     activityListNotificationsForAuthenticatedUser: (
-      query: ActivityListNotificationsForAuthenticatedUserParams,
+      query: ActivityListNotificationsForAuthenticatedUserParams = {},
       params: RequestParams = {},
     ) =>
       this.request<
@@ -52815,7 +52818,10 @@ export class Api<
      * @summary Get Octocat
      * @request GET:/octocat
      */
-    metaGetOctocat: (query: MetaGetOctocatParams, params: RequestParams = {}) =>
+    metaGetOctocat: (
+      query: MetaGetOctocatParams = {},
+      params: RequestParams = {},
+    ) =>
       this.request<MetaGetOctocatData, any>({
         path: \`/octocat\`,
         method: "GET",
@@ -52832,7 +52838,7 @@ export class Api<
      * @summary List organizations
      * @request GET:/organizations
      */
-    orgsList: (query: OrgsListParams, params: RequestParams = {}) =>
+    orgsList: (query: OrgsListParams = {}, params: RequestParams = {}) =>
       this.request<OrgsListData, any>({
         path: \`/organizations\`,
         method: "GET",
@@ -62356,7 +62362,7 @@ export class Api<
      * @request GET:/repositories
      */
     reposListPublic: (
-      query: ReposListPublicParams,
+      query: ReposListPublicParams = {},
       params: RequestParams = {},
     ) =>
       this.request<ReposListPublicData, ValidationError>({
@@ -63798,7 +63804,7 @@ export class Api<
      * @request GET:/user/starred
      */
     activityListReposStarredByAuthenticatedUser: (
-      query: ActivityListReposStarredByAuthenticatedUserParams,
+      query: ActivityListReposStarredByAuthenticatedUserParams = {},
       params: RequestParams = {},
     ) =>
       this.request<ActivityListReposStarredByAuthenticatedUserData, BasicError>(
@@ -63820,7 +63826,7 @@ export class Api<
      * @request GET:/user/subscriptions
      */
     activityListWatchedReposForAuthenticatedUser: (
-      query: ActivityListWatchedReposForAuthenticatedUserParams,
+      query: ActivityListWatchedReposForAuthenticatedUserParams = {},
       params: RequestParams = {},
     ) =>
       this.request<
@@ -63923,7 +63929,7 @@ export class Api<
      * @request GET:/user/installations
      */
     appsListInstallationsForAuthenticatedUser: (
-      query: AppsListInstallationsForAuthenticatedUserParams,
+      query: AppsListInstallationsForAuthenticatedUserParams = {},
       params: RequestParams = {},
     ) =>
       this.request<
@@ -63950,7 +63956,7 @@ export class Api<
      * @request GET:/user/marketplace_purchases
      */
     appsListSubscriptionsForAuthenticatedUser: (
-      query: AppsListSubscriptionsForAuthenticatedUserParams,
+      query: AppsListSubscriptionsForAuthenticatedUserParams = {},
       params: RequestParams = {},
     ) =>
       this.request<AppsListSubscriptionsForAuthenticatedUserData, BasicError>({
@@ -63970,7 +63976,7 @@ export class Api<
      * @request GET:/user/marketplace_purchases/stubbed
      */
     appsListSubscriptionsForAuthenticatedUserStubbed: (
-      query: AppsListSubscriptionsForAuthenticatedUserStubbedParams,
+      query: AppsListSubscriptionsForAuthenticatedUserStubbedParams = {},
       params: RequestParams = {},
     ) =>
       this.request<
@@ -64072,7 +64078,7 @@ export class Api<
      * @request GET:/user/issues
      */
     issuesListForAuthenticatedUser: (
-      query: IssuesListForAuthenticatedUserParams,
+      query: IssuesListForAuthenticatedUserParams = {},
       params: RequestParams = {},
     ) =>
       this.request<IssuesListForAuthenticatedUserData, BasicError>({
@@ -64150,7 +64156,7 @@ export class Api<
      * @request GET:/user/migrations
      */
     migrationsListForAuthenticatedUser: (
-      query: MigrationsListForAuthenticatedUserParams,
+      query: MigrationsListForAuthenticatedUserParams = {},
       params: RequestParams = {},
     ) =>
       this.request<MigrationsListForAuthenticatedUserData, BasicError>({
@@ -64251,7 +64257,7 @@ export class Api<
      * @request GET:/user/orgs
      */
     orgsListForAuthenticatedUser: (
-      query: OrgsListForAuthenticatedUserParams,
+      query: OrgsListForAuthenticatedUserParams = {},
       params: RequestParams = {},
     ) =>
       this.request<OrgsListForAuthenticatedUserData, BasicError>({
@@ -64271,7 +64277,7 @@ export class Api<
      * @request GET:/user/memberships/orgs
      */
     orgsListMembershipsForAuthenticatedUser: (
-      query: OrgsListMembershipsForAuthenticatedUserParams,
+      query: OrgsListMembershipsForAuthenticatedUserParams = {},
       params: RequestParams = {},
     ) =>
       this.request<
@@ -64408,7 +64414,7 @@ export class Api<
      * @request GET:/user/repos
      */
     reposListForAuthenticatedUser: (
-      query: ReposListForAuthenticatedUserParams,
+      query: ReposListForAuthenticatedUserParams = {},
       params: RequestParams = {},
     ) =>
       this.request<
@@ -64431,7 +64437,7 @@ export class Api<
      * @request GET:/user/repository_invitations
      */
     reposListInvitationsForAuthenticatedUser: (
-      query: ReposListInvitationsForAuthenticatedUserParams,
+      query: ReposListInvitationsForAuthenticatedUserParams = {},
       params: RequestParams = {},
     ) =>
       this.request<ReposListInvitationsForAuthenticatedUserData, BasicError>({
@@ -64451,7 +64457,7 @@ export class Api<
      * @request GET:/user/teams
      */
     teamsListForAuthenticatedUser: (
-      query: TeamsListForAuthenticatedUserParams,
+      query: TeamsListForAuthenticatedUserParams = {},
       params: RequestParams = {},
     ) =>
       this.request<TeamsListForAuthenticatedUserData, BasicError>({
@@ -64754,7 +64760,7 @@ export class Api<
      * @request GET:/user/emails
      */
     usersListEmailsForAuthenticated: (
-      query: UsersListEmailsForAuthenticatedParams,
+      query: UsersListEmailsForAuthenticatedParams = {},
       params: RequestParams = {},
     ) =>
       this.request<UsersListEmailsForAuthenticatedData, BasicError>({
@@ -64774,7 +64780,7 @@ export class Api<
      * @request GET:/user/following
      */
     usersListFollowedByAuthenticated: (
-      query: UsersListFollowedByAuthenticatedParams,
+      query: UsersListFollowedByAuthenticatedParams = {},
       params: RequestParams = {},
     ) =>
       this.request<UsersListFollowedByAuthenticatedData, BasicError>({
@@ -64794,7 +64800,7 @@ export class Api<
      * @request GET:/user/followers
      */
     usersListFollowersForAuthenticatedUser: (
-      query: UsersListFollowersForAuthenticatedUserParams,
+      query: UsersListFollowersForAuthenticatedUserParams = {},
       params: RequestParams = {},
     ) =>
       this.request<UsersListFollowersForAuthenticatedUserData, BasicError>({
@@ -64814,7 +64820,7 @@ export class Api<
      * @request GET:/user/gpg_keys
      */
     usersListGpgKeysForAuthenticated: (
-      query: UsersListGpgKeysForAuthenticatedParams,
+      query: UsersListGpgKeysForAuthenticatedParams = {},
       params: RequestParams = {},
     ) =>
       this.request<UsersListGpgKeysForAuthenticatedData, BasicError>({
@@ -64834,7 +64840,7 @@ export class Api<
      * @request GET:/user/public_emails
      */
     usersListPublicEmailsForAuthenticated: (
-      query: UsersListPublicEmailsForAuthenticatedParams,
+      query: UsersListPublicEmailsForAuthenticatedParams = {},
       params: RequestParams = {},
     ) =>
       this.request<UsersListPublicEmailsForAuthenticatedData, BasicError>({
@@ -64854,7 +64860,7 @@ export class Api<
      * @request GET:/user/keys
      */
     usersListPublicSshKeysForAuthenticated: (
-      query: UsersListPublicSshKeysForAuthenticatedParams,
+      query: UsersListPublicSshKeysForAuthenticatedParams = {},
       params: RequestParams = {},
     ) =>
       this.request<UsersListPublicSshKeysForAuthenticatedData, BasicError>({
@@ -65319,7 +65325,7 @@ export class Api<
      * @summary List users
      * @request GET:/users
      */
-    usersList: (query: UsersListParams, params: RequestParams = {}) =>
+    usersList: (query: UsersListParams = {}, params: RequestParams = {}) =>
       this.request<UsersListData, any>({
         path: \`/users\`,
         method: "GET",
@@ -66897,7 +66903,7 @@ export class Api<
      * @request GET:/gifs
      * @secure
      */
-    getGifsById: (query: GetGifsByIdParams, params: RequestParams = {}) =>
+    getGifsById: (query: GetGifsByIdParams = {}, params: RequestParams = {}) =>
       this.request<GetGifsByIdData, any>({
         path: \`/gifs\`,
         method: "GET",
@@ -66916,7 +66922,7 @@ export class Api<
      * @request GET:/gifs/random
      * @secure
      */
-    randomGif: (query: RandomGifParams, params: RequestParams = {}) =>
+    randomGif: (query: RandomGifParams = {}, params: RequestParams = {}) =>
       this.request<RandomGifData, any>({
         path: \`/gifs/random\`,
         method: "GET",
@@ -66973,7 +66979,10 @@ export class Api<
      * @request GET:/gifs/trending
      * @secure
      */
-    trendingGifs: (query: TrendingGifsParams, params: RequestParams = {}) =>
+    trendingGifs: (
+      query: TrendingGifsParams = {},
+      params: RequestParams = {},
+    ) =>
       this.request<TrendingGifsData, any>({
         path: \`/gifs/trending\`,
         method: "GET",
@@ -66993,7 +67002,10 @@ export class Api<
      * @request GET:/stickers/random
      * @secure
      */
-    randomSticker: (query: RandomStickerParams, params: RequestParams = {}) =>
+    randomSticker: (
+      query: RandomStickerParams = {},
+      params: RequestParams = {},
+    ) =>
       this.request<RandomStickerData, any>({
         path: \`/stickers/random\`,
         method: "GET",
@@ -67054,7 +67066,7 @@ export class Api<
      * @secure
      */
     trendingStickers: (
-      query: TrendingStickersParams,
+      query: TrendingStickersParams = {},
       params: RequestParams = {},
     ) =>
       this.request<TrendingStickersData, any>({
@@ -70204,7 +70216,7 @@ export class Api<
      * @summary List all pets
      * @request GET:/pets
      */
-    listPets: (query: ListPetsParams, params: RequestParams = {}) =>
+    listPets: (query: ListPetsParams = {}, params: RequestParams = {}) =>
       this.request<ListPetsData, ListPetsError>({
         path: \`/pets\`,
         method: "GET",
@@ -70632,7 +70644,7 @@ export class Api<
      * @summary List all pets
      * @request GET:/pets
      */
-    listPets: (query: ListPetsParams, params: RequestParams = {}) =>
+    listPets: (query: ListPetsParams = {}, params: RequestParams = {}) =>
       this.request<ListPetsData, ListPetsError>({
         path: \`/pets\`,
         method: "GET",
@@ -71188,7 +71200,7 @@ export class Api<
      * @name FindPets
      * @request GET:/pets
      */
-    findPets: (query: FindPetsParams, params: RequestParams = {}) =>
+    findPets: (query: FindPetsParams = {}, params: RequestParams = {}) =>
       this.request<FindPetsData, FindPetsError>({
         path: \`/pets\`,
         method: "GET",
@@ -71664,7 +71676,7 @@ export class Api<
      * @name FindPets
      * @request GET:/pets
      */
-    findPets: (query: FindPetsParams, params: RequestParams = {}) =>
+    findPets: (query: FindPetsParams = {}, params: RequestParams = {}) =>
       this.request<FindPetsData, FindPetsError>({
         path: \`/pets\`,
         method: "GET",
@@ -72473,7 +72485,7 @@ export class Api<
      * @name FindPets
      * @request GET:/pets
      */
-    findPets: (query: FindPetsParams, params: RequestParams = {}) =>
+    findPets: (query: FindPetsParams = {}, params: RequestParams = {}) =>
       this.request<FindPetsData, FindPetsError>({
         path: \`/pets\`,
         method: "GET",
@@ -74202,7 +74214,7 @@ export class Api<
      * @name FindPets
      * @request GET:/pets
      */
-    findPets: (query: FindPetsParams, params: RequestParams = {}) =>
+    findPets: (query: FindPetsParams = {}, params: RequestParams = {}) =>
       this.request<FindPetsData, FindPetsError>({
         path: \`/pets\`,
         method: "GET",
@@ -74546,7 +74558,7 @@ export class Api<
      * @request GET:/foobarbaz/{query}
      */
     listPets: (
-      { query, ...queryParams }: ListPetsParams,
+      { query, ...queryParams }: ListPetsParams = {},
       params: RequestParams = {},
     ) =>
       this.request<ListPetsData, any>({
@@ -77197,7 +77209,7 @@ export class Api<
      * @summary User Activity
      * @request GET:/history
      */
-    historyList: (query: HistoryListParams, params: RequestParams = {}) =>
+    historyList: (query: HistoryListParams = {}, params: RequestParams = {}) =>
       this.request<HistoryListData, HistoryListError>({
         path: \`/history\`,
         method: "GET",
@@ -78977,7 +78989,10 @@ export class Api<
      * @request GET:/accounts
      * @secure
      */
-    accountsList: (query: AccountsListParams, params: RequestParams = {}) =>
+    accountsList: (
+      query: AccountsListParams = {},
+      params: RequestParams = {},
+    ) =>
       this.request<AccountsListData, any>({
         path: \`/accounts\`,
         method: "GET",
@@ -79040,7 +79055,10 @@ export class Api<
      * @request GET:/categories
      * @secure
      */
-    categoriesList: (query: CategoriesListParams, params: RequestParams = {}) =>
+    categoriesList: (
+      query: CategoriesListParams = {},
+      params: RequestParams = {},
+    ) =>
       this.request<CategoriesListData, any>({
         path: \`/categories\`,
         method: "GET",
@@ -79079,7 +79097,7 @@ export class Api<
      * @request GET:/tags
      * @secure
      */
-    tagsList: (query: TagsListParams, params: RequestParams = {}) =>
+    tagsList: (query: TagsListParams = {}, params: RequestParams = {}) =>
       this.request<TagsListData, any>({
         path: \`/tags\`,
         method: "GET",
@@ -79167,7 +79185,7 @@ export class Api<
      * @secure
      */
     transactionsList: (
-      query: TransactionsListParams,
+      query: TransactionsListParams = {},
       params: RequestParams = {},
     ) =>
       this.request<TransactionsListData, any>({
@@ -79290,7 +79308,10 @@ export class Api<
      * @request GET:/webhooks
      * @secure
      */
-    webhooksList: (query: WebhooksListParams, params: RequestParams = {}) =>
+    webhooksList: (
+      query: WebhooksListParams = {},
+      params: RequestParams = {},
+    ) =>
       this.request<WebhooksListData, any>({
         path: \`/webhooks\`,
         method: "GET",

--- a/tests/spec/extractRequestParams/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/extractRequestParams/__snapshots__/basic.test.ts.snap
@@ -143,6 +143,11 @@ export interface SignUpdateParams {
   job: string;
 }
 
+export interface GetWithOptionalQueryParams {
+  filter?: string;
+  limit?: number;
+}
+
 export type QueryParamsType = Record<string | number, any>;
 export type ResponseFormat = keyof Omit<Body, "body" | "bodyUsed">;
 
@@ -681,8 +686,8 @@ export class Api<
      * @request POST:/scope
      */
     signRequest: (
-      query: SignRequestParams,
       body: Claims,
+      query: SignRequestParams = {},
       params: RequestParams = {},
     ) =>
       this.request<
@@ -804,6 +809,25 @@ export class Api<
       >({
         path: \`/scope/\${job}\`,
         method: "PUT",
+        ...params,
+      }),
+  };
+  optionalQuery = {
+    /**
+     * @description Route with only optional query params — params object should be optional
+     *
+     * @tags optional
+     * @name GetWithOptionalQuery
+     * @request GET:/optional-query
+     */
+    getWithOptionalQuery: (
+      query: GetWithOptionalQueryParams = {},
+      params: RequestParams = {},
+    ) =>
+      this.request<void, any>({
+        path: \`/optional-query\`,
+        method: "GET",
+        query: query,
         ...params,
       }),
   };

--- a/tests/spec/extractRequestParams/schema.json
+++ b/tests/spec/extractRequestParams/schema.json
@@ -808,6 +808,32 @@
         },
         "tags": ["scope", "put"]
       }
+    },
+    "/optional-query": {
+      "get": {
+        "description": "Route with only optional query params — params object should be optional",
+        "operationId": "getWithOptionalQuery",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "tags": ["optional"]
+      }
     }
   },
   "definitions": {

--- a/tests/spec/github-url-refs/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/github-url-refs/__snapshots__/basic.test.ts.snap
@@ -305,7 +305,10 @@ export class Api<
      * @summary Get path for project
      * @request GET:/v1/projects/path
      */
-    getProjectPath: (query: GetProjectPathParams, params: RequestParams = {}) =>
+    getProjectPath: (
+      query: GetProjectPathParams = {},
+      params: RequestParams = {},
+    ) =>
       this.request<GetProjectPathData, GetProjectPathError>({
         path: \`/v1/projects/path\`,
         method: "GET",

--- a/tests/spec/gitlab-url-refs/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/gitlab-url-refs/__snapshots__/basic.test.ts.snap
@@ -305,7 +305,7 @@ export class Api<
      * @summary Get path for memory
      * @request GET:/v1/memories/path
      */
-    getMemory: (query: GetMemoryParams, params: RequestParams = {}) =>
+    getMemory: (query: GetMemoryParams = {}, params: RequestParams = {}) =>
       this.request<GetMemoryData, GetMemoryError>({
         path: \`/v1/memories/path\`,
         method: "GET",

--- a/tests/spec/issue-1668/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/issue-1668/__snapshots__/basic.test.ts.snap
@@ -319,7 +319,7 @@ export class Api<SecurityDataType extends unknown> {
      * @summary List finding exports
      * @request GET:/findings/exports
      */
-    exportsList: (query: ExportsListParams, params: RequestParams = {}) =>
+    exportsList: (query: ExportsListParams = {}, params: RequestParams = {}) =>
       this.http.request<ExportsListData, any>({
         path: \`/findings/exports\`,
         method: "GET",
@@ -337,7 +337,7 @@ export class Api<SecurityDataType extends unknown> {
      * @summary List asset exports
      * @request GET:/assets/exports
      */
-    exportsList: (query: ExportsListParams2, params: RequestParams = {}) =>
+    exportsList: (query: ExportsListParams2 = {}, params: RequestParams = {}) =>
       this.http.request<ExportsListResult, any>({
         path: \`/assets/exports\`,
         method: "GET",
@@ -355,7 +355,7 @@ export class Api<SecurityDataType extends unknown> {
      * @summary List remediation exports
      * @request GET:/remediation/exports
      */
-    exportsList: (query: ExportsListParams4, params: RequestParams = {}) =>
+    exportsList: (query: ExportsListParams4 = {}, params: RequestParams = {}) =>
       this.http.request<ExportsListOutput, any>({
         path: \`/remediation/exports\`,
         method: "GET",
@@ -373,7 +373,7 @@ export class Api<SecurityDataType extends unknown> {
      * @summary List all exports
      * @request GET:/exports
      */
-    exportsList: (query: ExportsListParams6, params: RequestParams = {}) =>
+    exportsList: (query: ExportsListParams6 = {}, params: RequestParams = {}) =>
       this.http.request<ExportsListData1, any>({
         path: \`/exports\`,
         method: "GET",

--- a/tests/spec/paths/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/paths/__snapshots__/basic.test.ts.snap
@@ -870,7 +870,7 @@ export class Api<
      * @name FindPets
      * @request GET:/pets
      */
-    findPets: (query: FindPetsParams, params: RequestParams = {}) =>
+    findPets: (query: FindPetsParams = {}, params: RequestParams = {}) =>
       this.request<FindPetsData, void>({
         path: \`/pets\`,
         method: "GET",

--- a/tests/spec/responses-refs-test/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/responses-refs-test/__snapshots__/basic.test.ts.snap
@@ -5232,7 +5232,7 @@ export class Api<
      * @summary Neutral documentation text.
      * @request GET:/fixture/r0003
      */
-    op0003: (query: Op0003Params, params: RequestParams = {}) =>
+    op0003: (query: Op0003Params = {}, params: RequestParams = {}) =>
       this.request<Op0003Data, Sch0028>({
         path: \`/fixture/r0003\`,
         method: "GET",
@@ -5520,7 +5520,7 @@ export class Api<
      * @request GET:/fixture/r0018
      * @secure
      */
-    op0019: (query: Op0019Params, params: RequestParams = {}) =>
+    op0019: (query: Op0019Params = {}, params: RequestParams = {}) =>
       this.request<Op0019Data, Sch0028>({
         path: \`/fixture/r0018\`,
         method: "GET",
@@ -5578,7 +5578,7 @@ export class Api<
      * @request GET:/fixture/r0020
      * @secure
      */
-    op0022: (query: Op0022Params, params: RequestParams = {}) =>
+    op0022: (query: Op0022Params = {}, params: RequestParams = {}) =>
       this.request<Op0022Data, Sch0028>({
         path: \`/fixture/r0020\`,
         method: "GET",
@@ -5943,7 +5943,7 @@ export class Api<
      * @request GET:/fixture/r0030
      * @secure
      */
-    op0040: (query: Op0040Params, params: RequestParams = {}) =>
+    op0040: (query: Op0040Params = {}, params: RequestParams = {}) =>
       this.request<Op0040Data, Sch0028>({
         path: \`/fixture/r0030\`,
         method: "GET",
@@ -5978,7 +5978,7 @@ export class Api<
      * @request GET:/fixture/r0032
      * @secure
      */
-    op0042: (query: Op0042Params, params: RequestParams = {}) =>
+    op0042: (query: Op0042Params = {}, params: RequestParams = {}) =>
       this.request<Op0042Data, Sch0028>({
         path: \`/fixture/r0032\`,
         method: "GET",
@@ -6279,7 +6279,7 @@ export class Api<
      * @request GET:/fixture/r0043
      * @secure
      */
-    op0058: (query: Op0058Params, params: RequestParams = {}) =>
+    op0058: (query: Op0058Params = {}, params: RequestParams = {}) =>
       this.request<Op0058Data, Sch0028>({
         path: \`/fixture/r0043\`,
         method: "GET",
@@ -6472,7 +6472,7 @@ export class Api<
      * @request GET:/fixture/r0051
      * @secure
      */
-    op0068: (query: Op0068Params, params: RequestParams = {}) =>
+    op0068: (query: Op0068Params = {}, params: RequestParams = {}) =>
       this.request<Op0068Data, Sch0028>({
         path: \`/fixture/r0051\`,
         method: "GET",
@@ -6624,7 +6624,7 @@ export class Api<
      * @request GET:/fixture/r0056
      * @secure
      */
-    op0076: (query: Op0076Params, params: RequestParams = {}) =>
+    op0076: (query: Op0076Params = {}, params: RequestParams = {}) =>
       this.request<Op0076Data, Sch0028>({
         path: \`/fixture/r0056\`,
         method: "GET",
@@ -6898,7 +6898,7 @@ export class Api<
      * @request GET:/fixture/r0064
      * @secure
      */
-    op0090: (query: Op0090Params, params: RequestParams = {}) =>
+    op0090: (query: Op0090Params = {}, params: RequestParams = {}) =>
       this.request<Op0090Data, Sch0028>({
         path: \`/fixture/r0064\`,
         method: "GET",
@@ -6935,7 +6935,7 @@ export class Api<
      * @request GET:/fixture/r0066
      * @secure
      */
-    op0092: (query: Op0092Params, params: RequestParams = {}) =>
+    op0092: (query: Op0092Params = {}, params: RequestParams = {}) =>
       this.request<Op0092Data, Sch0028>({
         path: \`/fixture/r0066\`,
         method: "GET",
@@ -7635,7 +7635,7 @@ export class Api<
      * @request GET:/fixture/r0100
      * @secure
      */
-    op0129: (query: Op0129Params, params: RequestParams = {}) =>
+    op0129: (query: Op0129Params = {}, params: RequestParams = {}) =>
       this.request<Op0129Data, Sch0028>({
         path: \`/fixture/r0100\`,
         method: "GET",
@@ -8111,7 +8111,7 @@ export class Api<
      * @request GET:/fixture/r0118
      * @secure
      */
-    op0152: (query: Op0152Params, params: RequestParams = {}) =>
+    op0152: (query: Op0152Params = {}, params: RequestParams = {}) =>
       this.request<Op0152Data, Sch0028>({
         path: \`/fixture/r0118\`,
         method: "GET",
@@ -8342,7 +8342,7 @@ export class Api<
      * @request GET:/fixture/r0127
      * @secure
      */
-    op0164: (query: Op0164Params, params: RequestParams = {}) =>
+    op0164: (query: Op0164Params = {}, params: RequestParams = {}) =>
       this.request<Op0164Data, Sch0028>({
         path: \`/fixture/r0127\`,
         method: "GET",

--- a/types/index.ts
+++ b/types/index.ts
@@ -338,6 +338,7 @@ export interface ParsedRouteRequest {
   payload?: { name: string | null; optional?: boolean; type: string };
   query?: Record<string, unknown>;
   requestParams?: Record<string, unknown> | null;
+  requestParamsOptional?: boolean;
   security?: boolean;
 }
 


### PR DESCRIPTION
Closes https://github.com/acacode/swagger-typescript-api/issues/1755

## Problem

When using `extractRequestParams: true`, if a route has only optional query parameters and no path parameters, the generated method signature forces callers to pass an explicit argument even though every field inside it is optional:

```typescript
// generated — wrong
getItems(query: GetItemsParams, params?: RequestParams)

// caller is forced to write
api.items.getItems({})
// instead of simply
api.items.getItems()
```

The root cause is that `procedure-call.ejs` hardcodes `optional: false` for the combined params argument. The `allFieldsAreOptional` flag is already computed correctly inside `requestParamsSchema.typeData` by the existing `ObjectSchemaParser`, but it was never surfaced to the template.

## Solution

I propose a minimal source-level fix: expose `requestParamsSchema?.typeData?.allFieldsAreOptional` as `requestParamsOptional` on the route's request info object in `parseRouteInfo()` (`schema-routes.ts`). The template then reads this flag instead of hardcoding `false`, and adds `= {}` as the default value when the params object is optional.

No schema construction changes are needed — the data was already correct, just unexposed.

```typescript
// generated — correct
getItems(query: GetItemsParams = {}, params?: RequestParams)
```

## Changes

- `src/schema-routes/schema-routes.ts` — add `requestParamsOptional` to the route request info
- `types/index.ts` — add `requestParamsOptional?: boolean` to `ParsedRouteRequest`
- `templates/default/procedure-call.ejs` — read `route.request.requestParamsOptional` instead of hardcoded `false`
- `templates/modular/procedure-call.ejs` — same change
- `tests/spec/extractRequestParams/schema.json` — add a route with only optional query params to cover this case
- Snapshot updates across extended tests where routes with all-optional query params now correctly get `= {}`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `extractRequestParams` so routes with only optional query params no longer force callers to pass `{}`. Generated methods now make the combined query object optional and default it to `{}`.

- **Bug Fixes**
  - Mark the combined query params object as optional and add `= {}` when all its fields are optional and there are no path params.
  - Surface `requestParamsSchema.typeData.allFieldsAreOptional` as `requestParamsOptional` in `schema-routes.ts`, and add `requestParamsOptional` to `ParsedRouteRequest` in `types/index.ts`.
  - Update `templates/*/procedure-call.ejs` to respect `requestParamsOptional` and set `defaultValue: '{}'` when applicable.
  - Add a covering test route and update snapshots; add a patch changeset.

<sup>Written for commit 209cb7ae53d78b992ca9db32edea3ccb28a77fc7. Summary will update on new commits. <a href="https://cubic.dev/pr/acacode/swagger-typescript-api/pull/1756?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

