### PR TITLE
Handle boolean JSON schemas without crashing

### DIFF
--- a/.changeset/quiet-swans-parse.md
+++ b/.changeset/quiet-swans-parse.md
@@ -1,0 +1,5 @@
+---
+"swagger-typescript-api": patch
+---
+
+Handle boolean JSON schemas without crashing.

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -22,6 +22,7 @@ const TsKeyword = {
   String: "string",
   Boolean: "boolean",
   Any: "any",
+  Never: "never",
   Void: "void",
   Unknown: "unknown",
   Null: "null",

--- a/src/schema-parser/schema-parser.ts
+++ b/src/schema-parser/schema-parser.ts
@@ -176,6 +176,17 @@ export class SchemaParser {
   };
 
   parseSchema = () => {
+    if (typeof this.schema === "boolean") {
+      return this._baseSchemaParsers[SCHEMA_TYPES.PRIMITIVE](
+        {
+          type: this.schema
+            ? this.config.Ts.Keyword.Any
+            : this.config.Ts.Keyword.Never,
+        },
+        this.typeName,
+      );
+    }
+
     if (!this.schema)
       return this._baseSchemaParsers[SCHEMA_TYPES.PRIMITIVE](
         null,

--- a/tests/spec/boolean-schemas/basic.test.ts
+++ b/tests/spec/boolean-schemas/basic.test.ts
@@ -1,0 +1,34 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { generateApi } from "../../../src/index.js";
+
+describe("boolean schemas", () => {
+  let tmpdir = "";
+
+  beforeAll(async () => {
+    tmpdir = await fs.mkdtemp(path.join(os.tmpdir(), "swagger-typescript-api"));
+  });
+
+  afterAll(async () => {
+    await fs.rm(tmpdir, { recursive: true });
+  });
+
+  test("maps boolean schemas at component and nested positions", async () => {
+    const output = await generateApi({
+      fileName: "schema.ts",
+      input: path.resolve(import.meta.dirname, "schema.yaml"),
+      output: tmpdir,
+      silent: true,
+    });
+
+    const content = output.files[0]?.fileContent;
+
+    expect(content).toContain("export type AnyValue = any;");
+    expect(content).toContain("export type NoValue = never;");
+    expect(content).toMatch(/anyValue\??: any/);
+    expect(content).toMatch(/noValue\??: never/);
+    expect(content).toContain("export type ArrayOfNoValues = never[];");
+  });
+});

--- a/tests/spec/boolean-schemas/schema.yaml
+++ b/tests/spec/boolean-schemas/schema.yaml
@@ -1,0 +1,17 @@
+openapi: 3.1.0
+info:
+  title: Boolean schemas
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    AnyValue: true
+    NoValue: false
+    NestedValues:
+      type: object
+      properties:
+        anyValue: true
+        noValue: false
+    ArrayOfNoValues:
+      type: array
+      items: false

--- a/types/index.ts
+++ b/types/index.ts
@@ -18,6 +18,7 @@ type CodeGenConstruct = {
     String: string;
     Boolean: string;
     Any: string;
+    Never: string;
     Void: string;
     Unknown: string;
     Null: string;


### PR DESCRIPTION
Boolean JSON schemas could crash generation when `true` reached the response-schema check, and `false` was treated like a missing schema. This maps `true` to `any` and `false` to `never`, including nested object properties and array items. I checked the issue repro, the focused boolean-schema case, the full 286-test suite, and the build. Fixes #769


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes crashes when parsing boolean JSON schemas by mapping `true` to `any` and `false` to `never`. Applies to components, response schemas, and nested object/array positions.

- **Bug Fixes**
  - Handle boolean schemas in `SchemaParser.parseSchema`, including nested properties and array items.
  - Add `Never` to `Ts.Keyword` and type definitions to emit `never`.
  - Add tests covering component, nested, and array cases; verify `any`/`never` output.

<sup>Written for commit 10dca24765290581baa0f220ab1836c4683a387a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/acacode/swagger-typescript-api/pull/1811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

