### PR TITLE
Add options for import file extensions and type-only imports

### DIFF
--- a/.changeset/import-file-extension-and-type-only-imports.md
+++ b/.changeset/import-file-extension-and-type-only-imports.md
@@ -1,0 +1,14 @@
+---
+"swagger-typescript-api": minor
+---
+
+Add `importFileExtension` and `typeOnlyImports` options
+
+`importFileExtension` (`""` | `".js"` | `".ts"`) appends a file extension to
+generated relative imports, for projects using `moduleResolution: node16`/`nodenext`
+(`.js`) or `allowImportingTsExtensions` (`.ts`).
+
+`typeOnlyImports` emits `import type` for type-only imports (and inline `type` on
+mixed imports such as the http-client import, where `HttpClient` stays a value
+import) for projects using `verbatimModuleSyntax` / `isolatedModules`. `ContentType`
+is only marked `type` for `enumStyle: "union"`, where it is a pure type.

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /docs/
 /node_modules/
 /tmp-issue-463-run/
+/.idea/
+/.serena/

--- a/index.ts
+++ b/index.ts
@@ -199,6 +199,18 @@ const generateCommand = defineCommand({
         'enum output style: "enum" (default), "union" (T1 | T2 | TN), "const" (as const object + type alias), or "const-enum" (const enum)',
       default: codeGenBaseConfig.enumStyle,
     },
+    "import-file-extension": {
+      type: "string",
+      description:
+        'extension appended to generated relative imports: "" (default), ".js" (moduleResolution node16/nodenext), or ".ts" (allowImportingTsExtensions)',
+      default: codeGenBaseConfig.importFileExtension,
+    },
+    "type-only-imports": {
+      type: "boolean",
+      description:
+        "emit `import type` / inline `type` for type-only imports (verbatimModuleSyntax / isolatedModules)",
+      default: codeGenBaseConfig.typeOnlyImports,
+    },
     "http-client": {
       type: "string",
       description: `http client type (possible values: ${Object.values(
@@ -349,6 +361,12 @@ const generateCommand = defineCommand({
         | "const"
         | "const-enum"
         | undefined,
+      importFileExtension: args["import-file-extension"] as
+        | ""
+        | ".js"
+        | ".ts"
+        | undefined,
+      typeOnlyImports: args["type-only-imports"],
       httpClientType:
         args["http-client"] || args.axios
           ? HTTP_CLIENT.AXIOS

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -61,6 +61,10 @@ export class CodeGenConfig {
   enumStyle: "enum" | "union" | "const" | "const-enum" = "enum";
   /** @deprecated Use enumStyle: "union" instead */
   generateUnionEnums = false;
+  /** CLI flag. Extension appended to generated relative imports: "" (default), ".js", or ".ts". */
+  importFileExtension: "" | ".js" | ".ts" = "";
+  /** CLI flag. Emit `import type` / inline `type` for type-only imports. */
+  typeOnlyImports = false;
   /** CLI flag */
   addReadonly = false;
   enumNamesAsValues = false;

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -470,6 +470,12 @@ export class CodeGenConfig {
     >,
   ) => {
     objectAssign(this, update);
+    this.importFileExtension ??= "";
+    if (!["", ".js", ".ts"].includes(this.importFileExtension)) {
+      throw new Error(
+        `Invalid \`importFileExtension\` value "${this.importFileExtension}". Expected "", ".js", or ".ts".`,
+      );
+    }
     if (this.enumNamesAsValues) {
       this.extractEnums = true;
     }

--- a/templates/default/route-types.ejs
+++ b/templates/default/route-types.ejs
@@ -5,7 +5,7 @@ const dataContracts = config.modular ? _.map(modelTypes, "name") : [];
 %>
 
 <% if (dataContracts.length) { %>
-import { <%~ dataContracts.join(", ") %> } from "./<%~ config.fileNames.dataContracts %>"
+import <%~ config.typeOnlyImports ? "type " : "" %>{ <%~ dataContracts.join(", ") %> } from "./<%~ config.fileNames.dataContracts %><%~ config.importFileExtension %>"
 <% } %>
 
 <%

