### PR TITLE
fix: keep the referenced type when a $ref has complex siblings

### DIFF
--- a/src/schema-parser/base-schema-parsers/complex.ts
+++ b/src/schema-parser/base-schema-parsers/complex.ts
@@ -18,6 +18,14 @@ export class ComplexSchemaParser extends MonoSchemaParser {
       complexType
     ](this.schema);
 
+    // A $ref alongside `not`, `allOf` and friends is a sibling in OpenAPI 3.1: the
+    // keywords apply on top of the referenced schema. Parsing the reference too keeps
+    // the type, which would otherwise be lost with the complex keyword that cannot be
+    // expressed in TypeScript.
+    const shouldParseSimpleSchema =
+      this.schemaUtils.getInternalSchemaType(simpleSchema) ===
+        SCHEMA_TYPES.OBJECT || this.schemaUtils.isRefSchema(simpleSchema);
+
     return {
       ...(typeof this.schema === "object" ? this.schema : {}),
       $schemaPath: this.schemaPath.slice(),
@@ -33,19 +41,21 @@ export class ComplexSchemaParser extends MonoSchemaParser {
       ),
       content:
         this.config.Ts.IntersectionType(
-          compact([
-            this.config.Ts.ExpressionGroup(complexSchemaContent),
-            this.schemaUtils.getInternalSchemaType(simpleSchema) ===
-              SCHEMA_TYPES.OBJECT &&
-              this.config.Ts.ExpressionGroup(
-                this.schemaParserFabric
-                  .createSchemaParser({
-                    schema: simpleSchema,
-                    schemaPath: this.schemaPath,
-                  })
-                  .getInlineParseContent(),
-              ),
-          ]),
+          this.schemaUtils
+            .filterSchemaContents(
+              compact([
+                complexSchemaContent,
+                shouldParseSimpleSchema &&
+                  this.schemaParserFabric
+                    .createSchemaParser({
+                      schema: simpleSchema,
+                      schemaPath: this.schemaPath,
+                    })
+                    .getInlineParseContent(),
+              ]),
+              (content) => content !== this.config.Ts.Keyword.Any,
+            )
+            .map((content) => this.config.Ts.ExpressionGroup(content)),
         ) || this.config.Ts.Keyword.Any,
     };
   }

--- a/tests/spec/ref-with-sibling-keywords/__snapshots__/basic.test.ts.snap
+++ b/tests/spec/ref-with-sibling-keywords/__snapshots__/basic.test.ts.snap
@@ -1,0 +1,36 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`basic > ref-with-sibling-keywords 1`] = `
+"/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+export enum Status {
+  STATUS_UNSPECIFIED = "STATUS_UNSPECIFIED",
+  ACTIVE = "ACTIVE",
+  PAUSED = "PAUSED",
+}
+
+export interface Account {
+  plainRef?: Status;
+  /**
+   * annotatedRef
+   * a reference carrying annotations
+   */
+  annotatedRef?: Status;
+  /**
+   * constrainedRef
+   * a reference the value must match, minus one member
+   */
+  constrainedRef?: Status;
+}
+"
+`;

--- a/tests/spec/ref-with-sibling-keywords/basic.test.ts
+++ b/tests/spec/ref-with-sibling-keywords/basic.test.ts
@@ -1,0 +1,33 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { generateApi } from "../../../src/index.js";
+
+describe("basic", async () => {
+  let tmpdir = "";
+
+  beforeAll(async () => {
+    tmpdir = await fs.mkdtemp(path.join(os.tmpdir(), "swagger-typescript-api"));
+  });
+
+  afterAll(async () => {
+    await fs.rm(tmpdir, { recursive: true });
+  });
+
+  test("ref-with-sibling-keywords", async () => {
+    await generateApi({
+      fileName: "schema",
+      input: path.resolve(import.meta.dirname, "schema.json"),
+      output: tmpdir,
+      silent: true,
+      generateClient: false,
+    });
+
+    const content = await fs.readFile(path.join(tmpdir, "schema.ts"), {
+      encoding: "utf8",
+    });
+
+    expect(content).toMatchSnapshot();
+  });
+});

--- a/tests/spec/ref-with-sibling-keywords/schema.json
+++ b/tests/spec/ref-with-sibling-keywords/schema.json
@@ -1,0 +1,37 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Ref with sibling keywords",
+    "version": "1.0.0"
+  },
+  "components": {
+    "schemas": {
+      "Status": {
+        "type": "string",
+        "enum": ["STATUS_UNSPECIFIED", "ACTIVE", "PAUSED"]
+      },
+      "Account": {
+        "type": "object",
+        "properties": {
+          "plainRef": {
+            "$ref": "#/components/schemas/Status"
+          },
+          "annotatedRef": {
+            "$ref": "#/components/schemas/Status",
+            "title": "annotatedRef",
+            "description": "a reference carrying annotations"
+          },
+          "constrainedRef": {
+            "$ref": "#/components/schemas/Status",
+            "title": "constrainedRef",
+            "description": "a reference the value must match, minus one member",
+            "not": {
+              "enum": ["STATUS_UNSPECIFIED"]
+            }
+          }
+        }
+      }
+    }
+  },
+  "paths": {}
+}


### PR DESCRIPTION
A schema that carries a `$ref` next to `not`, `allOf`, `oneOf` or `anyOf` is routed to `ComplexSchemaParser`, which parses the complex keyword and drops the reference. With `not` — the one complex keyword that has no TypeScript equivalent, so `NotSchemaParser` returns `any` — the whole property collapses:

```yaml
constrainedRef:
  $ref: '#/components/schemas/Status'
  not: { enum: [STATUS_UNSPECIFIED] }
```

```ts
// before
constrainedRef?: any;
// after
constrainedRef?: Status;
```

Sibling keywords beside a `$ref` are legal in OpenAPI 3.1, where they compose with the referenced schema. They are also what `protoc-gen-connect-openapi` emits for a protobuf enum field carrying a protovalidate `not_in` rule — the common "must not be the UNSPECIFIED member" constraint. In a 678-operation document generated that way, this turned **156 properties into `any`**; with this change the same document generates 11, all of them genuinely dynamic (the client's own `contentFormatters`, a map value, `google.protobuf.Any`).

The fix parses the reference alongside the complex content and filters `any` out of the intersection, reusing the `ignoreTypes` idiom `AllOfSchemaParser` already applies. A `$ref` with only annotation siblings (`title`, `description`) took the primitive path and already resolved correctly; that behaviour is unchanged, and the new fixture covers all three shapes.

Tests: `tests/spec/ref-with-sibling-keywords` added. `vitest run` goes from 283 to 284 passing with no snapshot churn elsewhere; the 5 failures in `paths-2` and `paths-2-prefer-existing-schema-names` fail identically on a clean checkout of `main`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `$ref` schemas with complex siblings like `not`, `allOf`, `oneOf`, or `anyOf` so the referenced type is preserved instead of collapsing to `any`.

- Sibling keywords are legal in OpenAPI 3.1 and are what `protoc-gen-connect-openapi` emits for protobuf enum fields with `not_in` rules.
- The reference is now parsed alongside the complex content, and `any` members are filtered out of the intersection.
- In a 678-operation generated document, this restores types on 156 properties; only genuinely dynamic fields remain `any`.
- A `$ref` with only annotation siblings already resolved correctly and is unchanged.
- Adds a test fixture covering plain refs, annotated refs, and refs with `not`.

<sup>Written for commit 8ed51a39d94b8012fce7b84d675156d0931f62af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/acacode/swagger-typescript-api/pull/1832?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

