### PR TITLE
Fix: optional query arg silently hoisted past required body arg, swapping caller arguments

### DIFF
--- a/templates/default/procedure-call.ejs
+++ b/templates/default/procedure-call.ejs
@@ -46,9 +46,21 @@ const rawWrapperArgs = config.extractRequestParams ?
         requestConfigParam,
     ])
 
+// Before sorting, promote any optional arg that has a defaultValue and is
+// followed by a required arg to "positionally required". The sort still pushes
+// truly-optional (`?:`) args to the end, but defaultable args ahead of a
+// required arg stay in declaration order, so callers' positional arguments
+// don't silently shift when a previously-required query becomes optional.
+const positionedWrapperArgs = rawWrapperArgs.map((arg, i) => {
+    if (arg.optional && arg.defaultValue && rawWrapperArgs.slice(i + 1).some(a => !a.optional)) {
+        return { ...arg, optional: false };
+    }
+    return arg;
+})
+
 const wrapperArgs = _
     // Sort by optionality
-    .sortBy(rawWrapperArgs, [o => o.optional])
+    .sortBy(positionedWrapperArgs, [o => o.optional])
     .map(argToTmpl)
     .join(', ')
 

--- a/templates/modular/procedure-call.ejs
+++ b/templates/modular/procedure-call.ejs
@@ -46,9 +46,21 @@ const rawWrapperArgs = config.extractRequestParams ?
         requestConfigParam,
     ])
 
+// Before sorting, promote any optional arg that has a defaultValue and is
+// followed by a required arg to "positionally required". The sort still pushes
+// truly-optional (`?:`) args to the end, but defaultable args ahead of a
+// required arg stay in declaration order, so callers' positional arguments
+// don't silently shift when a previously-required query becomes optional.
+const positionedWrapperArgs = rawWrapperArgs.map((arg, i) => {
+    if (arg.optional && arg.defaultValue && rawWrapperArgs.slice(i + 1).some(a => !a.optional)) {
+        return { ...arg, optional: false };
+    }
+    return arg;
+})
+
 const wrapperArgs = _
     // Sort by optionality
-    .sortBy(rawWrapperArgs, [o => o.optional])
+    .sortBy(positionedWrapperArgs, [o => o.optional])
     .map(argToTmpl)
     .join(', ')
 