--- a/templates/modular/api.ejs
+++ b/templates/modular/api.ejs
@@ -4,17 +4,18 @@ const { _, pascalCase, require } = utils;
 const apiClassName = pascalCase(route.moduleName);
 const routes = route.routes;
 const dataContracts = _.map(modelTypes, "name");
+const importExt = config.importFileExtension;
+const typeModifier = config.typeOnlyImports ? "type " : "";
+// ContentType is a pure type only for the "union" style; otherwise it is a runtime value.
+const contentTypeSpecifier = config.enumStyle === "union" ? "type ContentType" : "ContentType";
+const httpClientSpecifiers = ["HttpClient", `${typeModifier}RequestParams`, contentTypeSpecifier, `${typeModifier}HttpResponse`].join(", ");
 %>
 
 <% if (config.httpClientType === config.constants.HTTP_CLIENT.AXIOS) { %> import type { AxiosRequestConfig, AxiosResponse } from "axios"; <% } %>
 
-<% if (config.enumStyle === "union") { %>
-import { HttpClient, RequestParams, type ContentType, HttpResponse } from "./<%~ config.fileNames.httpClient %>";
-<% } else { %>
-import { HttpClient, RequestParams, ContentType, HttpResponse } from "./<%~ config.fileNames.httpClient %>";
-<% } %>
+import { <%~ httpClientSpecifiers %> } from "./<%~ config.fileNames.httpClient %><%~ importExt %>";
 <% if (dataContracts.length) { %>
-import { <%~ dataContracts.join(", ") %> } from "./<%~ config.fileNames.dataContracts %>"
+import <%~ typeModifier %>{ <%~ dataContracts.join(", ") %> } from "./<%~ config.fileNames.dataContracts %><%~ importExt %>"
 <% } %>
 
 export class <%= apiClassName %><SecurityDataType = unknown><% if (!config.singleHttpClient) { %> extends HttpClient<SecurityDataType> <% } %> {

--- a/templates/modular/route-types.ejs
+++ b/templates/modular/route-types.ejs
@@ -6,7 +6,7 @@ const dataContracts = config.modular ? _.map(modelTypes, "name") : [];
 
 %>
 <% if (dataContracts.length) { %>
-import { <%~ dataContracts.join(", ") %> } from "./<%~ config.fileNames.dataContracts %>"
+import <%~ config.typeOnlyImports ? "type " : "" %>{ <%~ dataContracts.join(", ") %> } from "./<%~ config.fileNames.dataContracts %><%~ config.importFileExtension %>"
 <% } %>
 
 export namespace <%~ pascalCase(moduleName) %> {

--- a/tests/spec/import-file-extension/basic.test.ts
+++ b/tests/spec/import-file-extension/basic.test.ts
@@ -31,6 +31,24 @@ describe("import-file-extension", async () => {
     return fs.readFile(path.join(tmpdir, "Api.ts"), { encoding: "utf8" });
   };
 
+  const generateRouteTypes = async (
+    fileName: string,
+    options: Partial<Parameters<typeof generateApi>[0]>,
+  ) => {
+    await generateApi({
+      fileName,
+      input: path.resolve(import.meta.dirname, "schema.json"),
+      output: tmpdir,
+      silent: true,
+      modular: true,
+      cleanOutput: false,
+      generateRouteTypes: true,
+      generateClient: false,
+      ...options,
+    });
+    return fs.readFile(path.join(tmpdir, "ApiRoute.ts"), { encoding: "utf8" });
+  };
+
   test('appends ".js" to relative imports', async () => {
     const api = await generate("js-ext", { importFileExtension: ".js" });
 
@@ -110,5 +128,46 @@ describe("import-file-extension", async () => {
 
     expect(api).toMatch(/import type \{[^}]*\} from "\.\/data-contracts\.js"/);
     expect(api).toContain('from "./http-client.js"');
+  });
+
+  test("rejects an unsupported importFileExtension value", async () => {
+    await expect(
+      generateApi({
+        fileName: "invalid-ext",
+        input: path.resolve(import.meta.dirname, "schema.json"),
+        output: tmpdir,
+        silent: true,
+        cleanOutput: false,
+        importFileExtension: ".mjs" as ".js",
+      }),
+    ).rejects.toThrow(/importFileExtension/);
+  });
+
+  test("treats an explicit undefined importFileExtension as no extension", async () => {
+    const api = await generate("undef-ext", {
+      importFileExtension: undefined,
+    });
+
+    expect(api).toContain('from "./data-contracts"');
+    expect(api).not.toContain("data-contracts.js");
+  });
+
+  test("appends extension to route-type imports", async () => {
+    const routeTypes = await generateRouteTypes("route-types-ext", {
+      importFileExtension: ".js",
+    });
+
+    expect(routeTypes).toContain('from "./data-contracts.js"');
+  });
+
+  test("emits type-only route-type imports when typeOnlyImports", async () => {
+    const routeTypes = await generateRouteTypes("route-types-type-only", {
+      importFileExtension: ".js",
+      typeOnlyImports: true,
+    });
+
+    expect(routeTypes).toMatch(
+      /import type \{[^}]*\} from "\.\/data-contracts\.js"/,
+    );
   });
 });

--- a/tests/spec/import-file-extension/basic.test.ts
+++ b/tests/spec/import-file-extension/basic.test.ts
@@ -1,0 +1,114 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { generateApi } from "../../../src/index.js";
+
+describe("import-file-extension", async () => {
+  let tmpdir = "";
+
+  beforeAll(async () => {
+    tmpdir = await fs.mkdtemp(path.join(os.tmpdir(), "swagger-typescript-api"));
+  });
+
+  afterAll(async () => {
+    await fs.rm(tmpdir, { recursive: true });
+  });
+
+  const generate = async (
+    fileName: string,
+    options: Partial<Parameters<typeof generateApi>[0]>,
+  ) => {
+    await generateApi({
+      fileName,
+      input: path.resolve(import.meta.dirname, "schema.json"),
+      output: tmpdir,
+      silent: true,
+      modular: true,
+      cleanOutput: false,
+      ...options,
+    });
+    return fs.readFile(path.join(tmpdir, "Api.ts"), { encoding: "utf8" });
+  };
+
+  test('appends ".js" to relative imports', async () => {
+    const api = await generate("js-ext", { importFileExtension: ".js" });
+
+    expect(api).toContain('from "./data-contracts.js"');
+    expect(api).toContain('from "./http-client.js"');
+  });
+
+  test('appends ".ts" to relative imports', async () => {
+    const api = await generate("ts-ext", { importFileExtension: ".ts" });
+
+    expect(api).toContain('from "./data-contracts.ts"');
+    expect(api).toContain('from "./http-client.ts"');
+  });
+
+  test("defaults to no extension when option is unset", async () => {
+    const api = await generate("no-ext", {});
+
+    expect(api).toContain('from "./data-contracts"');
+    expect(api).toContain('from "./http-client"');
+    expect(api).not.toContain("data-contracts.js");
+    expect(api).not.toContain("data-contracts.ts");
+  });
+
+  test("emits whole-block type import for data-contracts when typeOnlyImports", async () => {
+    const api = await generate("type-only", { typeOnlyImports: true });
+
+    expect(api).toMatch(/import type \{[^}]*\} from "\.\/data-contracts"/);
+  });
+
+  test("marks type-only http-client specifiers inline, keeps HttpClient a value import", async () => {
+    const api = await generate("type-only-http", { typeOnlyImports: true });
+
+    const httpImport = api
+      .split("\n")
+      .find((line) => line.includes('from "./http-client"'));
+
+    expect(httpImport).toBeDefined();
+    expect(httpImport).toContain("type RequestParams");
+    // HttpClient is a runtime class (extended/instantiated) - never type-only
+    expect(httpImport).not.toContain("type HttpClient");
+    expect(httpImport).not.toMatch(/import type \{/);
+  });
+
+  test("does not mark ContentType as type for runtime enum styles", async () => {
+    const api = await generate("type-only-enum", {
+      typeOnlyImports: true,
+      enumStyle: "enum",
+    });
+
+    expect(api).not.toContain("type ContentType");
+  });
+
+  test("never imports ContentType as a runtime value for union enum style", async () => {
+    const api = await generate("type-only-union", {
+      typeOnlyImports: true,
+      enumStyle: "union",
+    });
+
+    const httpImport = api
+      .split("\n")
+      .find((line) => line.includes('from "./http-client"'));
+
+    expect(httpImport).toBeDefined();
+    // In union mode ContentType is a pure type: procedure calls use string
+    // literals instead, so it is either marked `type` or dropped as unused -
+    // it must never appear as a bare runtime import.
+    expect(httpImport).not.toMatch(/(?<!type )\bContentType\b/);
+    // The mixed http-client import still marks the type-only specifiers inline.
+    expect(httpImport).toContain("type RequestParams");
+  });
+
+  test("combines extension and type-only imports", async () => {
+    const api = await generate("combined", {
+      importFileExtension: ".js",
+      typeOnlyImports: true,
+    });
+
+    expect(api).toMatch(/import type \{[^}]*\} from "\.\/data-contracts\.js"/);
+    expect(api).toContain('from "./http-client.js"');
+  });
+});

