### PR TITLE
Infer object type from additionalProperties

### DIFF
--- a/src/schema-parser/schema-parser.ts
+++ b/src/schema-parser/schema-parser.ts
@@ -215,6 +215,9 @@ export class SchemaParser {
       ) {
         this.schema.type = SCHEMA_TYPES.ARRAY;
       }
+      if (this.schema.additionalProperties && !this.schema.type) {
+        this.schema.type = SCHEMA_TYPES.OBJECT;
+      }
       // schema is enum with one null value
       if (
         Array.isArray(this.schema.enum) &&

--- a/tests/spec/additional-properties-without-type/basic.test.ts
+++ b/tests/spec/additional-properties-without-type/basic.test.ts
@@ -1,0 +1,35 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { generateApi } from "../../../src/index.js";
+
+describe("additionalProperties without type", async () => {
+  let tmpdir = "";
+
+  beforeAll(async () => {
+    tmpdir = await fs.mkdtemp(path.join(os.tmpdir(), "swagger-typescript-api"));
+  });
+
+  afterAll(async () => {
+    await fs.rm(tmpdir, { recursive: true });
+  });
+
+  test("infers dictionary types", async () => {
+    await generateApi({
+      fileName: "schema",
+      input: path.resolve(import.meta.dirname, "schema.json"),
+      output: tmpdir,
+      silent: true,
+      generateClient: false,
+    });
+
+    const content = await fs.readFile(path.join(tmpdir, "schema.ts"), {
+      encoding: "utf8",
+    });
+
+    expect(content).toContain("values: Record<string, string[]>;");
+    expect(content).toContain("open?: Record<string, any>;");
+    expect(content).toContain("closed?: any;");
+  });
+});

--- a/tests/spec/additional-properties-without-type/schema.json
+++ b/tests/spec/additional-properties-without-type/schema.json
@@ -1,0 +1,32 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Additional properties without an explicit type",
+    "version": "1.0.0"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "Widget": {
+        "type": "object",
+        "required": ["values"],
+        "properties": {
+          "values": {
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "open": {
+            "additionalProperties": true
+          },
+          "closed": {
+            "additionalProperties": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Problem

Schemas that define `additionalProperties` without an explicit `type` currently fall through to `any`, losing the dictionary value schema. This is tracked in acacode/swagger-typescript-api#1822.

## Solution

Infer an object schema when `additionalProperties` is enabled and `type` is absent. Add an OpenAPI fixture covering typed, open, and explicitly closed additional properties.

Closes acacode/swagger-typescript-api#1822.

## Verification

- `bun run format:check`
- `bunx biome check src/schema-parser/schema-parser.ts tests/spec/additional-properties-without-type/basic.test.ts tests/spec/additional-properties-without-type/schema.json`
- `bun run test` (96 files, 288 tests)
- `bun run build`

`bun run lint` was also run; it currently reports existing diagnostics in unchanged files. The changed files pass the targeted Biome check above.

---
Written by an agent (OpenAI Codex, GPT-5).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Infers object type when `additionalProperties` is present without a `type`, preserving dictionary value schemas instead of falling back to `any`.

- **Bug Fixes**
  - Set schema `type` to `object` when `additionalProperties` is enabled and `type` is absent.
  - Added tests and an OpenAPI fixture for typed dictionaries, open maps, and explicitly closed maps.

<sup>Written for commit b66863400d0a769ab946c02289f8bd7a716208ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/acacode/swagger-typescript-api/pull/1823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