--- a/tests/__snapshots__/extended.test.ts.snap
+++ b/tests/__snapshots__/extended.test.ts.snap
@@ -9545,8 +9545,8 @@ export class Api<
      * @request POST:/scope
      */
     signRequest: (
-      body: Claims,
       query: SignRequestParams = {},
+      body: Claims,
       params: RequestParams = {},
     ) =>
       this.request<SignRequestData, SignRequestError>({

--- a/tests/spec/extractRequestParams/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/extractRequestParams/__snapshots__/basic.test.ts.snap
@@ -686,8 +686,8 @@ export class Api<
      * @request POST:/scope
      */
     signRequest: (
-      body: Claims,
       query: SignRequestParams = {},
+      body: Claims,
       params: RequestParams = {},
     ) =>
       this.request<

--- a/tests/spec/optional-query-required-body/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/optional-query-required-body/__snapshots__/basic.test.ts.snap
@@ -1,0 +1,311 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`optional-query-required-body > with --extract-request-params, query stays before body in generated signature 1`] = `
+"/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+export interface CheckImpactPayload {
+  staff_id: number;
+  action: string;
+}
+
+export interface CheckImpactParams {
+  cadence?: "weekly" | "biweekly";
+}
+
+export type QueryParamsType = Record<string | number, any>;
+export type ResponseFormat = keyof Omit<Body, "body" | "bodyUsed">;
+
+export interface FullRequestParams extends Omit<RequestInit, "body"> {
+  /** set parameter to \`true\` for call \`securityWorker\` for this request */
+  secure?: boolean;
+  /** request path */
+  path: string;
+  /** content type of request body */
+  type?: ContentType;
+  /** query params */
+  query?: QueryParamsType;
+  /** format of response (i.e. response.json() -> format: "json") */
+  format?: ResponseFormat;
+  /** request body */
+  body?: unknown;
+  /** base url */
+  baseUrl?: string;
+  /** request cancellation token */
+  cancelToken?: CancelToken;
+}
+
+export type RequestParams = Omit<
+  FullRequestParams,
+  "body" | "method" | "query" | "path"
+>;
+
+export interface ApiConfig<SecurityDataType = unknown> {
+  baseUrl?: string;
+  baseApiParams?: Omit<RequestParams, "baseUrl" | "cancelToken" | "signal">;
+  securityWorker?: (
+    securityData: SecurityDataType | null,
+  ) => Promise<RequestParams | void> | RequestParams | void;
+  customFetch?: typeof fetch;
+}
+
+export interface HttpResponse<D extends unknown, E extends unknown = unknown>
+  extends Response {
+  data: D;
+  error: E;
+}
+
+type CancelToken = Symbol | string | number;
+
+export enum ContentType {
+  Json = "application/json",
+  JsonApi = "application/vnd.api+json",
+  FormData = "multipart/form-data",
+  UrlEncoded = "application/x-www-form-urlencoded",
+  Text = "text/plain",
+}
+
+export class HttpClient<SecurityDataType = unknown> {
+  public baseUrl: string = "";
+  private securityData: SecurityDataType | null = null;
+  private securityWorker?: ApiConfig<SecurityDataType>["securityWorker"];
+  private abortControllers = new Map<CancelToken, AbortController>();
+  private customFetch = (...fetchParams: Parameters<typeof fetch>) =>
+    fetch(...fetchParams);
+
+  private baseApiParams: RequestParams = {
+    credentials: "same-origin",
+    headers: {},
+    redirect: "follow",
+    referrerPolicy: "no-referrer",
+  };
+
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
+  }
+
+  public setSecurityData = (data: SecurityDataType | null) => {
+    this.securityData = data;
+  };
+
+  protected encodeQueryParam(key: string, value: any) {
+    const encodedKey = encodeURIComponent(key);
+    return \`\${encodedKey}=\${encodeURIComponent(typeof value === "number" ? value : \`\${value}\`)}\`;
+  }
+
+  protected addQueryParam(query: QueryParamsType, key: string) {
+    return this.encodeQueryParam(key, query[key]);
+  }
+
+  protected addArrayQueryParam(query: QueryParamsType, key: string) {
+    const value = query[key];
+    return value.map((v: any) => this.encodeQueryParam(key, v)).join("&");
+  }
+
+  protected toQueryString(rawQuery?: QueryParamsType): string {
+    const query = rawQuery || {};
+    const keys = Object.keys(query).filter(
+      (key) => "undefined" !== typeof query[key],
+    );
+    return keys
+      .map((key) =>
+        Array.isArray(query[key])
+          ? this.addArrayQueryParam(query, key)
+          : this.addQueryParam(query, key),
+      )
+      .join("&");
+  }
+
+  protected addQueryParams(rawQuery?: QueryParamsType): string {
+    const queryString = this.toQueryString(rawQuery);
+    return queryString ? \`?\${queryString}\` : "";
+  }
+
+  private contentFormatters: Record<ContentType, (input: any) => any> = {
+    [ContentType.Json]: (input: any) =>
+      input !== null && (typeof input === "object" || typeof input === "string")
+        ? JSON.stringify(input)
+        : input,
+    [ContentType.JsonApi]: (input: any) =>
+      input !== null && (typeof input === "object" || typeof input === "string")
+        ? JSON.stringify(input)
+        : input,
+    [ContentType.Text]: (input: any) =>
+      input !== null && typeof input !== "string"
+        ? JSON.stringify(input)
+        : input,
+    [ContentType.FormData]: (input: any) => {
+      if (input instanceof FormData) {
+        return input;
+      }
+
+      return Object.keys(input || {}).reduce((formData, key) => {
+        const property = input[key];
+        formData.append(
+          key,
+          property instanceof Blob
+            ? property
+            : typeof property === "object" && property !== null
+              ? JSON.stringify(property)
+              : \`\${property}\`,
+        );
+        return formData;
+      }, new FormData());
+    },
+    [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),
+  };
+
+  protected mergeRequestParams(
+    params1: RequestParams,
+    params2?: RequestParams,
+  ): RequestParams {
+    return {
+      ...this.baseApiParams,
+      ...params1,
+      ...(params2 || {}),
+      headers: {
+        ...(this.baseApiParams.headers || {}),
+        ...(params1.headers || {}),
+        ...((params2 && params2.headers) || {}),
+      },
+    };
+  }
+
+  protected createAbortSignal = (
+    cancelToken: CancelToken,
+  ): AbortSignal | undefined => {
+    if (this.abortControllers.has(cancelToken)) {
+      const abortController = this.abortControllers.get(cancelToken);
+      if (abortController) {
+        return abortController.signal;
+      }
+      return void 0;
+    }
+
+    const abortController = new AbortController();
+    this.abortControllers.set(cancelToken, abortController);
+    return abortController.signal;
+  };
+
+  public abortRequest = (cancelToken: CancelToken) => {
+    const abortController = this.abortControllers.get(cancelToken);
+
+    if (abortController) {
+      abortController.abort();
+      this.abortControllers.delete(cancelToken);
+    }
+  };
+
+  public request = async <T = any, E = any>({
+    body,
+    secure,
+    path,
+    type,
+    query,
+    format,
+    baseUrl,
+    cancelToken,
+    ...params
+  }: FullRequestParams): Promise<HttpResponse<T, E>> => {
+    const secureParams =
+      ((typeof secure === "boolean" ? secure : this.baseApiParams.secure) &&
+        this.securityWorker &&
+        (await this.securityWorker(this.securityData))) ||
+      {};
+    const requestParams = this.mergeRequestParams(params, secureParams);
+    const queryString = query && this.toQueryString(query);
+    const payloadFormatter = this.contentFormatters[type || ContentType.Json];
+    const responseFormat = format || requestParams.format;
+
+    return this.customFetch(
+      \`\${baseUrl || this.baseUrl || ""}\${path}\${queryString ? \`?\${queryString}\` : ""}\`,
+      {
+        ...requestParams,
+        headers: {
+          ...(requestParams.headers || {}),
+          ...(type && type !== ContentType.FormData
+            ? { "Content-Type": type }
+            : {}),
+        },
+        signal:
+          (cancelToken
+            ? this.createAbortSignal(cancelToken)
+            : requestParams.signal) || null,
+        body:
+          typeof body === "undefined" || body === null
+            ? null
+            : payloadFormatter(body),
+      },
+    ).then(async (response) => {
+      const r = response as HttpResponse<T, E>;
+      r.data = null as unknown as T;
+      r.error = null as unknown as E;
+
+      const responseToParse = responseFormat ? response.clone() : response;
+      const data = !responseFormat
+        ? r
+        : await responseToParse[responseFormat]()
+            .then((data) => {
+              if (r.ok) {
+                r.data = data;
+              } else {
+                r.error = data;
+              }
+              return r;
+            })
+            .catch((e) => {
+              r.error = e;
+              return r;
+            });
+
+      if (cancelToken) {
+        this.abortControllers.delete(cancelToken);
+      }
+
+      if (!response.ok) throw data;
+      return data;
+    });
+  };
+}
+
+/**
+ * @title optional-query-required-body
+ * @version 1.0.0
+ */
+export class Api<
+  SecurityDataType extends unknown,
+> extends HttpClient<SecurityDataType> {
+  checkImpact = {
+    /**
+     * No description
+     *
+     * @name CheckImpact
+     * @summary Reproduces issue #1755 follow-up: optional query + required body must keep (query, body) argument order in the generated wrapper.
+     * @request POST:/check-impact
+     */
+    checkImpact: (
+      query: CheckImpactParams = {},
+      data: CheckImpactPayload,
+      params: RequestParams = {},
+    ) =>
+      this.request<void, any>({
+        path: \`/check-impact\`,
+        method: "POST",
+        query: query,
+        body: data,
+        type: ContentType.Json,
+        ...params,
+      }),
+  };
+}
+"
+`;

--- a/tests/spec/optional-query-required-body/basic.test.ts
+++ b/tests/spec/optional-query-required-body/basic.test.ts
@@ -1,0 +1,57 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { generateApi } from "../../../src/index.js";
+
+describe("optional-query-required-body", async () => {
+  let tmpdir = "";
+
+  beforeAll(async () => {
+    tmpdir = await fs.mkdtemp(path.join(os.tmpdir(), "swagger-typescript-api"));
+  });
+
+  afterAll(async () => {
+    await fs.rm(tmpdir, { recursive: true });
+  });
+
+  test("with --extract-request-params, query stays before body in generated signature", async () => {
+    await generateApi({
+      fileName: "schema",
+      input: path.resolve(import.meta.dirname, "schema.json"),
+      output: tmpdir,
+      silent: true,
+      extractRequestParams: true,
+      extractRequestBody: true,
+    });
+
+    const content = await fs.readFile(path.join(tmpdir, "schema.ts"), {
+      encoding: "utf8",
+    });
+
+    // The signature must read (query, body, params) — NOT (body, query, params).
+    // The optional query arg has a defaultValue ({}) and must keep its
+    // declaration position even though it is sorted after required args.
+    // Default template nests operation under a namespace object, so the call
+    // arrow appears as `<operation>: (args) =>` rather than `= (args) =>`.
+    const sigMatch = content.match(
+      /checkImpact:\s*\(\s*([\s\S]*?)\s*\)\s*=>\s*this\.request/,
+    );
+    expect(sigMatch, "checkImpact arrow not found in schema.ts").not.toBeNull();
+    const signature = sigMatch![1];
+
+    const queryPos = signature.indexOf("query");
+    const dataPos = signature.search(/\bdata\b/);
+    expect(queryPos).toBeGreaterThanOrEqual(0);
+    expect(dataPos).toBeGreaterThan(0);
+    expect(queryPos).toBeLessThan(dataPos);
+
+    // The optional query arg must keep a defaultValue (`= {}`) so callers can
+    // omit it while it stays in its declared position before the required body.
+    expect(signature).toMatch(/query:\s*CheckImpactParams\s*=\s*\{\}/);
+
+    // Lock the entire generated file so future template changes can't silently
+    // regress argument ordering.
+    expect(content).toMatchSnapshot();
+  });
+});

--- a/tests/spec/optional-query-required-body/schema.json
+++ b/tests/spec/optional-query-required-body/schema.json
@@ -1,0 +1,37 @@
+{
+  "openapi": "3.0.0",
+  "info": { "title": "optional-query-required-body", "version": "1.0.0" },
+  "paths": {
+    "/check-impact": {
+      "post": {
+        "operationId": "checkImpact",
+        "summary": "Reproduces issue #1755 follow-up: optional query + required body must keep (query, body) argument order in the generated wrapper.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "cadence",
+            "schema": { "type": "string", "enum": ["weekly", "biweekly"] }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["staff_id", "action"],
+                "properties": {
+                  "staff_id": { "type": "integer" },
+                  "action": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

`extractRequestParams` generates a wrapper with arguments in the wrong order
when an endpoint has a non-required query parameter together with a required
request body. The generated signature comes out as `(body, query, params)`
instead of `(query, body, params)`, which silently swaps the first two
positional arguments at every existing call site.

The bug is a runtime regression introduced by #1756. The output is still
type-legal under `// @ts-nocheck` (the default generator header), so TypeScript
does not catch the swap; the failure surfaces only when the wrapper is called
and the body content is serialized into the URL query string.

## Reproduction

Spec (minimal):

```json
{
  "openapi": "3.0.0",
  "paths": {
    "/check-impact": {
      "post": {
        "operationId": "checkImpact",
        "parameters": [
          { "in": "query", "name": "cadence", "schema": { "type": "string" } }
        ],
        "requestBody": {
          "required": true,
          "content": { "application/json": { "schema": {
            "type": "object",
            "required": ["staff_id"],
            "properties": { "staff_id": { "type": "integer" } }
          } } }
        },
        "responses": { "200": { "description": "OK" } }
      }
    }
  }
}
```

Generate with `--extract-request-params --extract-request-body`:

**Before (current `main`)**
```ts
checkImpact = (
  data: CheckImpactPayload,           // ← first
  query: CheckImpactParams = {},      // ← second
  params: RequestParams = {},
) => this.request({ path: "/check-impact", method: "POST", query, body: data, ... })
```

A caller writing `api.checkImpact({ cadence: "weekly" }, { staff_id: 1 })` —
which reads naturally as `(query, body)` and matches the OpenAPI declaration
order — passes `{ cadence: "weekly" }` as `body` and `{ staff_id: 1 }` as
`query`. The body fields are URL-encoded into the query string and the server
sees an empty JSON body. There is no runtime error; the request is just wrong.

**Expected**
```ts
checkImpact = (
  query: CheckImpactParams = {},      // ← first, in declaration order
  data: CheckImpactPayload,           // ← second, required
  params: RequestParams = {},
)
```

## Regression timeline

| Version | Behavior |
|---|---|
| 13.2.3 — 13.2.17 (last tagged release, Feb 8 2026) | Correct: `(query, body, params)` |
| `fed24c6` / #1756 ("Fix: query params object incorrectly required when all fields are optional", May 21 2026, currently on `main` / 13.12.x) | Regressed: `(body, query, params)` |

PR #1756 surfaced
`requestParamsSchema.typeData.allFieldsAreOptional` from `schema-routes.ts` as
`route.request.requestParamsOptional` and threaded it into the template so the
extracted query argument gets marked `optional` when all of its fields are
optional. That part is a real UX improvement — callers can omit the empty
`{}` placeholder for endpoints whose only query parameters are optional.

The unintended interaction is with the existing **"Sort by optionality"** step
in `templates/{default,modular}/procedure-call.ejs`:

```js
const wrapperArgs = _
    // Sort by optionality
    .sortBy(rawWrapperArgs, [o => o.optional])
    .map(argToTmpl)
    .join(', ')
```

`_.sortBy` is stable and puts `false` (required) before `true` (optional). For
endpoints with a required body and a now-optional query, the required body is
hoisted ahead of the optional query — even though the query already carries a
`defaultValue: '{}'` that would let it sit in front of a required argument
without producing invalid TypeScript.

## Real-world impact

Every existing caller that was written against the pre-#1756 wrapper shape now
swaps body and query at runtime, with no compiler or runtime error to flag it.
This affects any project that pins `^13.2.3` (the documented range) and
re-resolves a fresh `node_modules` — for example, a CI build that runs `npm
install` from a non-committed lockfile after the publish that contains #1756.

Concretely: I hit this on a deployed app where `~/local` resolved `^13.2.3` to
`13.2.16` and generated the correct shape; the CI deploy resolved the same
range to a post-#1756 version and generated the swapped shape. Same call site,
same spec, two different argument orders, and a 400 response with the body
fields URL-encoded into the query string.

## Proposed solution

The intent of the `sortBy` step is to keep generated signatures
TypeScript-legal: a required parameter cannot follow a parameter typed as
`name?: T`. But an argument that has a `defaultValue` is **only positionally**
optional — `argToTmpl` already emits it as `name: T = default`, not `name?: T`,
and TS happily accepts a required parameter after that.

So the fix is to leave defaulted args in declaration order when a required
arg follows them, while still pushing truly-optional (`?:`) args to the end:

```js
// Before sorting, promote any optional arg that has a defaultValue and is
// followed by a required arg to "positionally required". The sort still
// pushes truly-optional (`?:`) args to the end, but defaultable args ahead
// of a required arg stay in declaration order, so callers' positional
// arguments don't silently shift when a previously-required query becomes
// optional.
const positionedWrapperArgs = rawWrapperArgs.map((arg, i) => {
    if (arg.optional && arg.defaultValue && rawWrapperArgs.slice(i + 1).some(a => !a.optional)) {
        return { ...arg, optional: false };
    }
    return arg;
})

const wrapperArgs = _
    .sortBy(positionedWrapperArgs, [o => o.optional])
    .map(argToTmpl)
    .join(', ')
```

Applied identically to `templates/default/procedure-call.ejs` and
`templates/modular/procedure-call.ejs`.

### Why this preserves #1756's UX win

For endpoints where the body is *also* optional (or there is no body), no
required arg follows the query, so the predicate doesn't fire and the query
stays `optional: true`. Callers can still omit it entirely:

```ts
listThings = (query?: ListThingsParams, params: RequestParams = {}) => ...
api.listThings();                  // still works, no required body in the way
```

It only kicks in when there is a required arg after the defaulted arg —
exactly the case where the sort would otherwise swap them.

### Why not simpler alternatives

- **Remove the sort.** Would emit invalid TS (`query?: T, body: T2`) for
  endpoints whose query arg has no `defaultValue`.
- **Sort by `o => o.optional && !o.defaultValue` (treat any defaulted arg as
  positionally required).** Promotes too much: `requestConfigParam` always
  carries `defaultValue: '{}'`, and this would hoist it ahead of a trailing
  `query?: T` for GET endpoints, churning unrelated snapshots. The
  position-aware variant in this PR only fires when the swap actually matters.
- **Revert #1756.** Throws away a genuine ergonomic improvement and forces
  callers to pass `{}` even when there is nothing to pass.

## Tests

Adds `tests/spec/optional-query-required-body/`:

- Minimal OpenAPI schema (one POST endpoint, optional `cadence` query, required
  body).
- Test asserts the generated signature has `query` before `data` and that the
  query arg keeps its `= {}` default. Locks the entire generated file via
  snapshot.
- Verified to fail on `main` and pass with the fix.

Updates two existing snapshots that were locking in the regression. Both
endpoints (`authentiq` and `extractRequestParams` test fixture) use the
`signRequest` operation, which has `body: Claims` + optional query and was
being generated as `(body, query, params)`. The new (correct) snapshot is:

```ts
signRequest: (
  query: SignRequestParams = {},
  body: Claims,
  params: RequestParams = {},
) => ...
```

All other tests pass. (The 4 failing `paths-2*` strict-TSC tests in my local
run fail on `main` too — they shell out to `bunx tsc`, which wasn't on PATH in
my environment; not related to this change.)

## End-to-end verification

Regenerated a real client (~120 endpoints) against the patched generator. Only
the two endpoints whose swagger matches the bug shape (required body +
non-required query) changed; every other endpoint's signature is byte-identical
to the 13.2.x output. Both regressed endpoints now produce
`(query: ... = {}, data, params = {})`, matching what their callers were
written against.

Closes the silent-swap regression introduced by #1756 without reverting that
PR's UX improvement.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a regression where generated wrapper arguments for endpoints with an optional query and required body flipped from `(query, body, params)` to `(body, query, params)`, silently swapping caller arguments at runtime. Defaulted args followed by a required arg are now treated as positionally required during the optionality sort, so declaration order is preserved without losing #1756's ability to omit empty query objects.

**Bug Fixes**
- In `templates/{default,modular}/procedure-call.ejs`, promote optional args with a `defaultValue` to positionally required when a required arg follows, then sort.
- Keeps the emitted `query: T = {}` (not `query?: T`), so the signature stays TypeScript-legal with a required arg after it.
- Added `tests/spec/optional-query-required-body` to lock the corrected signature.
- Updated existing `signRequest` snapshots that had captured the swapped order.

<sup>Written for commit c222c2374e0f32580a824387580ba8abeb5de14e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/acacode/swagger-typescript-api/pull/1816?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