--- a/tests/spec/import-file-extension/schema.json
+++ b/tests/spec/import-file-extension/schema.json
@@ -1,0 +1,1099 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "description": "This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.",
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "email": "apiteam@swagger.io"
+    },
+    "license": {
+      "name": "Apache-2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/v2",
+  "tags": [
+    {
+      "name": "pet",
+      "description": "Everything about your Pets",
+      "externalDocs": {
+        "description": "Find out more",
+        "url": "http://swagger.io"
+      }
+    },
+    {
+      "name": "store",
+      "description": "Access to Petstore orders"
+    },
+    {
+      "name": "user",
+      "description": "Operations about user",
+      "externalDocs": {
+        "description": "Find out more about our store",
+        "url": "http://swagger.io"
+      }
+    }
+  ],
+  "schemes": ["http"],
+  "paths": {
+    "api/v1/pet": {
+      "post": {
+        "tags": ["pet"],
+        "summary": "Add a new pet to the store",
+        "description": "",
+        "operationId": "addPet",
+        "consumes": ["application/json", "application/xml"],
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Pet object that needs to be added to the store",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          }
+        ],
+        "responses": {
+          "405": {
+            "description": "Invalid input"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": ["write:pets", "read:pets"]
+          }
+        ],
+        "x-contentType": "application/json",
+        "x-accepts": "application/json"
+      },
+      "put": {
+        "tags": ["pet"],
+        "summary": "Update an existing pet",
+        "description": "",
+        "operationId": "updatePet",
+        "consumes": ["application/json", "application/xml"],
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Pet object that needs to be added to the store",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Pet not found"
+          },
+          "405": {
+            "description": "Validation exception"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": ["write:pets", "read:pets"]
+          }
+        ],
+        "x-contentType": "application/json",
+        "x-accepts": "application/json"
+      }
+    },
+    "api/v1/pet/findByStatus": {
+      "get": {
+        "tags": ["pet"],
+        "summary": "Finds Pets by status",
+        "description": "Multiple status values can be provided with comma separated strings",
+        "operationId": "findPetsByStatus",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Status values that need to be considered for filter",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": "available",
+              "enum": ["available", "pending", "sold"]
+            },
+            "collectionFormat": "csv"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Pet"
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid status value"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": ["write:pets", "read:pets"]
+          }
+        ],
+        "x-accepts": "application/json"
+      }
+    },
+    "api/v1/pet/findByTags": {
+      "get": {
+        "tags": ["pet"],
+        "summary": "Finds Pets by tags",
+        "description": "Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.",
+        "operationId": "findPetsByTags",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "Tags to filter by",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "csv"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Pet"
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid tag value"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": ["write:pets", "read:pets"]
+          }
+        ],
+        "deprecated": true,
+        "x-accepts": "application/json"
+      }
+    },
+    "api/v1/pet/{petId}": {
+      "get": {
+        "tags": ["pet"],
+        "summary": "Find pet by ID",
+        "description": "Returns a single pet",
+        "operationId": "getPetById",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet to return",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Pet not found"
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ],
+        "x-accepts": "application/json"
+      },
+      "post": {
+        "tags": ["pet"],
+        "summary": "Updates a pet in the store with form data",
+        "description": "",
+        "operationId": "updatePetWithForm",
+        "consumes": ["application/x-www-form-urlencoded"],
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet that needs to be updated",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "name",
+            "in": "formData",
+            "description": "Updated name of the pet",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "status",
+            "in": "formData",
+            "description": "Updated status of the pet",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "405": {
+            "description": "Invalid input"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": ["write:pets", "read:pets"]
+          }
+        ],
+        "x-contentType": "application/x-www-form-urlencoded",
+        "x-accepts": "application/json"
+      },
+      "delete": {
+        "tags": ["pet"],
+        "summary": "Deletes a pet",
+        "description": "",
+        "operationId": "deletePet",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "api_key",
+            "in": "header",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "Pet id to delete",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid pet value"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": ["write:pets", "read:pets"]
+          }
+        ],
+        "x-accepts": "application/json"
+      }
+    },
+    "api/v1/pet/{petId}/uploadImage": {
+      "post": {
+        "tags": ["pet"],
+        "summary": "uploads an image",
+        "description": "",
+        "operationId": "uploadFile",
+        "consumes": ["multipart/form-data"],
+        "produces": ["application/json"],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet to update",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "additionalMetadata",
+            "in": "formData",
+            "description": "Additional data to pass to server",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "file",
+            "in": "formData",
+            "description": "file to upload",
+            "required": false,
+            "type": "file"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/ApiResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": ["write:pets", "read:pets"]
+          }
+        ],
+        "x-contentType": "multipart/form-data",
+        "x-accepts": "application/json"
+      }
+    },
+    "api/v1/store/inventory": {
+      "get": {
+        "tags": ["store"],
+        "summary": "Returns pet inventories by status",
+        "description": "Returns a map of status codes to quantities",
+        "operationId": "getInventory",
+        "produces": ["application/json"],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ],
+        "x-accepts": "application/json"
+      }
+    },
+    "api/v1/store/order": {
+      "post": {
+        "tags": ["store"],
+        "summary": "Place an order for a pet",
+        "description": "",
+        "operationId": "placeOrder",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "order placed for purchasing the pet",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Order"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/Order"
+            }
+          },
+          "400": {
+            "description": "Invalid Order"
+          }
+        },
+        "x-contentType": "application/json",
+        "x-accepts": "application/json"
+      }
+    },
+    "api/v1/store/order/{orderId}": {
+      "get": {
+        "tags": ["store"],
+        "summary": "Find purchase order by ID",
+        "description": "For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions",
+        "operationId": "getOrderById",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "orderId",
+            "in": "path",
+            "description": "ID of pet that needs to be fetched",
+            "required": true,
+            "type": "integer",
+            "maximum": 5,
+            "minimum": 1,
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/Order"
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Order not found"
+          }
+        },
+        "x-accepts": "application/json"
+      },
+      "delete": {
+        "tags": ["store"],
+        "summary": "Delete purchase order by ID",
+        "description": "For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors",
+        "operationId": "deleteOrder",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "orderId",
+            "in": "path",
+            "description": "ID of the order that needs to be deleted",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Order not found"
+          }
+        },
+        "x-accepts": "application/json"
+      }
+    },
+    "api/v1/user": {
+      "post": {
+        "tags": ["user"],
+        "summary": "Create user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "createUser",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Created user object",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        },
+        "x-contentType": "application/json",
+        "x-accepts": "application/json"
+      }
+    },
+    "api/v1/user/createWithArray": {
+      "post": {
+        "tags": ["user"],
+        "summary": "Creates list of users with given input array",
+        "description": "",
+        "operationId": "createUsersWithArrayInput",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "List of user object",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/User"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        },
+        "x-contentType": "application/json",
+        "x-accepts": "application/json"
+      }
+    },
+    "api/v1/user/createWithList": {
+      "post": {
+        "tags": ["user"],
+        "summary": "Creates list of users with given input array",
+        "description": "",
+        "operationId": "createUsersWithListInput",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "List of user object",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/User"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        },
+        "x-contentType": "application/json",
+        "x-accepts": "application/json"
+      }
+    },
+    "api/v1/user/login": {
+      "get": {
+        "tags": ["user"],
+        "summary": "Logs user into the system",
+        "description": "",
+        "operationId": "loginUser",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "username",
+            "in": "query",
+            "description": "The user name for login",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "password",
+            "in": "query",
+            "description": "The password for login in clear text",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "headers": {
+              "X-Rate-Limit": {
+                "type": "integer",
+                "format": "int32",
+                "description": "calls per hour allowed by the user"
+              },
+              "X-Expires-After": {
+                "type": "string",
+                "format": "date-time",
+                "description": "date in UTC when toekn expires"
+              }
+            },
+            "schema": {
+              "type": "string"
+            }
+          },
+          "400": {
+            "description": "Invalid username/password supplied"
+          }
+        },
+        "x-accepts": "application/json"
+      }
+    },
+    "api/v1/user/logout": {
+      "get": {
+        "tags": ["user"],
+        "summary": "Logs out current logged in user session",
+        "description": "",
+        "operationId": "logoutUser",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [],
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        },
+        "x-accepts": "application/json"
+      }
+    },
+    "api/v1/user/{username}": {
+      "get": {
+        "tags": ["user"],
+        "summary": "Get user by user name",
+        "description": "",
+        "operationId": "getUserByName",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "The name that needs to be fetched. Use user1 for testing.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          },
+          "400": {
+            "description": "Invalid username supplied"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        },
+        "x-accepts": "application/json"
+      },
+      "put": {
+        "tags": ["user"],
+        "summary": "Updated user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "updateUser",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "name that need to be deleted",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Updated user object",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid user supplied"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        },
+        "x-contentType": "application/json",
+        "x-accepts": "application/json"
+      },
+      "delete": {
+        "tags": ["user"],
+        "summary": "Delete user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "deleteUser",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "The name that needs to be deleted",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid username supplied"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        },
+        "x-accepts": "application/json"
+      }
+    },
+    "api/v1/{username}": {
+      "get": {
+        "tags": ["user"],
+        "summary": "Get user by user name",
+        "description": "",
+        "operationId": "getUserByName",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "The name that needs to be fetched. Use user1 for testing.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          },
+          "400": {
+            "description": "Invalid username supplied"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        },
+        "x-accepts": "application/json"
+      },
+      "put": {
+        "tags": ["user"],
+        "summary": "Updated user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "updateUser",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "name that need to be deleted",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Updated user object",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid user supplied"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        },
+        "x-contentType": "application/json",
+        "x-accepts": "application/json"
+      },
+      "delete": {
+        "tags": ["user"],
+        "summary": "Delete user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "deleteUser",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "The name that needs to be deleted",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid username supplied"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        },
+        "x-accepts": "application/json"
+      }
+    }
+  },
+  "securityDefinitions": {
+    "petstore_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "http://petstore.swagger.io/api/v1/oauth/dialog",
+      "flow": "implicit",
+      "scopes": {
+        "write:pets": "modify pets in your account",
+        "read:pets": "read your pets"
+      }
+    },
+    "api_key": {
+      "type": "apiKey",
+      "name": "api_key",
+      "in": "header"
+    }
+  },
+  "definitions": {
+    "Order": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "petId": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "quantity": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "shipDate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "status": {
+          "type": "string",
+          "description": "Order Status",
+          "enum": ["placed", "approved", "delivered"]
+        },
+        "complete": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "title": "Pet Order",
+      "xml": {
+        "name": "Order"
+      },
+      "description": "An order for a pets from the pet store",
+      "example": {
+        "petId": 6,
+        "quantity": 1,
+        "id": 0,
+        "shipDate": "2000-01-23T04:56:07.000+00:00",
+        "complete": false,
+        "status": "placed"
+      }
+    },
+    "Category": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "title": "Pet category",
+      "xml": {
+        "name": "Category"
+      },
+      "description": "A category for a pet",
+      "example": {
+        "name": "name",
+        "id": 6
+      }
+    },
+    "User": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "username": {
+          "type": "string"
+        },
+        "firstName": {
+          "type": "string"
+        },
+        "lastName": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        },
+        "phone": {
+          "type": "string"
+        },
+        "userStatus": {
+          "type": "integer",
+          "format": "int32",
+          "description": "User Status"
+        }
+      },
+      "title": "a User",
+      "xml": {
+        "name": "User"
+      },
+      "description": "A User who is purchasing from the pet store",
+      "example": {
+        "firstName": "firstName",
+        "lastName": "lastName",
+        "password": "password",
+        "userStatus": 6,
+        "phone": "phone",
+        "id": 0,
+        "email": "email",
+        "username": "username"
+      }
+    },
+    "Tag": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "title": "Pet Tag",
+      "xml": {
+        "name": "Tag"
+      },
+      "description": "A tag for a pet",
+      "example": {
+        "name": "name",
+        "id": 1
+      }
+    },
+    "PetNames": {
+      "type": "string",
+      "enum": ["Fluffy Hero", "Piggy Po", "Swagger Typescript Api"]
+    },
+    "PetIds": {
+      "type": "integer",
+      "enum": [10, 20, 30, 40]
+    },
+    "Pet": {
+      "type": "object",
+      "required": ["name", "photoUrls"],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "category": {
+          "$ref": "#/definitions/Category"
+        },
+        "name": {
+          "type": "string",
+          "example": "doggie"
+        },
+        "photoUrls": {
+          "type": "array",
+          "xml": {
+            "name": "photoUrl",
+            "wrapped": true
+          },
+          "items": {
+            "type": "string"
+          }
+        },
+        "tags": {
+          "type": "array",
+          "xml": {
+            "name": "tag",
+            "wrapped": true
+          },
+          "items": {
+            "$ref": "#/definitions/Tag"
+          }
+        },
+        "status": {
+          "type": "string",
+          "description": "pet status in the store",
+          "enum": ["available", "pending", "sold"]
+        }
+      },
+      "title": "a Pet",
+      "xml": {
+        "name": "Pet"
+      },
+      "description": "A pet for sale in the pet store",
+      "example": {
+        "photoUrls": ["photoUrls", "photoUrls"],
+        "name": "doggie",
+        "id": 0,
+        "category": {
+          "name": "name",
+          "id": 6
+        },
+        "tags": [
+          {
+            "name": "name",
+            "id": 1
+          },
+          {
+            "name": "name",
+            "id": 1
+          }
+        ],
+        "status": "available"
+      }
+    },
+    "ApiResponse": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "type": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        }
+      },
+      "title": "An uploaded response",
+      "description": "Describes the result of uploading an image resource",
+      "example": {
+        "code": 0,
+        "type": "type",
+        "message": "message"
+      }
+    },
+    "Amount": {
+      "type": "object",
+      "required": ["currency", "value"],
+      "properties": {
+        "value": {
+          "type": "number",
+          "format": "double",
+          "description": "some description\n",
+          "minimum": 0.01,
+          "maximum": 1000000000000000
+        },
+        "currency": {
+          "$ref": "#/definitions/Currency"
+        }
+      },
+      "description": "some description\n"
+    },
+    "Currency": {
+      "type": "string",
+      "pattern": "^[A-Z]{3,3}$",
+      "description": "some description\n"
+    }
+  },
+  "externalDocs": {
+    "description": "Find out more about Swagger",
+    "url": "http://swagger.io"
+  }
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -535,6 +535,16 @@ export interface GenerateApiConfiguration {
     enumStyle: "enum" | "union" | "const" | "const-enum";
     /** @deprecated Use enumStyle: "union" instead */
     generateUnionEnums: boolean;
+    /**
+     * file extension appended to generated relative imports (e.g. `./data-contracts` -> `./data-contracts.js`).
+     * Use ".js" for `moduleResolution: node16/nodenext`, ".ts" for `allowImportingTsExtensions`, or "" (default) for none.
+     */
+    importFileExtension: "" | ".js" | ".ts";
+    /**
+     * emit `import type` (and inline `type` on mixed imports) for type-only imports.
+     * Useful for `verbatimModuleSyntax` / `isolatedModules`.
+     */
+    typeOnlyImports: boolean;
     /** parsed swagger schema */
     swaggerSchema: OpenAPI.Document;
     /** original swagger schema */


### PR DESCRIPTION
Closes #1829

## Problem

The generated client emits **extensionless, value-only relative imports**:

```ts
import { ApiResponse, Pet, User } from "./data-contracts";
import { ContentType, HttpClient, RequestParams } from "./http-client";
```

This breaks two increasingly common TypeScript setups, with no built-in option to change it — users must post-process the output by hand:

1. **Missing file extensions.** `moduleResolution: "node16" | "nodenext"` requires explicit extensions on relative imports; the generated `./data-contracts` / `./http-client` fail to resolve at runtime (ESM) and are flagged by the compiler. `allowImportingTsExtensions` needs `.ts` instead.
2. **Value imports break `verbatimModuleSyntax` / `isolatedModules`.** Type-only names (data contracts, `RequestParams`, `HttpResponse`, and `ContentType` in `enumStyle: "union"`) are imported as values, which is an error under those flags.

The http-client import is **mixed**: `HttpClient` is a runtime class and must stay a value import, while `RequestParams`/`HttpResponse` are type-only — so it needs per-specifier inline `type`, not a whole-block `import type`.

## Solution

Two new options, both defaulting to current behavior (no change to existing output):

- **`importFileExtension: "" | ".js" | ".ts"`** (default `""`) — appended to generated relative imports. `.js` for `node16`/`nodenext`, `.ts` for `allowImportingTsExtensions`.
- **`typeOnlyImports: boolean`** (default `false`) — emits `import type` for the wholly type-only data-contracts import, and inline `type` on the mixed http-client import, keeping `HttpClient` a value import. `ContentType` is marked `type` only for `enumStyle: "union"` (where it is a pure type); for `enum`/`const`/`const-enum` it stays a runtime value.

Both are exposed as CLI flags (`--import-file-extension`, `--type-only-imports`).

Implemented at the template level (`templates/modular/api.ejs`, `templates/modular/route-types.ejs`, `templates/default/route-types.ejs`) rather than as a post-processing pass, since the templates already know the import paths and which specifiers are types.

Example — replacing a typical hand-rolled Node16 post-process:

```ts
generateApi({
  importFileExtension: ".js",
  typeOnlyImports: true,
});
```

Produces:

```ts
import type { ApiResponse, Pet, User } from "./data-contracts.js";
import { ContentType, HttpClient, type RequestParams } from "./http-client.js";
```

## Verification

- New spec suite `tests/spec/import-file-extension/` (8 tests): `.js` / `.ts` extensions, default (no extension), whole-block `import type` for data-contracts, inline `type` on the mixed http-client import with `HttpClient` kept as a value, `ContentType` value-vs-type per enum style, and the combined case.
- All existing snapshot tests pass unchanged, confirming default output is byte-identical.
- `bun run build` passes; no new lint warnings/errors introduced.

## Notes

- Adds a changeset (`minor`).
- One unrelated commit adds `/.idea/` and `/.serena/` to `.gitignore`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `importFileExtension` and `typeOnlyImports` options so generated relative imports work with `moduleResolution: node16`/`nodenext`, `allowImportingTsExtensions`, and `verbatimModuleSyntax`/`isolatedModules`. Both default to current behavior, so existing output is byte-identical.

**New Features**
- `importFileExtension` (`""` | `".js"` | `".ts"`) appends an extension to generated relative imports; use `.js` for `node16`/`nodenext` and `.ts` for `allowImportingTsExtensions`.
- Invalid `importFileExtension` values are rejected at runtime; explicit `undefined` normalizes to `""`.
- `typeOnlyImports` emits whole-block `import type` for data-contracts and inline `type` on the mixed http-client import, keeping `HttpClient` as a value import.
- `ContentType` is only marked `type` for `enumStyle: "union"`, where it is a pure type.
- Both options are exposed as CLI flags: `--import-file-extension` and `--type-only-imports`.
- Adds a spec suite covering extension, type-only, combined, and route-type imports.
- Also adds `/.idea/` and `/.serena/` to `.gitignore`.

<sup>Written for commit 5143ae3ad6b998c5628bfe98988c9cac0e5d3e25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/acacode/swagger-typescript-api/pull/1830?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

