### PR TITLE
Handle object-shaped not schemas without crashing

### DIFF
--- a/.changeset/silly-waves-learn.md
+++ b/.changeset/silly-waves-learn.md
@@ -1,0 +1,5 @@
+---
+"swagger-typescript-api": patch
+---
+
+Handle object-shaped not schemas without crashing

--- a/src/schema-parser/base-schema-parsers/complex.ts
+++ b/src/schema-parser/base-schema-parsers/complex.ts
@@ -5,6 +5,11 @@ import { MonoSchemaParser } from "../mono-schema-parser.js";
 export class ComplexSchemaParser extends MonoSchemaParser {
   override parse() {
     const complexType = this.schemaUtils.getComplexType(this.schema);
+    const complexSchemaItems: Array<Record<string, unknown>> = Array.isArray(
+      this.schema[complexType],
+    )
+      ? this.schema[complexType]
+      : [];
     const simpleSchema = omit(
       this.schema,
       Object.keys(this.schemaParser._complexSchemaParsers),
@@ -23,11 +28,7 @@ export class ComplexSchemaParser extends MonoSchemaParser {
       name: this.typeName,
       description: this.schemaFormatters.formatDescription(
         this.schema.description ||
-          compact(
-            (this.schema[complexType] || []).map(
-              (item: any) => item?.description,
-            ),
-          )[0] ||
+          compact(complexSchemaItems.map((item) => item.description))[0] ||
           "",
       ),
       content:

--- a/src/schema-parser/base-schema-parsers/object.ts
+++ b/src/schema-parser/base-schema-parsers/object.ts
@@ -58,6 +58,16 @@ export class ObjectSchemaParser extends MonoSchemaParser {
 
       const complexType = this.schemaUtils.getComplexType(property);
       const rawDataComplexType = this.schemaUtils.getComplexType(rawTypeData);
+      const propertyComplexSchemaItems: Array<Record<string, unknown>> =
+        Array.isArray((property as Record<string, unknown>)[complexType])
+          ? ((property as Record<string, unknown>)[complexType] as Array<
+              Record<string, unknown>
+            >)
+          : [];
+      const rawDataComplexSchemaItems: Array<Record<string, unknown>> =
+        Array.isArray(rawTypeData[rawDataComplexType])
+          ? (rawTypeData[rawDataComplexType] as Array<Record<string, unknown>>)
+          : [];
 
       propertiesContent.push({
         ...(property as object),
@@ -66,16 +76,11 @@ export class ObjectSchemaParser extends MonoSchemaParser {
         description:
           (property as Record<string, unknown>).description ||
           compact(
-            (
-              ((property as Record<string, unknown>)[complexType] as any[]) ||
-              []
-            ).map((item: any) => item?.description),
+            propertyComplexSchemaItems.map((item) => item?.description),
           )[0] ||
           rawTypeData.description ||
           compact(
-            ((rawTypeData[rawDataComplexType] as any[]) || []).map(
-              (item: any) => item?.description,
-            ),
+            rawDataComplexSchemaItems.map((item) => item?.description),
           )[0] ||
           "",
         isRequired: required,

--- a/tests/spec/issue-1798/basic.test.ts
+++ b/tests/spec/issue-1798/basic.test.ts
@@ -1,0 +1,34 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { generateApi } from "../../../src/index.js";
+
+describe("issue-1798", async () => {
+  let tmpdir = "";
+
+  beforeAll(async () => {
+    tmpdir = await fs.mkdtemp(path.join(os.tmpdir(), "swagger-typescript-api"));
+  });
+
+  afterAll(async () => {
+    await fs.rm(tmpdir, { recursive: true });
+  });
+
+  test("generates schemas with object-shaped not clauses", async () => {
+    await generateApi({
+      fileName: "client",
+      input: path.resolve(import.meta.dirname, "schema.json"),
+      output: tmpdir,
+      silent: true,
+      sortTypes: true,
+      cleanOutput: true,
+    });
+
+    const content = await fs.readFile(path.join(tmpdir, "client.ts"), {
+      encoding: "utf8",
+    });
+
+    expect(content).toContain("export interface ProductVariant");
+  });
+});

--- a/tests/spec/issue-1798/schema.json
+++ b/tests/spec/issue-1798/schema.json
@@ -1,0 +1,81 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "issue 1798",
+    "version": "1.0.0"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "RelatedProductVariant": {
+        "type": "object",
+        "properties": {
+          "variantId": {
+            "type": "integer"
+          },
+          "variantReferenceKey": {
+            "type": "string"
+          },
+          "isMainVariant": {
+            "type": "boolean"
+          }
+        }
+      },
+      "ProductVariant": {
+        "type": "object",
+        "properties": {
+          "relatedVariants": {
+            "oneOf": [
+              {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/RelatedProductVariant"
+                    },
+                    {
+                      "type": "object",
+                      "required": ["variantId", "isMainVariant"],
+                      "properties": {
+                        "variantId": {
+                          "type": "integer"
+                        },
+                        "variantReferenceKey": {
+                          "not": {}
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/RelatedProductVariant"
+                    },
+                    {
+                      "type": "object",
+                      "required": ["variantReferenceKey", "isMainVariant"],
+                      "properties": {
+                        "variantReferenceKey": {
+                          "type": "string"
+                        },
+                        "variantId": {
+                          "not": {}
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
A `not: {}` schema could reach the complex schema parser and crash because the parser expected complex keyword values to be arrays.

This adds array guards for complex keyword parsing, so non-array values take the same empty-result path as before while array-valued `oneOf`, `anyOf`, and `allOf` behavior stays unchanged. I checked the issue repro against the failing path, then ran install, format, build, and the full test suite with 275 tests passing.

Fixes #1798