### PR TITLE
Add Xquik search generation test

### DIFF
--- a/tests/xquik-search.test.ts
+++ b/tests/xquik-search.test.ts
@@ -1,0 +1,121 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { generateApi } from "../src/index.js";
+
+describe("Xquik search OpenAPI generation", () => {
+  let tmpRoot = "";
+
+  afterEach(async () => {
+    if (tmpRoot) {
+      await fs.rm(tmpRoot, { recursive: true, force: true });
+      tmpRoot = "";
+    }
+  });
+
+  test("generates query parameters and response schemas", async () => {
+    tmpRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "swagger-typescript-api-xquik-search-"),
+    );
+
+    const schema = {
+      openapi: "3.1.0",
+      info: { title: "Xquik API", version: "1.0" },
+      components: {
+        securitySchemes: {
+          apiKey: {
+            type: "apiKey",
+            in: "header",
+            name: "x-api-key",
+          },
+        },
+        schemas: {
+          PaginatedTweets: {
+            type: "object",
+            properties: {
+              tweets: {
+                type: "array",
+                items: { $ref: "#/components/schemas/SearchTweet" },
+              },
+              has_next_page: { type: "boolean" },
+              next_cursor: { type: "string" },
+            },
+          },
+          SearchTweet: {
+            type: "object",
+            properties: {
+              id: { type: "string" },
+              text: { type: "string" },
+              likeCount: { type: "integer" },
+            },
+          },
+        },
+      },
+      paths: {
+        "/api/v1/x/tweets/search": {
+          get: {
+            tags: ["Tweets"],
+            operationId: "searchTweets",
+            security: [{ apiKey: [] }],
+            parameters: [
+              {
+                name: "q",
+                in: "query",
+                required: true,
+                schema: { type: "string" },
+              },
+              {
+                name: "cursor",
+                in: "query",
+                schema: { type: "string" },
+              },
+              {
+                name: "limit",
+                in: "query",
+                schema: { type: "integer", maximum: 200 },
+              },
+            ],
+            responses: {
+              "200": {
+                description: "Search results",
+                content: {
+                  "application/json": {
+                    schema: {
+                      $ref: "#/components/schemas/PaginatedTweets",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const schemaPath = path.join(tmpRoot, "xquik-search-openapi.json");
+    await fs.writeFile(schemaPath, JSON.stringify(schema), "utf8");
+
+    await generateApi({
+      output: tmpRoot,
+      input: schemaPath,
+      fileName: "xquik-search",
+      httpClientType: "fetch",
+      generateClient: true,
+      silent: true,
+    });
+
+    const content = await fs.readFile(
+      path.join(tmpRoot, "xquik-search.ts"),
+      "utf8",
+    );
+
+    expect(content).toContain("export interface PaginatedTweets");
+    expect(content).toContain("tweets?: SearchTweet[]");
+    expect(content).toContain("likeCount?: number");
+    expect(content).toContain("searchTweets");
+    expect(content).toContain("q: string");
+    expect(content).toContain("cursor?: string");
+    expect(content).toContain("limit?: number");
+  });
+});


### PR DESCRIPTION
Problem:
The generator should keep real OpenAPI 3.1 search endpoints stable across query parameters and response schemas.

Solution:
Add a compact Xquik search generation test that writes a temporary spec file, runs generateApi, and asserts the generated client includes the expected response schemas and query fields.

Verification:
- bun install --frozen-lockfile
- bun run test -- tests/xquik-search.test.ts
- bunx biome format tests/xquik-search.test.ts
- bun run build


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a focused test for the Xquik search OpenAPI 3.1 generation to ensure the client stays stable across query params and response schemas. It writes a temp spec and verifies `generateApi` outputs the expected types and fields for GET `/api/v1/x/tweets/search` (params: `q`, `cursor`, `limit`; schemas: `PaginatedTweets`, `SearchTweet`).

<sup>Written for commit 6306fc635f5200cc796db8e0e376342680c0f3c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/acacode/swagger-typescript-api/pull/1807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

