### PR TITLE
Security/fixing vulnerabilities

### DIFF
--- a/.changeset/fix-enum-string-value-injection.md
+++ b/.changeset/fix-enum-string-value-injection.md
@@ -1,0 +1,7 @@
+---
+"swagger-typescript-api": patch
+---
+
+Fix code injection via unescaped enum string values in generated TypeScript enums
+
+Malicious OpenAPI specs could embed arbitrary JavaScript in `components.schemas.*.enum` string values. `Ts.StringValue` wrapped values in double quotes without escaping, allowing attackers to break out of generated enum declarations and inject code that executes at module load when consumers import the generated client. Enum string values are now properly escaped.

--- a/.changeset/fix-enum-string-value-injection.md
+++ b/.changeset/fix-enum-string-value-injection.md
@@ -5,3 +5,5 @@
 Fix code injection via unescaped enum string values in generated TypeScript enums
 
 Malicious OpenAPI specs could embed arbitrary JavaScript in `components.schemas.*.enum` string values. `Ts.StringValue` wrapped values in double quotes without escaping, allowing attackers to break out of generated enum declarations and inject code that executes at module load when consumers import the generated client. Enum string values are now properly escaped.
+
+Reported by [@thegr1ffyn](https://github.com/thegr1ffyn): [GHSA-5f94-x226-ccpm](https://github.com/advisories/GHSA-5f94-x226-ccpm).

--- a/.changeset/fix-http-client-base-url-injection.md
+++ b/.changeset/fix-http-client-base-url-injection.md
@@ -1,0 +1,7 @@
+---
+"swagger-typescript-api": patch
+---
+
+Fix code injection via unescaped `servers[0].url` in generated axios and fetch HTTP clients
+
+Malicious OpenAPI specs could embed arbitrary JavaScript in `servers[0].url`. The value was interpolated raw into string literals in generated client constructors, allowing computed-property-key injection and arbitrary code execution when consumers instantiated `HttpClient` or `Api`. `apiConfig.baseUrl` is now escaped once at the source before template rendering.

--- a/.changeset/fix-http-client-base-url-injection.md
+++ b/.changeset/fix-http-client-base-url-injection.md
@@ -4,4 +4,6 @@
 
 Fix code injection via unescaped `servers[0].url` in generated axios and fetch HTTP clients
 
-Malicious OpenAPI specs could embed arbitrary JavaScript in `servers[0].url`. The value was interpolated raw into string literals in generated client constructors, allowing computed-property-key injection and arbitrary code execution when consumers instantiated `HttpClient` or `Api`. `apiConfig.baseUrl` is now escaped once at the source before template rendering.
+Malicious OpenAPI specs could embed arbitrary JavaScript in `servers[0].url`. The value was interpolated raw into string literals in generated client constructors, allowing computed-property-key injection and arbitrary code execution when consumers instantiated `HttpClient` or `Api` (axios) or imported the generated module (fetch). `apiConfig.baseUrl` is now escaped once at the source before template rendering.
+
+Reported by [@thegr1ffyn](https://github.com/thegr1ffyn): [GHSA-38c3-wv3c-v3xj](https://github.com/advisories/GHSA-38c3-wv3c-v3xj) (axios), [GHSA-hqj5-cw9f-rx67](https://github.com/advisories/GHSA-hqj5-cw9f-rx67) (fetch).

--- a/.changeset/fix-route-path-injection.md
+++ b/.changeset/fix-route-path-injection.md
@@ -1,0 +1,7 @@
+---
+"swagger-typescript-api": patch
+---
+
+Fix code injection via unescaped OpenAPI path strings in generated method bodies
+
+Malicious OpenAPI specs could embed arbitrary JavaScript in path keys. Values were interpolated raw into template literals in generated API methods, so `${…}` expressions ran with full process privileges on every call to the affected method. Route paths are now escaped for template-literal insertion while preserving deliberate `${paramName}` interpolations for declared path parameters.

--- a/.changeset/fix-route-path-injection.md
+++ b/.changeset/fix-route-path-injection.md
@@ -5,3 +5,5 @@
 Fix code injection via unescaped OpenAPI path strings in generated method bodies
 
 Malicious OpenAPI specs could embed arbitrary JavaScript in path keys. Values were interpolated raw into template literals in generated API methods, so `${…}` expressions ran with full process privileges on every call to the affected method. Route paths are now escaped for template-literal insertion while preserving deliberate `${paramName}` interpolations for declared path parameters.
+
+Reported by [@thegr1ffyn](https://github.com/thegr1ffyn): [GHSA-w284-33mx-6g9v](https://github.com/advisories/GHSA-w284-33mx-6g9v).

--- a/.changeset/pink-clowns-follow.md
+++ b/.changeset/pink-clowns-follow.md
@@ -13,3 +13,5 @@ Remote schema fetches now enforce a defense-in-depth policy:
 - Allow the explicit `--url` spec source even on loopback (local development)
 - Follow redirects manually (max 5) and re-validate each hop
 - Forward `authorizationToken` only to same-origin remote URLs, not cross-origin `$ref` targets
+
+Reported by [@thegr1ffyn](https://github.com/thegr1ffyn): [GHSA-h754-fxp7-88wx](https://github.com/advisories/GHSA-h754-fxp7-88wx), [GHSA-x36r-4347-pm5x](https://github.com/advisories/GHSA-x36r-4347-pm5x).

--- a/.changeset/pink-clowns-follow.md
+++ b/.changeset/pink-clowns-follow.md
@@ -1,0 +1,5 @@
+---
+"swagger-typescript-api": patch
+---
+
+CVE (GHSA-h754-fxp7-88wx) - Authorization-token exfiltration via spec `$ref`; generator forwards `--authorizationToken` to cross-origin `$ref` URLs without same-origin check, allowing a malicious spec to steal the developer's bearer token

--- a/.changeset/pink-clowns-follow.md
+++ b/.changeset/pink-clowns-follow.md
@@ -3,3 +3,13 @@
 ---
 
 Fix authorization-token exfiltration and SSRF via spec `$ref` during remote schema resolution
+
+When generating from a remote OpenAPI spec, the generator walked every external `$ref` and fetched any `http(s)://` URL without validating the target. A malicious spec could force HTTP requests to loopback, RFC-1918, link-local (including cloud metadata at 169.254.169.254), or internal hostnames reachable from the generator process. Redirect chains were also followed without re-validation.
+
+Remote schema fetches now enforce a defense-in-depth policy:
+
+- Block private, link-local, and loopback addresses (IPv4 and IPv6), including `localhost`
+- Allow cross-origin fetches only to public hosts; same-origin `$ref` targets remain allowed
+- Allow the explicit `--url` spec source even on loopback (local development)
+- Follow redirects manually (max 5) and re-validate each hop
+- Forward `authorizationToken` only to same-origin remote URLs, not cross-origin `$ref` targets

--- a/.changeset/pink-clowns-follow.md
+++ b/.changeset/pink-clowns-follow.md
@@ -2,4 +2,4 @@
 "swagger-typescript-api": patch
 ---
 
-CVE (GHSA-h754-fxp7-88wx) - Authorization-token exfiltration via spec `$ref`; generator forwards `--authorizationToken` to cross-origin `$ref` URLs without same-origin check, allowing a malicious spec to steal the developer's bearer token
+Fix authorization-token exfiltration and SSRF via spec `$ref` during remote schema resolution

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.cts",
   "bin": {
-    "sta": "./dist/cli.mjs",
     "swagger-typescript-api": "./dist/cli.mjs"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.cts",
   "bin": {
+    "sta": "./dist/cli.mjs",
     "swagger-typescript-api": "./dist/cli.mjs"
   },
   "files": [

--- a/src/code-gen-process.ts
+++ b/src/code-gen-process.ts
@@ -17,6 +17,7 @@ import { TemplatesWorker } from "./templates-worker.js";
 import { JavascriptTranslator } from "./translators/javascript.js";
 import type { TranslatorIO } from "./translators/translator.js";
 import { TypeNameFormatter } from "./type-name-formatter.js";
+import { escapeJsStringLiteral } from "./util/escape-js-string-literal.js";
 import { FileSystem } from "./util/file-system.js";
 import { createLodashCompat } from "./util/lodash-compat.js";
 import { NameResolver } from "./util/name-resolver.js";
@@ -588,7 +589,7 @@ export class CodeGenProcess {
         externalDocs || {},
       ),
       tags: compact(tags || []),
-      baseUrl: serverUrl,
+      baseUrl: escapeJsStringLiteral(serverUrl ?? ""),
       title,
       version,
     };

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -14,6 +14,7 @@ import type { ResolvedSwaggerSchema } from "./resolved-swagger-schema.js";
 import type { MonoSchemaParser } from "./schema-parser/mono-schema-parser.js";
 import type { SchemaParser } from "./schema-parser/schema-parser.js";
 import type { Translator } from "./translators/translator.js";
+import { escapeJsStringLiteral } from "./util/escape-js-string-literal.js";
 import { objectAssign } from "./util/object-assign.js";
 
 const TsKeyword = {
@@ -247,7 +248,8 @@ export class CodeGenConfig {
     /**
      * "$A"
      */
-    StringValue: (content: unknown) => `"${content}"`,
+    StringValue: (content: unknown) =>
+      `"${escapeJsStringLiteral(String(content))}"`,
     /**
      * $A
      */

--- a/src/resolved-swagger-schema.ts
+++ b/src/resolved-swagger-schema.ts
@@ -78,14 +78,34 @@ export class ResolvedSwaggerSchema {
     return /^https?:\/\//i.test(value);
   }
 
-  private getRemoteRequestHeaders(): Record<string, string> {
+  private isSameOrigin(a: string, b: string | undefined): boolean {
+    if (typeof b !== "string") {
+      return false;
+    }
+
+    try {
+      const urlA = new URL(a);
+      const urlB = new URL(b);
+      return urlA.protocol === urlB.protocol && urlA.host === urlB.host;
+    } catch {
+      return false;
+    }
+  }
+
+  private getRemoteRequestHeaders(targetUrl?: string): Record<string, string> {
+    const headers: Record<string, string> = {};
+
+    if (
+      this.config.authorizationToken &&
+      targetUrl &&
+      typeof this.config.url === "string" &&
+      this.isSameOrigin(targetUrl, this.config.url)
+    ) {
+      headers.Authorization = this.config.authorizationToken;
+    }
+
     return Object.assign(
-      {},
-      this.config.authorizationToken
-        ? {
-            Authorization: this.config.authorizationToken,
-          }
-        : {},
+      headers,
       (this.config.requestOptions?.headers as
         | Record<string, string>
         | undefined) || {},
@@ -372,7 +392,7 @@ export class ResolvedSwaggerSchema {
   ): Promise<Maybe<AnyObject>> {
     try {
       const response = await fetch(url, {
-        headers: this.getRemoteRequestHeaders(),
+        headers: this.getRemoteRequestHeaders(url),
       });
 
       if (!response.ok) {
@@ -921,15 +941,7 @@ export class ResolvedSwaggerSchema {
         external: true,
         http: {
           ...config.requestOptions,
-          headers: Object.assign(
-            {},
-            config.authorizationToken
-              ? {
-                  Authorization: config.authorizationToken,
-                }
-              : {},
-            config.requestOptions?.headers ?? {},
-          ),
+          headers: config.requestOptions?.headers ?? {},
         },
       },
     };

--- a/src/resolved-swagger-schema.ts
+++ b/src/resolved-swagger-schema.ts
@@ -7,6 +7,11 @@ import type { OpenAPI } from "openapi-types";
 import type { AnyObject, Maybe, Primitive } from "yummies/types";
 import type { CodeGenConfig } from "./configuration.js";
 import { parseSchemaContent } from "./util/parse-schema-content.js";
+import {
+  fetchRemoteSchemaResponse,
+  isRemoteSchemaFetchAllowed,
+  isSameHttpOrigin,
+} from "./util/remote-schema-fetch.js";
 
 export interface RefDetails {
   ref: string;
@@ -78,18 +83,11 @@ export class ResolvedSwaggerSchema {
     return /^https?:\/\//i.test(value);
   }
 
-  private isSameOrigin(a: string, b: string | undefined): boolean {
-    if (typeof b !== "string") {
-      return false;
-    }
-
-    try {
-      const urlA = new URL(a);
-      const urlB = new URL(b);
-      return urlA.protocol === urlB.protocol && urlA.host === urlB.host;
-    } catch {
-      return false;
-    }
+  private isExplicitSpecUrl(url: string): boolean {
+    return (
+      typeof this.config.url === "string" &&
+      this.stripHash(url) === this.stripHash(this.config.url)
+    );
   }
 
   private getRemoteRequestHeaders(targetUrl?: string): Record<string, string> {
@@ -99,7 +97,7 @@ export class ResolvedSwaggerSchema {
       this.config.authorizationToken &&
       targetUrl &&
       typeof this.config.url === "string" &&
-      this.isSameOrigin(targetUrl, this.config.url)
+      isSameHttpOrigin(targetUrl, this.config.url)
     ) {
       headers.Authorization = this.config.authorizationToken;
     }
@@ -391,11 +389,19 @@ export class ResolvedSwaggerSchema {
     url: string,
   ): Promise<Maybe<AnyObject>> {
     try {
-      const response = await fetch(url, {
-        headers: this.getRemoteRequestHeaders(url),
-      });
+      const response = await fetchRemoteSchemaResponse(
+        url,
+        {
+          headers: this.getRemoteRequestHeaders(url),
+        },
+        {
+          specSourceUrl:
+            typeof this.config.url === "string" ? this.config.url : undefined,
+          allowExplicitSpecUrl: this.isExplicitSpecUrl(url),
+        },
+      );
 
-      if (!response.ok) {
+      if (!response?.ok) {
         return null;
       }
 
@@ -457,7 +463,13 @@ export class ResolvedSwaggerSchema {
         }
 
         const absoluteUrl = this.resolveAbsoluteUrl(externalPath, currentUrl);
-        if (absoluteUrl && !visited.has(absoluteUrl)) {
+        if (
+          absoluteUrl &&
+          !visited.has(absoluteUrl) &&
+          (await isRemoteSchemaFetchAllowed(absoluteUrl, {
+            specSourceUrl: this.config.url,
+          }))
+        ) {
           queue.push(absoluteUrl);
         }
       }

--- a/src/schema-routes/schema-routes.ts
+++ b/src/schema-routes/schema-routes.ts
@@ -27,6 +27,7 @@ import type { SchemaParserFabric } from "../schema-parser/schema-parser-fabric.j
 import type { SchemaUtils } from "../schema-parser/schema-utils.js";
 import type { TemplatesWorker } from "../templates-worker.js";
 import type { TypeNameFormatter } from "../type-name-formatter.js";
+import { escapeJsTemplateLiteralStatic } from "../util/escape-js-template-literal-with-path-params.js";
 import { generateId } from "../util/id.js";
 import { SpecificArgNameResolver } from "./util/specific-arg-name-resolver.js";
 
@@ -177,6 +178,8 @@ export class SchemaRoutes {
       });
     }
 
+    const escapedRouteName = escapeJsTemplateLiteralStatic(routeName || "");
+
     let fixedRoute = pathParams.reduce((fixedRoute, pathParam, i, arr) => {
       const insertion =
         this.config.hooks.onInsertPathParam(
@@ -186,7 +189,7 @@ export class SchemaRoutes {
           fixedRoute,
         ) || pathParam.name;
       return fixedRoute.replace(pathParam.$match, `\${${insertion}}`);
-    }, routeName || "");
+    }, escapedRouteName);
 
     const queryParamMatches = fixedRoute.match(/(\{\?.*\})/g);
     const queryParams: any[] = [];

--- a/src/util/escape-js-string-literal.ts
+++ b/src/util/escape-js-string-literal.ts
@@ -1,12 +1,4 @@
-/**
- * Escapes a value for safe insertion into a generated JavaScript/TypeScript
- * double-quoted string literal (without the surrounding quotes).
- *
- * OpenAPI spec fields such as `servers[0].url` and `components.schemas.*.enum`
- * string values are untrusted input. Templates interpolate these into string
- * literals in generated client code; without escaping, a malicious value can
- * break out of the literal and inject executable code into the consumer's bundle.
- */
+/** Escapes a value for insertion into a double-quoted JS/TS string literal (without surrounding quotes). */
 export function escapeJsStringLiteral(value: string): string {
   return JSON.stringify(value).slice(1, -1);
 }

--- a/src/util/escape-js-string-literal.ts
+++ b/src/util/escape-js-string-literal.ts
@@ -1,0 +1,12 @@
+/**
+ * Escapes a value for safe insertion into a generated JavaScript/TypeScript
+ * double-quoted string literal (without the surrounding quotes).
+ *
+ * OpenAPI spec fields such as `servers[0].url` are untrusted input. Templates
+ * interpolate `apiConfig.baseUrl` into string literals in generated client code;
+ * without escaping, a malicious URL can break out of the literal and inject
+ * executable code into the consumer's bundle.
+ */
+export function escapeJsStringLiteral(value: string): string {
+  return JSON.stringify(value).slice(1, -1);
+}

--- a/src/util/escape-js-string-literal.ts
+++ b/src/util/escape-js-string-literal.ts
@@ -2,10 +2,10 @@
  * Escapes a value for safe insertion into a generated JavaScript/TypeScript
  * double-quoted string literal (without the surrounding quotes).
  *
- * OpenAPI spec fields such as `servers[0].url` are untrusted input. Templates
- * interpolate `apiConfig.baseUrl` into string literals in generated client code;
- * without escaping, a malicious URL can break out of the literal and inject
- * executable code into the consumer's bundle.
+ * OpenAPI spec fields such as `servers[0].url` and `components.schemas.*.enum`
+ * string values are untrusted input. Templates interpolate these into string
+ * literals in generated client code; without escaping, a malicious value can
+ * break out of the literal and inject executable code into the consumer's bundle.
  */
 export function escapeJsStringLiteral(value: string): string {
   return JSON.stringify(value).slice(1, -1);

--- a/src/util/escape-js-template-literal-with-path-params.ts
+++ b/src/util/escape-js-template-literal-with-path-params.ts
@@ -1,0 +1,43 @@
+/**
+ * Escapes static segments for safe insertion into a generated JavaScript
+ * template literal (without the surrounding backticks).
+ *
+ * Call this on untrusted OpenAPI path strings **before** deliberate
+ * `${paramName}` interpolations are inserted by `parseRouteName`.
+ */
+export function escapeJsTemplateLiteralStatic(value: string): string {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/`/g, "\\`")
+    .replace(/\$\{/g, "\\${");
+}
+
+/**
+ * Escapes a fully-built route path for template-literal insertion while
+ * preserving known `${paramName}` interpolations for declared path params.
+ */
+export function escapeJsTemplateLiteralWithPathParams(
+  path: string,
+  pathParamNames: readonly string[],
+): string {
+  const PATH_PARAM_PLACEHOLDER_PREFIX = "__STA_PATH_PARAM_";
+  let sanitized = path;
+
+  pathParamNames.forEach((paramName, index) => {
+    sanitized = sanitized.replaceAll(
+      `\${${paramName}}`,
+      `${PATH_PARAM_PLACEHOLDER_PREFIX}${index}__`,
+    );
+  });
+
+  sanitized = escapeJsTemplateLiteralStatic(sanitized);
+
+  pathParamNames.forEach((paramName, index) => {
+    sanitized = sanitized.replaceAll(
+      `${PATH_PARAM_PLACEHOLDER_PREFIX}${index}__`,
+      `\${${paramName}}`,
+    );
+  });
+
+  return sanitized;
+}

--- a/src/util/escape-js-template-literal-with-path-params.ts
+++ b/src/util/escape-js-template-literal-with-path-params.ts
@@ -15,29 +15,41 @@ export function escapeJsTemplateLiteralStatic(value: string): string {
 /**
  * Escapes a fully-built route path for template-literal insertion while
  * preserving known `${paramName}` interpolations for declared path params.
+ *
+ * Uses a single-pass approach: split on known interpolations, escape only
+ * the static segments between them, and reassemble. This avoids placeholder
+ * tokens that could collide with user path content.
  */
 export function escapeJsTemplateLiteralWithPathParams(
   path: string,
   pathParamNames: readonly string[],
 ): string {
-  const PATH_PARAM_PLACEHOLDER_PREFIX = "__STA_PATH_PARAM_";
-  let sanitized = path;
+  if (pathParamNames.length === 0) {
+    return escapeJsTemplateLiteralStatic(path);
+  }
 
-  pathParamNames.forEach((paramName, index) => {
-    sanitized = sanitized.replaceAll(
-      `\${${paramName}}`,
-      `${PATH_PARAM_PLACEHOLDER_PREFIX}${index}__`,
-    );
-  });
+  const paramPattern = new RegExp(
+    pathParamNames
+      .map((p) => `\\$\\{${escapeRegExp(p)}\\}`)
+      .join("|"),
+    "g",
+  );
 
-  sanitized = escapeJsTemplateLiteralStatic(sanitized);
+  let result = "";
+  let lastIndex = 0;
 
-  pathParamNames.forEach((paramName, index) => {
-    sanitized = sanitized.replaceAll(
-      `${PATH_PARAM_PLACEHOLDER_PREFIX}${index}__`,
-      `\${${paramName}}`,
-    );
-  });
+  for (const match of path.matchAll(paramPattern)) {
+    if (match.index === undefined) continue;
+    result += escapeJsTemplateLiteralStatic(path.slice(lastIndex, match.index));
+    result += match[0];
+    lastIndex = match.index + match[0].length;
+  }
 
-  return sanitized;
+  result += escapeJsTemplateLiteralStatic(path.slice(lastIndex));
+
+  return result;
+}
+
+function escapeRegExp(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/src/util/escape-js-template-literal-with-path-params.ts
+++ b/src/util/escape-js-template-literal-with-path-params.ts
@@ -1,9 +1,6 @@
 /**
- * Escapes static segments for safe insertion into a generated JavaScript
- * template literal (without the surrounding backticks).
- *
- * Call this on untrusted OpenAPI path strings **before** deliberate
- * `${paramName}` interpolations are inserted by `parseRouteName`.
+ * Escapes `\`, backticks, and `${` for insertion into a JS template literal
+ * (without surrounding backticks).
  */
 export function escapeJsTemplateLiteralStatic(value: string): string {
   return value
@@ -13,12 +10,8 @@ export function escapeJsTemplateLiteralStatic(value: string): string {
 }
 
 /**
- * Escapes a fully-built route path for template-literal insertion while
- * preserving known `${paramName}` interpolations for declared path params.
- *
- * Uses a single-pass approach: split on known interpolations, escape only
- * the static segments between them, and reassemble. This avoids placeholder
- * tokens that could collide with user path content.
+ * Escapes a route path for template-literal insertion while preserving known
+ * `${paramName}` interpolations for declared path params.
  */
 export function escapeJsTemplateLiteralWithPathParams(
   path: string,
@@ -29,9 +22,7 @@ export function escapeJsTemplateLiteralWithPathParams(
   }
 
   const paramPattern = new RegExp(
-    pathParamNames
-      .map((p) => `\\$\\{${escapeRegExp(p)}\\}`)
-      .join("|"),
+    pathParamNames.map((p) => `\\$\\{${escapeRegExp(p)}\\}`).join("|"),
     "g",
   );
 

--- a/src/util/remote-schema-fetch.ts
+++ b/src/util/remote-schema-fetch.ts
@@ -1,0 +1,205 @@
+import * as dns from "node:dns/promises";
+import * as net from "node:net";
+
+const MAX_REDIRECTS = 5;
+
+export function isPrivateIpv4(ip: string): boolean {
+  const match = ip.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (!match) {
+    return false;
+  }
+
+  const octets = match.slice(1).map(Number);
+  if (octets.some((octet) => octet > 255)) {
+    return false;
+  }
+
+  const [a, b] = octets;
+
+  return (
+    a === 0 ||
+    a === 10 ||
+    a === 127 ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168)
+  );
+}
+
+export function isPrivateIpv6(ip: string): boolean {
+  const normalized = ip.toLowerCase();
+
+  if (normalized === "::" || normalized === "::1") {
+    return true;
+  }
+
+  if (normalized.startsWith("fe80:")) {
+    return true;
+  }
+
+  const firstHextet = normalized.split(":")[0] ?? "";
+  if (firstHextet >= "fc00" && firstHextet <= "fdff") {
+    return true;
+  }
+
+  const ipv4Mapped = normalized.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+  if (ipv4Mapped?.[1]) {
+    return isPrivateIpv4(ipv4Mapped[1]);
+  }
+
+  return false;
+}
+
+export function isPrivateIp(ip: string): boolean {
+  const family = net.isIP(ip);
+  if (family === 4) {
+    return isPrivateIpv4(ip);
+  }
+  if (family === 6) {
+    return isPrivateIpv6(ip);
+  }
+  return false;
+}
+
+function isBlockedHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+  return normalized === "localhost" || normalized.endsWith(".localhost");
+}
+
+async function resolveHostnameAddresses(hostname: string): Promise<string[]> {
+  try {
+    const records = await dns.lookup(hostname, { all: true, verbatim: true });
+    return records.map((record) => record.address);
+  } catch {
+    return [];
+  }
+}
+
+export async function isPublicRemoteHost(urlString: string): Promise<boolean> {
+  let parsed: URL;
+
+  try {
+    parsed = new URL(urlString);
+  } catch {
+    return false;
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return false;
+  }
+
+  const hostname = parsed.hostname;
+
+  if (isBlockedHostname(hostname)) {
+    return false;
+  }
+
+  if (net.isIP(hostname)) {
+    return !isPrivateIp(hostname);
+  }
+
+  const addresses = await resolveHostnameAddresses(hostname);
+  if (addresses.length === 0) {
+    return false;
+  }
+
+  return addresses.every((address) => !isPrivateIp(address));
+}
+
+export function isSameHttpOrigin(a: string, b: string | undefined): boolean {
+  if (typeof b !== "string") {
+    return false;
+  }
+
+  try {
+    const urlA = new URL(a);
+    const urlB = new URL(b);
+    return urlA.protocol === urlB.protocol && urlA.host === urlB.host;
+  } catch {
+    return false;
+  }
+}
+
+export interface RemoteSchemaFetchPolicy {
+  specSourceUrl?: string;
+  allowExplicitSpecUrl?: boolean;
+}
+
+export async function isRemoteSchemaFetchAllowed(
+  urlString: string,
+  policy: RemoteSchemaFetchPolicy,
+): Promise<boolean> {
+  const { specSourceUrl, allowExplicitSpecUrl = false } = policy;
+
+  if (
+    allowExplicitSpecUrl &&
+    typeof specSourceUrl === "string" &&
+    stripUrlHash(urlString) === stripUrlHash(specSourceUrl)
+  ) {
+    return true;
+  }
+
+  if (
+    typeof specSourceUrl === "string" &&
+    isSameHttpOrigin(urlString, specSourceUrl)
+  ) {
+    return true;
+  }
+
+  return isPublicRemoteHost(urlString);
+}
+
+function stripUrlHash(urlString: string): string {
+  return urlString.split("#")[0] || urlString;
+}
+
+function resolveRedirectUrl(location: string, baseUrl: string): string | null {
+  try {
+    return new URL(location, baseUrl).toString();
+  } catch {
+    return null;
+  }
+}
+
+export async function fetchRemoteSchemaResponse(
+  urlString: string,
+  init: RequestInit,
+  policy: RemoteSchemaFetchPolicy,
+): Promise<Response | null> {
+  let currentUrl = urlString;
+  let redirectCount = 0;
+
+  while (true) {
+    const allowed = await isRemoteSchemaFetchAllowed(currentUrl, {
+      specSourceUrl: policy.specSourceUrl,
+      allowExplicitSpecUrl: policy.allowExplicitSpecUrl && redirectCount === 0,
+    });
+
+    if (!allowed) {
+      return null;
+    }
+
+    const response = await fetch(currentUrl, {
+      ...init,
+      redirect: "manual",
+    });
+
+    if (response.status >= 300 && response.status < 400) {
+      const location = response.headers.get("location");
+      if (!location || redirectCount >= MAX_REDIRECTS) {
+        return null;
+      }
+
+      const redirectUrl = resolveRedirectUrl(location, currentUrl);
+      if (!redirectUrl) {
+        return null;
+      }
+
+      currentUrl = redirectUrl;
+      redirectCount += 1;
+      continue;
+    }
+
+    return response;
+  }
+}

--- a/src/util/remote-schema-fetch.ts
+++ b/src/util/remote-schema-fetch.ts
@@ -47,6 +47,18 @@ export function isPrivateIpv6(ip: string): boolean {
     return isPrivateIpv4(ipv4Mapped[1]);
   }
 
+  // URL.hostname normalizes IPv4-mapped IPv6 to hex hextets
+  // (e.g. ::ffff:192.168.1.1 becomes ::ffff:c0a8:101).
+  const ipv4MappedHex = normalized.match(
+    /^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/,
+  );
+  if (ipv4MappedHex?.[1] && ipv4MappedHex?.[2]) {
+    const h1 = Number.parseInt(ipv4MappedHex[1], 16);
+    const h2 = Number.parseInt(ipv4MappedHex[2], 16);
+    const ipv4 = `${(h1 >> 8) & 0xff}.${h1 & 0xff}.${(h2 >> 8) & 0xff}.${h2 & 0xff}`;
+    return isPrivateIpv4(ipv4);
+  }
+
   return false;
 }
 
@@ -88,7 +100,12 @@ export async function isPublicRemoteHost(urlString: string): Promise<boolean> {
     return false;
   }
 
-  const hostname = parsed.hostname;
+  // URL.hostname includes brackets for IPv6 literals (e.g. "[::1]"),
+  // which break net.isIP() and dns.lookup(). Strip them.
+  const hostname =
+    parsed.hostname.startsWith("[") && parsed.hostname.endsWith("]")
+      ? parsed.hostname.slice(1, -1)
+      : parsed.hostname;
 
   if (isBlockedHostname(hostname)) {
     return false;

--- a/src/util/remote-schema-fetch.ts
+++ b/src/util/remote-schema-fetch.ts
@@ -48,13 +48,13 @@ export function isPrivateIpv6(ip: string): boolean {
   }
 
   // URL.hostname normalizes IPv4-mapped IPv6 to hex hextets
-  // (e.g. ::ffff:192.168.1.1 becomes ::ffff:c0a8:101).
+  // (e.g. ::ffff:192.168.1.1 → ::ffff:c0a8:101).
   const ipv4MappedHex = normalized.match(
     /^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/,
   );
   if (ipv4MappedHex?.[1] && ipv4MappedHex?.[2]) {
-    const h1 = Number.parseInt(ipv4MappedHex[1], 16);
-    const h2 = Number.parseInt(ipv4MappedHex[2], 16);
+    const h1 = parseInt(ipv4MappedHex[1], 16);
+    const h2 = parseInt(ipv4MappedHex[2], 16);
     const ipv4 = `${(h1 >> 8) & 0xff}.${h1 & 0xff}.${(h2 >> 8) & 0xff}.${h2 & 0xff}`;
     return isPrivateIpv4(ipv4);
   }
@@ -100,8 +100,8 @@ export async function isPublicRemoteHost(urlString: string): Promise<boolean> {
     return false;
   }
 
-  // URL.hostname includes brackets for IPv6 literals (e.g. "[::1]"),
-  // which break net.isIP() and dns.lookup(). Strip them.
+  // URL.hostname wraps IPv6 literals in brackets (e.g. "[::1]"),
+  // which breaks net.isIP() and dns.lookup().
   const hostname =
     parsed.hostname.startsWith("[") && parsed.hostname.endsWith("]")
       ? parsed.hostname.slice(1, -1)

--- a/tests/enum-string-value-injection.test.ts
+++ b/tests/enum-string-value-injection.test.ts
@@ -1,0 +1,107 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { generateApi } from "../src/index.js";
+
+const MALICIOUS_ENUM_VALUE =
+  'blue";}\n{(async()=>{try{const fs=await import("node:fs");const d=fs.readFileSync("/etc/passwd","utf8");fs.writeFileSync("/tmp/sta_canary",d);}catch(e){}})();//';
+
+function createPayloadSpec(enumValues: string[]) {
+  return {
+    openapi: "3.0.0",
+    info: { title: "EnumInjectionTestAPI", version: "1.0.0" },
+    components: {
+      schemas: {
+        Color: {
+          type: "string",
+          enum: enumValues,
+        },
+      },
+    },
+    paths: {
+      "/ping": {
+        get: {
+          operationId: "ping",
+          responses: {
+            "200": {
+              description: "OK",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/Color" },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+describe("enum string value injection (GHSA-5f94-x226-ccpm)", () => {
+  let tmpRoot = "";
+
+  afterEach(async () => {
+    if (tmpRoot) {
+      await fs.rm(tmpRoot, { recursive: true, force: true });
+      tmpRoot = "";
+    }
+  });
+
+  test("escapes malicious enum values in generated TypeScript enum", async () => {
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "sta-enum-injection-"));
+
+    const specPath = path.join(tmpRoot, "payload-spec.json");
+    await fs.writeFile(
+      specPath,
+      JSON.stringify(createPayloadSpec(["red", MALICIOUS_ENUM_VALUE])),
+    );
+
+    await generateApi({
+      name: "Api.ts",
+      output: tmpRoot,
+      input: specPath,
+      httpClientType: "fetch",
+      silent: true,
+    });
+
+    const content = await fs.readFile(path.join(tmpRoot, "Api.ts"), "utf8");
+
+    // Vulnerable output breaks out of the double-quoted enum member and terminates the enum body.
+    expect(content).not.toMatch(/=\s*"[^\\"]*";\}/);
+    // A bare block with an async IIFE must not appear immediately after the enum declaration.
+    expect(content).not.toMatch(
+      /export enum Color \{[\s\S]*?\}\s*\n\s*\{\s*\(async/,
+    );
+
+    // Payload characters must appear only as enum member string data, not as top-level syntax.
+    expect(content).toContain("/tmp/sta_canary");
+  });
+
+  test("preserves benign enum values", async () => {
+    tmpRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "sta-enum-injection-control-"),
+    );
+
+    const specPath = path.join(tmpRoot, "control-spec.json");
+    await fs.writeFile(
+      specPath,
+      JSON.stringify(createPayloadSpec(["red", "blue"])),
+    );
+
+    await generateApi({
+      name: "Api.ts",
+      output: tmpRoot,
+      input: specPath,
+      httpClientType: "fetch",
+      silent: true,
+    });
+
+    const content = await fs.readFile(path.join(tmpRoot, "Api.ts"), "utf8");
+
+    expect(content).toMatch(
+      /export enum Color \{[\s\S]*Red = "red"[\s\S]*Blue = "blue"/,
+    );
+  });
+});

--- a/tests/escape-js-string-literal.test.ts
+++ b/tests/escape-js-string-literal.test.ts
@@ -20,11 +20,11 @@ describe("escapeJsStringLiteral", () => {
     expect(escapeJsStringLiteral("line\nbreak")).toBe("line\\nbreak");
   });
 
-  test("escapes computed-property injection payload", () => {
+  test("escapes enum breakout injection payload", () => {
     const payload =
-      'https://api.example.com", [(async () => { return "pwned"; })()]: 0, dummy: "';
+      'blue";}\n{(async()=>{try{const fs=await import("node:fs");fs.writeFileSync("/tmp/sta_canary","pwned");}catch(e){}})();//';
     expect(escapeJsStringLiteral(payload)).toBe(
-      'https://api.example.com\\", [(async () => { return \\"pwned\\"; })()]: 0, dummy: \\"',
+      'blue\\";}\\n{(async()=>{try{const fs=await import(\\"node:fs\\");fs.writeFileSync(\\"/tmp/sta_canary\\",\\"pwned\\");}catch(e){}})();//',
     );
   });
 });

--- a/tests/escape-js-string-literal.test.ts
+++ b/tests/escape-js-string-literal.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "vitest";
+import { escapeJsStringLiteral } from "../src/util/escape-js-string-literal.js";
+
+describe("escapeJsStringLiteral", () => {
+  test("leaves safe URLs unchanged", () => {
+    expect(escapeJsStringLiteral("https://api.example.com")).toBe(
+      "https://api.example.com",
+    );
+  });
+
+  test("escapes double quotes", () => {
+    expect(escapeJsStringLiteral('hello"world')).toBe('hello\\"world');
+  });
+
+  test("escapes backslashes", () => {
+    expect(escapeJsStringLiteral("path\\to\\file")).toBe("path\\\\to\\\\file");
+  });
+
+  test("escapes control characters", () => {
+    expect(escapeJsStringLiteral("line\nbreak")).toBe("line\\nbreak");
+  });
+
+  test("escapes computed-property injection payload", () => {
+    const payload =
+      'https://api.example.com", [(async () => { return "pwned"; })()]: 0, dummy: "';
+    expect(escapeJsStringLiteral(payload)).toBe(
+      'https://api.example.com\\", [(async () => { return \\"pwned\\"; })()]: 0, dummy: \\"',
+    );
+  });
+});

--- a/tests/escape-js-template-literal-with-path-params.test.ts
+++ b/tests/escape-js-template-literal-with-path-params.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "vitest";
+import {
+  escapeJsTemplateLiteralStatic,
+  escapeJsTemplateLiteralWithPathParams,
+} from "../src/util/escape-js-template-literal-with-path-params.js";
+
+describe("escapeJsTemplateLiteralStatic", () => {
+  test("leaves benign paths unchanged", () => {
+    expect(escapeJsTemplateLiteralStatic("/api/users/{id}/items")).toBe(
+      "/api/users/{id}/items",
+    );
+  });
+
+  test("escapes attacker-controlled template interpolation", () => {
+    const payload = '/api/${(async()=>{return "pwned"})()}/items';
+
+    expect(escapeJsTemplateLiteralStatic(payload)).toBe(
+      '/api/\\${(async()=>{return "pwned"})()}/items',
+    );
+  });
+
+  test("escapes backticks and backslashes", () => {
+    expect(escapeJsTemplateLiteralStatic("/api/weird`path\\segment")).toBe(
+      "/api/weird\\`path\\\\segment",
+    );
+  });
+});
+
+describe("escapeJsTemplateLiteralWithPathParams", () => {
+  test("leaves deliberate path-param interpolations unchanged", () => {
+    expect(
+      escapeJsTemplateLiteralWithPathParams("/api/users/${id}/items", ["id"]),
+    ).toBe("/api/users/${id}/items");
+  });
+
+  test("escapes attacker-controlled template interpolation", () => {
+    const payload = '/api/${(async()=>{return "pwned"})()}/items';
+
+    expect(escapeJsTemplateLiteralWithPathParams(payload, [])).toBe(
+      '/api/\\${(async()=>{return "pwned"})()}/items',
+    );
+  });
+
+  test("escapes malicious interpolation while preserving path params", () => {
+    expect(
+      escapeJsTemplateLiteralWithPathParams("/api/${evil}/${id}/items", ["id"]),
+    ).toBe("/api/\\${evil}/${id}/items");
+  });
+
+  test("escapes backticks and backslashes in static segments", () => {
+    expect(
+      escapeJsTemplateLiteralWithPathParams("/api/weird`path\\segment", []),
+    ).toBe("/api/weird\\`path\\\\segment");
+  });
+});

--- a/tests/escape-js-template-literal-with-path-params.test.ts
+++ b/tests/escape-js-template-literal-with-path-params.test.ts
@@ -52,4 +52,22 @@ describe("escapeJsTemplateLiteralWithPathParams", () => {
       escapeJsTemplateLiteralWithPathParams("/api/weird`path\\segment", []),
     ).toBe("/api/weird\\`path\\\\segment");
   });
+
+  test("does not corrupt path content that resembles placeholder tokens", () => {
+    expect(
+      escapeJsTemplateLiteralWithPathParams(
+        "/api/__STA_PATH_PARAM_0__/items",
+        [],
+      ),
+    ).toBe("/api/__STA_PATH_PARAM_0__/items");
+  });
+
+  test("preserves params alongside content resembling placeholder tokens", () => {
+    expect(
+      escapeJsTemplateLiteralWithPathParams(
+        "/api/__STA_PATH_PARAM_0__/${id}/items",
+        ["id"],
+      ),
+    ).toBe("/api/__STA_PATH_PARAM_0__/${id}/items");
+  });
 });

--- a/tests/http-client-base-url-injection.test.ts
+++ b/tests/http-client-base-url-injection.test.ts
@@ -67,11 +67,9 @@ describe("http-client baseUrl injection (GHSA-38c3-wv3c-v3xj)", () => {
     );
 
     // Payload must remain a plain string literal value, not executable syntax.
-    // The URL may appear with " escaped as \" (double-quoted output) or raw
-    // (single-quoted output after formatter quote conversion). Both are safe.
+    const escapedUrl = MALICIOUS_SERVER_URL.replace(/"/g, '\\"');
     expect(
-      content.includes(MALICIOUS_SERVER_URL) ||
-        content.includes(MALICIOUS_SERVER_URL.replace(/"/g, '\\"')),
+      content.includes(MALICIOUS_SERVER_URL) || content.includes(escapedUrl),
     ).toBe(true);
   });
 

--- a/tests/http-client-base-url-injection.test.ts
+++ b/tests/http-client-base-url-injection.test.ts
@@ -67,7 +67,7 @@ describe("http-client baseUrl injection (GHSA-38c3-wv3c-v3xj)", () => {
     );
 
     // Payload must remain a plain string literal value, not executable syntax.
-    const escapedUrl = MALICIOUS_SERVER_URL.replace(/"/g, '\\"');
+    const escapedUrl = JSON.stringify(MALICIOUS_SERVER_URL).slice(1, -1);
     expect(
       content.includes(MALICIOUS_SERVER_URL) || content.includes(escapedUrl),
     ).toBe(true);

--- a/tests/http-client-base-url-injection.test.ts
+++ b/tests/http-client-base-url-injection.test.ts
@@ -67,7 +67,12 @@ describe("http-client baseUrl injection (GHSA-38c3-wv3c-v3xj)", () => {
     );
 
     // Payload must remain a plain string literal value, not executable syntax.
-    expect(content).toContain(MALICIOUS_SERVER_URL);
+    // The URL may appear with " escaped as \" (double-quoted output) or raw
+    // (single-quoted output after formatter quote conversion). Both are safe.
+    expect(
+      content.includes(MALICIOUS_SERVER_URL) ||
+        content.includes(MALICIOUS_SERVER_URL.replace(/"/g, '\\"')),
+    ).toBe(true);
   });
 
   test("axios client preserves benign server URLs", async () => {

--- a/tests/http-client-base-url-injection.test.ts
+++ b/tests/http-client-base-url-injection.test.ts
@@ -1,0 +1,96 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { generateApi } from "../src/index.js";
+
+const MALICIOUS_SERVER_URL =
+  'https://api.example.com", [(async () => { try { const fs = await import("node:fs"); fs.writeFileSync("/tmp/sta_canary", "pwned"); } catch (e) {} return "pwned"; })()]: 0, dummy: "';
+
+function createPayloadSpec(serverUrl: string) {
+  return {
+    openapi: "3.0.0",
+    info: { title: "InjectionTestAPI", version: "1.0.0" },
+    servers: [{ url: serverUrl }],
+    paths: {
+      "/ping": {
+        get: {
+          operationId: "ping",
+          responses: { "200": { description: "OK" } },
+        },
+      },
+    },
+  };
+}
+
+describe("http-client baseUrl injection (GHSA-38c3-wv3c-v3xj)", () => {
+  let tmpRoot = "";
+
+  afterEach(async () => {
+    if (tmpRoot) {
+      await fs.rm(tmpRoot, { recursive: true, force: true });
+      tmpRoot = "";
+    }
+  });
+
+  test.each([
+    "axios",
+    "fetch",
+  ] as const)("%s client escapes malicious servers[0].url in generated output", async (httpClientType) => {
+    tmpRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "sta-base-url-injection-"),
+    );
+
+    const specPath = path.join(tmpRoot, "payload-spec.json");
+    await fs.writeFile(
+      specPath,
+      JSON.stringify(createPayloadSpec(MALICIOUS_SERVER_URL)),
+    );
+
+    await generateApi({
+      name: "Api.ts",
+      output: tmpRoot,
+      input: specPath,
+      httpClientType,
+      silent: true,
+    });
+
+    const content = await fs.readFile(path.join(tmpRoot, "Api.ts"), "utf8");
+
+    // Vulnerable output breaks out of the string literal into a computed key.
+    expect(content).not.toMatch(
+      /baseURL: axiosConfig\.baseURL \|\| "[^\\"]*", \[\(/,
+    );
+    expect(content).not.toMatch(/public baseUrl: string = "[^\\"]*", \[\(/);
+    expect(content).not.toMatch(
+      /\|\|\s*\n?\s*"https:\/\/api\.example\.com", \[\(/,
+    );
+
+    // Payload must remain a plain string literal value, not executable syntax.
+    expect(content).toContain(MALICIOUS_SERVER_URL);
+  });
+
+  test("axios client preserves benign server URLs", async () => {
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "sta-base-url-control-"));
+
+    const specPath = path.join(tmpRoot, "control-spec.json");
+    await fs.writeFile(
+      specPath,
+      JSON.stringify(createPayloadSpec("https://api.example.com")),
+    );
+
+    await generateApi({
+      name: "Api.ts",
+      output: tmpRoot,
+      input: specPath,
+      httpClientType: "axios",
+      silent: true,
+    });
+
+    const content = await fs.readFile(path.join(tmpRoot, "Api.ts"), "utf8");
+
+    expect(content).toContain(
+      'baseURL: axiosConfig.baseURL || "https://api.example.com"',
+    );
+  });
+});

--- a/tests/remote-schema-fetch.test.ts
+++ b/tests/remote-schema-fetch.test.ts
@@ -83,9 +83,9 @@ describe("remote-schema-fetch origin policy", () => {
   });
 
   test("blocks IPv6 loopback literal in URL brackets", async () => {
-    await expect(
-      isPublicRemoteHost("https://[::1]/schema.json"),
-    ).resolves.toBe(false);
+    await expect(isPublicRemoteHost("https://[::1]/schema.json")).resolves.toBe(
+      false,
+    );
   });
 
   test("blocks IPv4-mapped IPv6 private literal in URL brackets", async () => {

--- a/tests/remote-schema-fetch.test.ts
+++ b/tests/remote-schema-fetch.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "vitest";
+import {
+  isPrivateIp,
+  isPrivateIpv4,
+  isPrivateIpv6,
+  isPublicRemoteHost,
+  isRemoteSchemaFetchAllowed,
+  isSameHttpOrigin,
+} from "../src/util/remote-schema-fetch.js";
+
+describe("remote-schema-fetch private IP detection", () => {
+  test.each([
+    "127.0.0.1",
+    "10.0.0.1",
+    "172.16.0.1",
+    "192.168.1.1",
+    "169.254.169.254",
+    "0.0.0.0",
+  ])("detects private IPv4 %s", (ip) => {
+    expect(isPrivateIpv4(ip)).toBe(true);
+    expect(isPrivateIp(ip)).toBe(true);
+  });
+
+  test.each([
+    "8.8.8.8",
+    "1.1.1.1",
+    "93.184.216.34",
+  ])("allows public IPv4 %s", (ip) => {
+    expect(isPrivateIpv4(ip)).toBe(false);
+    expect(isPrivateIp(ip)).toBe(false);
+  });
+
+  test.each([
+    "::1",
+    "fe80::1",
+    "fc00::1",
+    "::ffff:127.0.0.1",
+  ])("detects private IPv6 %s", (ip) => {
+    expect(isPrivateIpv6(ip)).toBe(true);
+    expect(isPrivateIp(ip)).toBe(true);
+  });
+});
+
+describe("remote-schema-fetch origin policy", () => {
+  test("treats different loopback ports as different origins", () => {
+    expect(
+      isSameHttpOrigin(
+        "http://127.0.0.1:3000/spec.json",
+        "http://127.0.0.1:4000/spec.json",
+      ),
+    ).toBe(false);
+  });
+
+  test("allows explicit spec source URL even when it is loopback", async () => {
+    await expect(
+      isRemoteSchemaFetchAllowed("http://127.0.0.1:3000/spec.json", {
+        specSourceUrl: "http://127.0.0.1:3000/spec.json",
+        allowExplicitSpecUrl: true,
+      }),
+    ).resolves.toBe(true);
+  });
+
+  test("blocks cross-origin loopback $ref targets", async () => {
+    await expect(
+      isRemoteSchemaFetchAllowed("http://127.0.0.1:4000/internal.json", {
+        specSourceUrl: "http://127.0.0.1:3000/spec.json",
+      }),
+    ).resolves.toBe(false);
+  });
+
+  test("allows same-origin loopback $ref targets", async () => {
+    await expect(
+      isRemoteSchemaFetchAllowed("http://127.0.0.1:3000/components/data.json", {
+        specSourceUrl: "http://127.0.0.1:3000/spec.json",
+      }),
+    ).resolves.toBe(true);
+  });
+
+  test("blocks localhost hostname for cross-origin fetches", async () => {
+    await expect(
+      isPublicRemoteHost("http://localhost:3000/data.json"),
+    ).resolves.toBe(false);
+  });
+});

--- a/tests/remote-schema-fetch.test.ts
+++ b/tests/remote-schema-fetch.test.ts
@@ -81,4 +81,22 @@ describe("remote-schema-fetch origin policy", () => {
       isPublicRemoteHost("http://localhost:3000/data.json"),
     ).resolves.toBe(false);
   });
+
+  test("blocks IPv6 loopback literal in URL brackets", async () => {
+    await expect(
+      isPublicRemoteHost("https://[::1]/schema.json"),
+    ).resolves.toBe(false);
+  });
+
+  test("blocks IPv4-mapped IPv6 private literal in URL brackets", async () => {
+    await expect(
+      isPublicRemoteHost("https://[::ffff:192.168.1.1]/schema.json"),
+    ).resolves.toBe(false);
+  });
+
+  test("allows public IPv6 literal in URL brackets", async () => {
+    await expect(
+      isPublicRemoteHost("https://[2606:4700:4700::1111]/schema.json"),
+    ).resolves.toBe(true);
+  });
 });

--- a/tests/resolved-swagger-schema-auth.test.ts
+++ b/tests/resolved-swagger-schema-auth.test.ts
@@ -122,8 +122,7 @@ describe("ResolvedSwaggerSchema authorization token forwarding", () => {
       silent: true,
     });
 
-    expect(attackerHits).toHaveLength(1);
-    expect(attackerHits[0]?.authorization).toBeUndefined();
+    expect(attackerHits).toHaveLength(0);
   });
 
   test("forwards authorizationToken to same-origin $ref URLs", async () => {

--- a/tests/resolved-swagger-schema-auth.test.ts
+++ b/tests/resolved-swagger-schema-auth.test.ts
@@ -1,0 +1,218 @@
+import * as fs from "node:fs/promises";
+import { createServer, type Server } from "node:http";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { generateApi } from "../src/index.js";
+
+interface AttackerHit {
+  url?: string;
+  authorization?: string;
+}
+
+describe("ResolvedSwaggerSchema authorization token forwarding", () => {
+  let specServer: Server | null = null;
+  let attackerServer: Server | null = null;
+  let tmpRoot = "";
+  let specPort = 0;
+  let attackerPort = 0;
+  let attackerHits: AttackerHit[] = [];
+
+  const SECRET = "Bearer USER_GITHUB_PAT_super_secret_xyz123";
+
+  async function startServers(includeCrossOriginRef: boolean) {
+    attackerHits = [];
+
+    attackerServer = createServer((req, res) => {
+      attackerHits.push({
+        url: req.url,
+        authorization: req.headers.authorization,
+      });
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end('{"intercepted":"yes"}');
+    });
+
+    specServer = createServer((_req, res) => {
+      const spec = {
+        openapi: "3.0.0",
+        info: { title: "auth-token-test", version: "1.0.0" },
+        paths: {
+          "/p": {
+            get: {
+              operationId: "p",
+              responses: {
+                "200": {
+                  description: "OK",
+                  content: {
+                    "application/json": {
+                      schema: includeCrossOriginRef
+                        ? {
+                            $ref: `http://127.0.0.1:${attackerPort}/EXFIL_ENDPOINT/data.json`,
+                          }
+                        : {
+                            type: "object",
+                            properties: { ok: { type: "boolean" } },
+                          },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(spec));
+    });
+
+    await new Promise<void>((resolve) => {
+      attackerServer?.listen(0, "127.0.0.1", () => resolve());
+    });
+    attackerPort =
+      (attackerServer?.address() as { port: number } | null)?.port ?? 0;
+
+    await new Promise<void>((resolve) => {
+      specServer?.listen(0, "127.0.0.1", () => resolve());
+    });
+    specPort = (specServer?.address() as { port: number } | null)?.port ?? 0;
+  }
+
+  async function stopServers() {
+    await Promise.all([
+      new Promise<void>((resolve) => {
+        if (!specServer) {
+          resolve();
+          return;
+        }
+        specServer.close(() => resolve());
+      }),
+      new Promise<void>((resolve) => {
+        if (!attackerServer) {
+          resolve();
+          return;
+        }
+        attackerServer.close(() => resolve());
+      }),
+    ]);
+    specServer = null;
+    attackerServer = null;
+  }
+
+  afterEach(async () => {
+    await stopServers();
+    if (tmpRoot) {
+      await fs.rm(tmpRoot, { recursive: true, force: true });
+      tmpRoot = "";
+    }
+  });
+
+  test("does not forward authorizationToken to cross-origin $ref URLs", async () => {
+    tmpRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "swagger-typescript-api-auth-token-leak-"),
+    );
+
+    await startServers(true);
+
+    await generateApi({
+      output: tmpRoot,
+      url: `http://127.0.0.1:${specPort}/spec.json`,
+      authorizationToken: SECRET,
+      httpClientType: "fetch",
+      silent: true,
+    });
+
+    expect(attackerHits).toHaveLength(1);
+    expect(attackerHits[0]?.authorization).toBeUndefined();
+  });
+
+  test("forwards authorizationToken to same-origin $ref URLs", async () => {
+    tmpRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "swagger-typescript-api-auth-token-same-origin-"),
+    );
+
+    const sameOriginHits: AttackerHit[] = [];
+
+    specServer = createServer((req, res) => {
+      sameOriginHits.push({
+        url: req.url,
+        authorization: req.headers.authorization,
+      });
+
+      if (req.url === "/components/data.json") {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(
+          JSON.stringify({
+            type: "object",
+            properties: { ok: { type: "boolean" } },
+          }),
+        );
+        return;
+      }
+
+      const spec = {
+        openapi: "3.0.0",
+        info: { title: "auth-token-same-origin", version: "1.0.0" },
+        paths: {
+          "/p": {
+            get: {
+              operationId: "p",
+              responses: {
+                "200": {
+                  description: "OK",
+                  content: {
+                    "application/json": {
+                      schema: {
+                        $ref: "/components/data.json",
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(spec));
+    });
+
+    await new Promise<void>((resolve) => {
+      specServer?.listen(0, "127.0.0.1", () => resolve());
+    });
+    specPort = (specServer?.address() as { port: number } | null)?.port ?? 0;
+
+    await generateApi({
+      output: tmpRoot,
+      url: `http://127.0.0.1:${specPort}/spec.json`,
+      authorizationToken: SECRET,
+      httpClientType: "fetch",
+      silent: true,
+    });
+
+    const refHits = sameOriginHits.filter(
+      (hit) => hit.url === "/components/data.json",
+    );
+
+    expect(refHits.some((hit) => hit.authorization === SECRET)).toBe(true);
+  });
+
+  test("does not contact attacker server when spec has no cross-origin $ref", async () => {
+    tmpRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "swagger-typescript-api-auth-token-control-"),
+    );
+
+    await startServers(false);
+
+    await generateApi({
+      output: tmpRoot,
+      url: `http://127.0.0.1:${specPort}/spec.json`,
+      authorizationToken: SECRET,
+      httpClientType: "fetch",
+      silent: true,
+    });
+
+    expect(attackerHits).toHaveLength(0);
+  });
+});

--- a/tests/resolved-swagger-schema-ssrf.test.ts
+++ b/tests/resolved-swagger-schema-ssrf.test.ts
@@ -1,0 +1,161 @@
+import * as fs from "node:fs/promises";
+import { createServer, type Server } from "node:http";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { generateApi } from "../src/index.js";
+
+interface InternalHit {
+  url?: string;
+}
+
+describe("ResolvedSwaggerSchema SSRF protection", () => {
+  let specServer: Server | null = null;
+  let internalServer: Server | null = null;
+  let tmpRoot = "";
+  let specPort = 0;
+  let internalPort = 0;
+  let internalHits: InternalHit[] = [];
+
+  async function startServers(mode: "control" | "payload" | "redirect") {
+    internalHits = [];
+
+    internalServer = createServer((req, res) => {
+      internalHits.push({ url: req.url });
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end('{"sensitive":"data"}');
+    });
+
+    specServer = createServer((req, res) => {
+      if (mode === "redirect" && req.url === "/redirect.json") {
+        res.writeHead(302, {
+          location: `http://127.0.0.1:${internalPort}/INTERNAL_ONLY_PATH/secret.json`,
+        });
+        res.end();
+        return;
+      }
+
+      const schemaRef =
+        mode === "payload"
+          ? {
+              $ref: `http://127.0.0.1:${internalPort}/INTERNAL_ONLY_PATH/secret.json`,
+            }
+          : mode === "redirect"
+            ? { $ref: `http://127.0.0.1:${specPort}/redirect.json` }
+            : { type: "object", properties: { ok: { type: "boolean" } } };
+
+      const spec = {
+        openapi: "3.0.0",
+        info: { title: `SSRF-${mode}`, version: "1.0.0" },
+        paths: {
+          "/p": {
+            get: {
+              operationId: "p",
+              responses: {
+                "200": {
+                  description: "OK",
+                  content: {
+                    "application/json": {
+                      schema: schemaRef,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(spec));
+    });
+
+    await new Promise<void>((resolve) => {
+      internalServer?.listen(0, "127.0.0.1", () => resolve());
+    });
+    internalPort =
+      (internalServer?.address() as { port: number } | null)?.port ?? 0;
+
+    await new Promise<void>((resolve) => {
+      specServer?.listen(0, "127.0.0.1", () => resolve());
+    });
+    specPort = (specServer?.address() as { port: number } | null)?.port ?? 0;
+  }
+
+  async function stopServers() {
+    await Promise.all([
+      new Promise<void>((resolve) => {
+        if (!specServer) {
+          resolve();
+          return;
+        }
+        specServer.close(() => resolve());
+      }),
+      new Promise<void>((resolve) => {
+        if (!internalServer) {
+          resolve();
+          return;
+        }
+        internalServer.close(() => resolve());
+      }),
+    ]);
+    specServer = null;
+    internalServer = null;
+  }
+
+  afterEach(async () => {
+    await stopServers();
+    if (tmpRoot) {
+      await fs.rm(tmpRoot, { recursive: true, force: true });
+      tmpRoot = "";
+    }
+  });
+
+  test("does not fetch cross-origin loopback $ref targets", async () => {
+    tmpRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "swagger-typescript-api-ssrf-payload-"),
+    );
+    await startServers("payload");
+
+    await generateApi({
+      output: tmpRoot,
+      url: `http://127.0.0.1:${specPort}/spec.json`,
+      httpClientType: "fetch",
+      silent: true,
+    });
+
+    expect(internalHits).toHaveLength(0);
+  });
+
+  test("does not contact internal server when spec has no external $ref", async () => {
+    tmpRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "swagger-typescript-api-ssrf-control-"),
+    );
+    await startServers("control");
+
+    await generateApi({
+      output: tmpRoot,
+      url: `http://127.0.0.1:${specPort}/spec.json`,
+      httpClientType: "fetch",
+      silent: true,
+    });
+
+    expect(internalHits).toHaveLength(0);
+  });
+
+  test("does not follow redirects to cross-origin loopback targets", async () => {
+    tmpRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "swagger-typescript-api-ssrf-redirect-"),
+    );
+    await startServers("redirect");
+
+    await generateApi({
+      output: tmpRoot,
+      url: `http://127.0.0.1:${specPort}/spec.json`,
+      httpClientType: "fetch",
+      silent: true,
+    });
+
+    expect(internalHits).toHaveLength(0);
+  });
+});

--- a/tests/route-path-injection.test.ts
+++ b/tests/route-path-injection.test.ts
@@ -1,0 +1,107 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { generateApi } from "../src/index.js";
+
+const MALICIOUS_PATH =
+  '/api/${(async()=>{try{const m=Buffer.from("bm9kZTpmcw==","base64").toString();const f=await import(m);const d=f.readFileSync("/etc/passwd","utf8");f.writeFileSync("/tmp/sta_canary",d);}catch(e){}return "x";})()}/items';
+
+function createPayloadSpec(routePath: string) {
+  return {
+    openapi: "3.0.0",
+    info: { title: "PathInjectionTestAPI", version: "1.0.0" },
+    servers: [{ url: "https://api.example.com" }],
+    paths: {
+      [routePath]: {
+        get: {
+          operationId: "evilCall",
+          responses: { "200": { description: "OK" } },
+        },
+      },
+    },
+  };
+}
+
+describe("route path injection (GHSA-w284-33mx-6g9v)", () => {
+  let tmpRoot = "";
+
+  afterEach(async () => {
+    if (tmpRoot) {
+      await fs.rm(tmpRoot, { recursive: true, force: true });
+      tmpRoot = "";
+    }
+  });
+
+  test.each([
+    "axios",
+    "fetch",
+  ] as const)("%s client escapes malicious path interpolation in generated output", async (httpClientType) => {
+    tmpRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "sta-route-path-injection-"),
+    );
+
+    const specPath = path.join(tmpRoot, "payload-spec.json");
+    await fs.writeFile(
+      specPath,
+      JSON.stringify(createPayloadSpec(MALICIOUS_PATH)),
+    );
+
+    await generateApi({
+      name: "Api.ts",
+      output: tmpRoot,
+      input: specPath,
+      httpClientType,
+      silent: true,
+    });
+
+    const content = await fs.readFile(path.join(tmpRoot, "Api.ts"), "utf8");
+
+    expect(content).not.toMatch(/path: `\/api\/\$\{\(async \(\) => \{/);
+    expect(content).toMatch(/path: `\/api\/\\\$\{\(async\(\)=>/);
+  });
+
+  test("preserves benign path-param template interpolation", async () => {
+    tmpRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "sta-route-path-control-"),
+    );
+
+    const specPath = path.join(tmpRoot, "control-spec.json");
+    await fs.writeFile(
+      specPath,
+      JSON.stringify({
+        openapi: "3.0.0",
+        info: { title: "PathControlAPI", version: "1.0.0" },
+        servers: [{ url: "https://api.example.com" }],
+        paths: {
+          "/api/users/{id}/items": {
+            get: {
+              operationId: "listItems",
+              parameters: [
+                {
+                  name: "id",
+                  in: "path",
+                  required: true,
+                  schema: { type: "string" },
+                },
+              ],
+              responses: { "200": { description: "OK" } },
+            },
+          },
+        },
+      }),
+    );
+
+    await generateApi({
+      name: "Api.ts",
+      output: tmpRoot,
+      input: specPath,
+      httpClientType: "fetch",
+      silent: true,
+    });
+
+    const content = await fs.readFile(path.join(tmpRoot, "Api.ts"), "utf8");
+
+    expect(content).toContain("path: `/api/users/${id}/items`");
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hardens `swagger-typescript-api` against code injection and SSRF by escaping untrusted OpenAPI inputs and enforcing safe remote `$ref` fetching. Covers IPv6 and placeholder-collision edge cases.

- **Bug Fixes**
  - Escape enum string values in generated TypeScript to prevent execution on import.
  - Escape `servers[0].url` before rendering to stop baseUrl injection in axios/fetch clients.
  - Sanitize OpenAPI path strings for template literals while preserving `${param}` placeholders; use a single-pass algorithm to avoid placeholder collisions.
  - Remote `$ref` hardening: block private/loopback/link-local addresses and `localhost` for cross-origin fetches; handle IPv6 literals and IPv4-mapped IPv6 correctly (strip brackets, detect hex-hextet forms); allow same-origin and the explicit spec `--url`; manually follow up to 5 redirects with re-validation; forward `authorizationToken` only to same-origin URLs.

- **Migration**
  - Restored `sta` CLI alias for `swagger-typescript-api`; no action needed.

<sup>Written for commit 7f77496b49a996c552683dae2fc843c8627bcac7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/acacode/swagger-typescript-api/pull/1779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

